### PR TITLE
increase port identifier limit to 128 characters

### DIFF
--- a/spec/core/ics-024-host-requirements/README.md
+++ b/spec/core/ics-024-host-requirements/README.md
@@ -58,7 +58,7 @@ By default, identifiers have the following minimum and maximum lengths in charac
 
 | Port identifier | Client identifier | Connection identifier | Channel identifier |
 | --------------- | ----------------- | --------------------- | ------------------ |
-| 2 - 64          | 9 - 64            | 10 - 64               | 10 - 64            |
+| 2 - 128         | 9 - 64            | 10 - 64               | 10 - 64            |
 
 ### Key/value Store
 


### PR DESCRIPTION
closes #594 