### PR TITLE
Improve ics-023 spec

### DIFF
--- a/spec/core/ics-023-vector-commitments/README.md
+++ b/spec/core/ics-023-vector-commitments/README.md
@@ -38,7 +38,7 @@ This document only defines desired properties, not a concrete implementation —
 
 ## Technical Specification
 
-Below we define a behaviour and an overview of datatypes. For data type definition look at [confio/ics23](https://github.com/confio/ics23/blob/master/go/ics23.go) repository.
+Below we define a behaviour and an overview of datatypes. For data type definition look at [confio/ics23](https://github.com/confio/ics23/blob/master/proofs.proto) repository.
 
 
 ### Datatypes

--- a/spec/core/ics-023-vector-commitments/README.md
+++ b/spec/core/ics-023-vector-commitments/README.md
@@ -38,6 +38,9 @@ This document only defines desired properties, not a concrete implementation —
 
 ## Technical Specification
 
+Below we define a behaviour and an overview of datatypes. For data type definition look at [confio/ics23](https://github.com/confio/ics23/blob/master/go/ics23.go) repository.
+
+
 ### Datatypes
 
 A commitment construction MUST specify the following datatypes, which are otherwise opaque (need not be introspected) but MUST be serialisable:


### PR DESCRIPTION
Adding link to data definitions (defined as code - the only thing we have). 
The ICS-23 spec presents only high level requirements, but not a technical requirements (structure definitions, serialization, etc...).
ref: https://github.com/cosmos/cosmos-sdk/discussions/9331#discussioncomment-993092