### PR TITLE
spec: updating ics27 spec to ensure parity with implementation

### DIFF
--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -16,7 +16,7 @@ This standard document specifies packet data structure, state machine handling l
 
 ### Motivation
 
-On Ethereum, there are two types of accounts: externally owned accounts, controlled by private keys, and contract accounts, controlled by their contract code ([ref](https://github.com/ethereum/wiki/wiki/White-Paper)). Similar to Ethereum's contract accounts, interchain accounts are controlled by another chain (not a private key) while retaining all the capabilities of a normal account (i.e. stake, send, vote, etc). While an Ethereum CA's contract logic is performed within Ethereum's EVM, interchain accounts are managed by a separate chain via IBC in a way such that the owner of the account retains full control over how it behaves. ICS27-1 primarily targets the use cases of DAO investing and staking derivatives over IBC.
+ICS-27 Interchain Accounts outlines a cross-chain account management protocol built upon IBC. ICS-27 enabled chains can programmatically create accounts on other ICS-27 enabled chains & control these accounts via IBC transactions (instead of signing with a private key). Interchain accounts retain all of the capabilities of a normal account (i.e. stake, send, vote) but instead are managed by a separate chain via IBC in a way such that the owner of the accounts retain full control over how the accounts behave. 
 
 ### Definitions 
 
@@ -30,16 +30,19 @@ The IBC handler interface & IBC relayer module interface are as defined in [ICS 
 ### Desired Properties
 
 - Permissionless 
+- Fault tolerance: A controller chain must not be able to control accounts registered by other controller chains. For example, in the case of a fork attack on a controller chain, only the interchain accounts registered by the forked chain will be vulnerable
 - The ordering of transactions sent to an interchain account on a host chain must be maintained. Transactions should be executed by an interchain account in the order in which they are sent by the controller chain
 - If a channel closes, the controller chain must be able to regain access to registered interchain accounts by simply opening a new channel
-- Each interchain account is owned by a single account on the controller chain. Only the owner account on the controller chain is authorized to control the interchain account
-- The controller chain must store the account address of the interchain account
+- Each interchain account is owned by a single account on the controller chain. Only the owner account on the controller chain is authorized to control the interchain account. The controller chain is responsible for enforcing this logic
+- The controller chain must store the account address of any owned interchain account's registered on host chains
+- A host chain must have the ability to limit interchain account functionality on its chain as necessary (e.g. a host chain can decide that interchain accounts registered on the host chain cannot take part in staking)
+
 
 ## Technical Specification
 
 ### General Design 
 
-A chain can implement one or both parts of the interchain accounts protocol (*controlling* and *hosting*). A controller chain that registers accounts on other host chains (that support interchain accounts) does not necessarily have to allow other controller chains to register accounts on its chain, and vice versa. 
+A chain can utilize one or both parts of the interchain accounts protocol (*controlling* and *hosting*). A controller chain that registers accounts on other host chains (that support interchain accounts) does not necessarily have to allow other controller chains to register accounts on its chain, and vice versa. 
 
 This specification defines the general way to register an interchain account and transfer tx bytes to control the account. The host chain is responsible for deserializing and executing the tx bytes, and the controller chain should know how the host chain will handle the tx bytes in advance (Cosmos SDK chains will deserialize using Protobuf). 
 
@@ -49,52 +52,38 @@ This specification defines the general way to register an interchain account and
 
 // * CONTROLLER CHAIN *
 
-// InitInterchainAccount is the entry point to registering an interchain account.
-// It generates a new port identifier using the owner address, connection identifiers
-// The port id will look like: ics27-1-{connection-number}-{counterparty-connection-number}-{owner-address}
-// and counterparty connection identifier. It will bind to the port identifier and
+// InitInterchainAccount is the entry point to registering an interchain account 
+// It generates a new port identifier using the owner address & connection identifiers
+// The port id will look like: ics27-1.{connection-id}.{counterparty-connection-id}.{owner-address}
+// It will bind to the port identifier and
 // call 04-channel 'ChanOpenInit'. An error is returned if the port identifier is already in use
 // An `OnChannelOpenInit` event is emitted which can be picked up by an offchain process such as a relayer
-function InitInterchainAccount(connectionId: string, counterPartyConnectionId: string, ownerAddress: string) returns (nil){
+// The account will be registered during the OnChanOpenTry step on the host chain
+function InitInterchainAccount(connectionId: string, counterPartyConnectionId: string, owner: string) returns (error){
 }
 
-// TrySendTx is used to send an IBC packet containing instructions (messages) to an interchain account on a host chain for a given interchain account owner. 
-function TrySendTx(connectionId: string, counterPartyConnectionId: string, ownerAddress: string, messages: []bytes) returns ([]bytes, error){
-    // A port id string will be generated from the connectionIds + ownerAddress. This is the port-id that the IBC packet will be sent on
-    // A call to GetActiveChannel() checks if there is a currently active channel for this port-id which also implies an interchain account has previously be registered
-    // A call to check if the channel status is OPEN (an additional, albeit slightly redundant check)
+// TrySendTx is used to send an IBC packet containing instructions (messages) to an interchain account on a host chain for a given interchain account owner 
+function TrySendTx(channelCapability: ChannelCapability, portID: string, connectionId: string, counterPartyConnectionId: string, icaPacketData: InterchainAccountPacketData) returns (uint64, error){
+    // A call to GetActiveChannel() checks if there is a currently active channel for this port-id which also implies an interchain account has been registered using this port identifier
     // if there are no errors CreateOutgoingPacket() is called and the IBC packet will be sent to the host chain on the active channel
 }
 
-// This helper function is required for the controller chain to get the address of a newly registered interchain account on a host chain.
-// Because the registration of an interchain account happens during the channel creation handshake, there is no way for the controller chain to know what the address of the interchain account is on the host chain in advance. 
-// This function sends an IBC packet to the host chain, on the owner port + active channel with the sole intention of eventually parsing the interchain account address from the Acknowledgement packet on the controller chain side.
-// The OnAcknowledgePacket function on the controller chain will handle the parsing + setting the interchain account address in state.
-// The controller chain builds the messages (before sending via IBC in the TrySendTx fn) that the host side will eventually execute. Therefore, the interchain account address must be known by the controller chain.
-function GetInterchainAccountAddressFromAck(connectionId: string, counterPartyConnectionId: string, ownerAddress: string) returns (nil){
-    // Sends a generic IBC packet to the host chain with the intention of parsing the interchain account address associated with this port/connection/channel from the Acknowledgement packet.
-}
 
 // Opens a new channel on a particular port given a connection
 // This is a helper function to open a new channel 
 // This is a safety function in case of a channel closing and the controller chain needs to regain access to an interchain account on the host chain 
 function InitChannel(portId: string, connectionId: string) returns (nil){
-  // An `OnChannelOpenInit` event is emitted which can be picked up by an offchain process such as a relayer which will finish the channel opening handshake
+  // An `OnChannelOpenInit` event is emitted which can be picked up by an off-chain process such as a relayer which will finish the channel opening handshake
+  // The active channel will be set to the newly opened channel on the OnChanOpenAck & OnChanOpenConfirm steps
 }
 
 // * HOST CHAIN *
 
-// RegisterInterchainAccount is called on the OnOpenTry step during the channel creation handshake 
-function RegisterInterchainAccount(counterPartyPortId: string) returns (error){
-   // generates an address for the interchain account 
+// RegisterInterchainAccount is called on the OnChanOpenTry step during the channel creation handshake 
+function RegisterInterchainAccount(accAddr: string, counterPartyPortId: string) returns (nil){
    // checks to make sure the account has not already been registered
    // creates a new address on chain 
    // calls SetInterchainAccountAddress()
-   // returns the address of the newly created account
-}
-
-// DeserializeTx is used to deserialize message bytes parsed from an IBC packet into a format that the host chain can recognize & execute i.e. cosmos SDK messages
-function DeserializeTx(txBytes []byte) returns ([]Any, error){
 }
 
 // AuthenticateTx is called before ExecuteTx.
@@ -113,11 +102,11 @@ function ExecuteTx(sourcePort: string, destPort: string, destChannel: string, ms
 // * UTILITY FUNCTIONS *
 
 // Sets the active channel
-function SetActiveChannel(portId: string, channelId: string) returns (error){
+function SetActiveChannelID(portId: string, channelId: string) returns (error){
 }
 
 // Returns the id of the active channel if present
-function GetActiveChannel(portId: string) returns (string, boolean){
+function GetActiveChannelID(portId: string) returns (string, boolean){
 }
 
 // Stores the address of the interchain account in state
@@ -125,74 +114,107 @@ function SetInterchainAccountAddress(portId string, address string) returns (str
 }
 
 // Gets the interchain account from state
-function GetInterchainAccountAddress(portId string) returns (string, error){
+function GetInterchainAccountAddress(portId string) returns (string, bool){
 }
 ```
 
-### Registering & Controlling flows
-**Active Channels**
+### Register & Controlling flows
 
-The controller and host chain should keep track of an `active-channel` for each registered interchain account. The `active-channel` is set during the channel creation handshake process. This is a safety mechanism that allows a controller chain to regain access to an interchain account on a host chain in case of a channel closing. 
-
-An active channel can look like this:
-
-
-```typescript
-{
- // Controller Chain
- SourcePortId: `ics-27-0-0-cosmos1mjk79fjjgpplak5wq838w0yd982gzkyfrk07am`,
- SourceChannelId: `channel-1`,
- // Host Chain
- CounterPartyPortId: `interchain_account`,
- CounterPartyChannelId: `channel-2`,
-}
-```
-
-**Register Account Flow**
+#### Register Account Flow
 
 To register an interchain account we require an off-chain process (relayer) to listen for `OnChannelOpenInit` events with the capability to finish a channel creation handshake on a given connection. 
 
 1. The controller chain binds a new IBC port with an id composed of the *source/counterparty connection-ids* & the *interchain account owner address*
 
-The IBC portID will look like this:
+The IBC port identifier will look like this:
 ```
-ics27-1-{connection-number}-{counterparty-connection-number}-{owner-address}
+ics27-1.{connection-id}.{counterparty-connection-id}.{owner-address}
 ```
-This port will be used to create channels between the controller & host chain for a specific owner/interchain account pair. Only the account with `{owner-address}` matching the bound port will be authorized to send IBC packets over channels created with `ics27-1-{connection-number}-{counterparty-connection-number}-{owner-address}`. The host chain trusts that each controller chain will enforce this port registration and access. 
+
+This port will be used to create channels between the controller & host chain for a specific owner/interchain account pair. Only the account with `{owner-address}` matching the bound port will be authorized to send IBC packets over channels created with `ics27-1.{connection-id}.{counterparty-connection-id}.{owner-address}`. It is up to each controller chain to enforce this port registration and access on the controller side. 
 
 2. The controller chain emits an event signaling to open a new channel on this port given a connection 
 3. A relayer listening for `OnChannelOpenInit` events will begin the channel creation handshake
-4. During the `OnChanOpenTry` callback on the host chain an interchain account will be registered and a mapping of the interchain account address to the owner account address will be stored in state (this is used for authenticating transactions on the host chain at execution time)
-5. During the `OnChanOpenAck` & `OnChanOpenConfirm` callbacks on the controller & host chains respectively, the `active-channel` for this interchain account/owner pair, is set in state
+4. During the `OnChanOpenTry` callback on the host chain an interchain account will be registered and a mapping of the interchain account address to the owner account address will be stored in state (this is used for authenticating transactions on the host chain at execution time). 
+5. During the `OnChanOpenAck` callback on the controller chain a record of the interchain account address registered on the host chain during `OnChanOpenTry` is set in state with a mapping from portID -> interchain account address. See [version negotiation](#Version-Negotiation) section below for how to implement this
+6. During the `OnChanOpenAck` & `OnChanOpenConfirm` callbacks on the controller & host chains respectively, the [active-channel](#Active-Channels) for this interchain account/owner pair, is set in state
+
+#### Active Channels
+
+The controller and host chain should keep track of an `active-channel` for each registered interchain account. The `active-channel` is set during the channel creation handshake process. This is a safety mechanism that allows a controller chain to regain access to an interchain account on a host chain in case of a channel closing. 
+
+An active channel on the controller chain will look like this:
 
 
-**Controlling Flow**
+```typescript
+{
+ // Controller Chain
+ SourcePortId: `ics27-1.0.0.<owner-id>`,
+ SourceChannelId: `channel-1`,
+ // Host Chain
+ CounterPartyPortId: `interchain-account`,
+ CounterPartyChannelId: `channel-2`,
+}
+```
 
-Once an interchain account is registered on the host chain a controller chain can begin sending instructions (messages) to control this account. 
+In the event of a channel closing, the active channel should be unset. ICS-27 channels should only be closed in the event of a timeout (if the implementation uses ordered channels) or in the unlikely event of a light client attack. It is critical that controller chains retain the ability to open new ICS-27 channels and reset the active channel for a particular port id (owner) and associated interchain account. 
 
-1. The controller chain calls `GetInterchainAccountAddressFromAck()` to get the address of the interchain account on the host chain and sets the address in state mapped to the respective portID. 
-2. The controller chain calls `TrySendTx` and passes message(s) that will be executed on the host side by the associated interchain account (determined by the source port identifer)
+#### Version Negotiation
+
+ICS-27 takes advantage of [ISC-04 channel version negotiation](https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#versioning) to store a mapping of the controller chain port ID to the newly registered interchain account address, on both the host chain & controller chains, during the channel creation handshake ([account registration flow](#Register-Account-Flow)). 
+
+ICS-004 allows for each channel version negotiation to be application-specific. In the case of interchain accounts, the channel version set during the `OnChanOpenInit` step (controller chain) must be `ics27-<version>` & the version set during the host chain `OnChanOpenTry` step will include the interchain account address that will be created. Note that the generation of this address is stateless, and can be generated in advance of the account creation. An example implementation of this can be viewed here: 
+
+Due to how the mechanics of ICS-004 channel version negotiation operate the version passed into the host chain side (OnChanOpenTry) must match the counterparty version passed into the controller side (OnChanOpenAck) otherwise there will be a resulting error at the IBC protocol level. 
+
+Combined with the one channel per interchain account approach, this method of version negotiation allows us to pass the address of the interchain account back to the controller chain and create a mapping from controller port ID -> interchain account address during the `OnChanOpenAck` callback. As outlined in the [controlling flow](#Controlling-Flow), a controller chain will need to know the address of a registered interchain account in order to send transactions to the account on the host chain.
+
+
+#### Version negotiation summary
+
+| Initiator | Datagram         | Chain acted upon |  Version (Controller, Host) | Port ID (Controller, Host) |
+| --------- | ---------------- | ---------------- |  ---------------------- | ---------------------- |
+| Controller| ChanOpenInit     | Controller       |  (ics27-1, none)        | (ics27-1.0.0.<owner-id>, interchain-account)           |
+| Relayer   | ChanOpenTry      | Host             |  (ics27-1, ics27-1.<owner-id>)        | (ics27-1.0.0.<owner-id>, interchain-account)       |
+| Relayer   | ChanOpenAck      | Controller       |  (ics27-1, ics27-1.<owner-id>)        | (ics27-1.0.0.<owner-id>, interchain-account)        | (ics27-1.0.0.<owner-id>, interchain-account)        |
+| Relayer   | ChanOpenConfirm  | Host             |  (ics27-1, ics27-1.<owner-id>)        | (ics27-1.0.0.<owner-id>, interchain-account)           | (ics27-1.0.0.<owner-id>, interchain-account)           |
+
+
+
+#### Controlling Flow
+
+Once an interchain account is registered on the host chain a controller chain can begin sending instructions (messages) to the host chain to control the account. 
+
+1. The controller chain calls `TrySendTx` and passes message(s) that will be executed on the host side by the associated interchain account (determined by the controller side port identifier)
 
 Cosmos SDK psuedo code example:
 
 ```typescript
 interchainAccountAddress := GetInterchainAccountAddress(portId)
 msg := &banktypes.MsgSend{FromAddress: interchainAccountAddress, ToAddress: ToAddress, Amount: amount}
+icaPacketData = InterchainAccountPacketData{
+   Type: types.EXECUTE_TX,
+   Data: serialize(msg),
+   Memo: "memo",
+}
+
 // Sends the message to the host chain, where it will eventually be executed 
-TrySendTx(ownerAddress, connectionId, counterPartyConnectionId, msg)
+TrySendTx(chanCapability, ownerAddress, connectionId, counterPartyConnectionId, data)
 ```
 
-4. The host chain upon receiving the IBC packet will call `DeserializeTx` and then call `AuthenticateTx` for each message. If either of these steps fails an error will be returned.
+4. The host chain upon receiving the IBC packet will call `DeserializeTx` and then call `AuthenticateTx` for each message. If either of these steps fails an error will be returned
+    
+Messages are authenticated on the host chain by taking the controller side port identifier and calling `GetInterchainAccountAddress(controllerPortId)` to get the expected interchain account address for the controller port (owner). If the signer of this message does not match the expected account address then authentication will fail. An example implementation for the cosmos SDK can be seen here:
+    
 5. The host chain will then call `ExecuteTx` for each message and return an acknowledgment
 
-
-
 ### Packet Data
-`InterchainAccountPacketData` contains an array of messages that an interchain account can execute and a memo string that is sent to the host chain.  
+`InterchainAccountPacketData` contains an array of messages that an interchain account can execute and a memo string that is sent to the host chain as well as the packet `type`. ICS-27 version 1 has only one type `EXECUTE_TX`.
 
 ```typescript
 message InterchainAccountPacketData  {
-    repeated google.protobuf.Any messages = 1;
+    enum type
+    bytes data = 1;
     string memo = 2;
 }
 ```
@@ -209,23 +231,21 @@ message Acknowledgement {
 }
 ```
 
-The ```InterchainAccountHook``` interface allows the controller chain to receive results of executed transactions on the host chain.
-```typescript
-interface InterchainAccountHook {
-  onTxSucceeded(sourcePort:string, sourceChannel:string, txBytes: Uint8Array)
-  onTxFailed(sourcePort:string, sourceChannel:string, txBytes: Uint8Array)
-}
-```
+### Custom logic
+
+ICS-27 relies on [ICS-30 middleware architecture](https://github.com/cosmos/ibc/tree/master/spec/app/ics-030-middleware) to provide the option for application developers to apply custom logic on the success or fail of ICS-27 packets. 
+
+Controller chains will wrap `OnAcknowledgement` & `OnTimeoutPacket` in order to handle the success or fail cases for ICS-27 packets. 
 
 ### Port & channel setup
 
-The interchain account module on a host chain must always bind to a port with the id `interchain-account`. Controller chains will bind to ports dynamically, with each port id set as `ics27-1-{connection-number}-{counterparty-connection-number}-{owner-address}`.
+The interchain account module on a host chain must always bind to a port with the id `interchain-account`. Controller chains will bind to ports dynamically, with each port id set as `ics27-1.{connection-id}.{counterparty-connection-id}.{owner-address}`.
 
 The example below assumes a module is implementing the entire `InterchainAccountModule` interface. The `setup` function must be called exactly once when the module is created (perhaps when the blockchain itself is initialized) to bind to the appropriate port.
 
 ```typescript
 function setup() {
-  capability = routingModule.bindPort("interchain_account", ModuleCallbacks{
+  capability = routingModule.bindPort("interchain-account", ModuleCallbacks{
       onChanOpenInit,
       onChanOpenTry,
       onChanOpenAck,
@@ -248,7 +268,7 @@ Once the `setup` function has been called, channels can be created via the IBC r
 An interchain account module will accept new channels from any module on another machine, if and only if:
 
 - The channel being created is ordered
-- The version string is "ics27-1"
+- The channel initialization step is being invoked from the controller chain
 
 ```typescript
 function onChanOpenInit(
@@ -261,11 +281,13 @@ function onChanOpenInit(
   version: string) {
   // only ordered channels allowed
   abortTransactionUnless(order === ORDERED)
-  // only allow channels to "interchain_account" port on counterparty chain
+  // validate port format
+  abortTransactionUnless(validateControllerPortParams(portIdentifier))
+  // only allow channels to be created on the "interchain-account" port on the counterparty chain
   abortTransactionUnless(counterpartyPortIdentifier === "interchain-account")
-  // version not used at present
+  // validate controller side channel version
   abortTransactionUnless(version === "ics27-1")
-  // Only open the channel if there is no active channel already set (with status OPEN)
+  // only open the channel if there is no active channel already set (with status OPEN)
   abortTransactionUnless(activeChannel === nil)
 }
 ```
@@ -282,12 +304,14 @@ function onChanOpenTry(
   counterpartyVersion: string) {
   // only unordered channels allowed
   abortTransactionUnless(order === ORDERED)
-
-  // assert that version is "ics27-1"
-  abortTransactionUnless(version === "ics27-1")
+  // validate port format
+  abortTransactionUnless(validateControllerPortParams(portIdentifier))
+  // assert that version is expected format `ics27-1.interchain-account-address`
+  abortTransactionUnless(validateVersion(version))
+  // assert that the counterparty version is `ics27-1`  
   abortTransactionUnless(counterpartyVersion === "ics27-1")
-  // create an interchain account 
-  createInterchainAccount(counterpartyPortIdentifier, counterpartyChannelIdentifier)
+  // create the interchain account 
+  RegisterInterchainAccount(accAddr, counterpartyPortIdentifier)
 }
 ```
 
@@ -296,10 +320,11 @@ function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
   version: string) {
-  // port has already been validated
-  // assert that version is "ics27-1"
-  abortTransactionUnless(version === "ics27-1")
+  // validate that the counterparty version is expected format `ics27-1.interchain-account-address`      
+  abortTransactionUnless(validateVersion(version))
   // state change to keep track of successfully registered interchain account
+  SetInterchainAccountAddress(portID, accAddr)
+  // set the active channel for this owner/interchain account pair
   setActiveChannel(SourcePortId)
 }
 ```
@@ -308,16 +333,17 @@ function onChanOpenAck(
 function onChanOpenConfirm(
   portIdentifier: Identifier,
   channelIdentifier: Identifier) {
-  setActiveChannel(CounterPartyPortId)
+  // set the active channel for this owner/interchain account pair
+  setActiveChannel(portIdentifier)
 }
 ```
 
 ```typescript
 function onChanCloseInit(
   portIdentifier: Identifier,
-  channelIdentifier: Identifier) {
-    // users should not be able to close channels
-    return nil
+  channelIdentifier: Identifier) { \
+    // unset the active channel for this owner/interchain account pair
+    DeleteActiveChannel(portIdentifier, channelIdentifier)
 }
 ```
 
@@ -325,8 +351,8 @@ function onChanCloseInit(
 function onChanCloseConfirm(
   portIdentifier: Identifier,
   channelIdentifier: Identifier) {
-   // users should not be able to close channels
-   return nil
+    // unset the active channel for this owner/interchain account pair
+    DeleteActiveChannel(portIdentifier, channelIdentifier)
 }
 ```
 
@@ -334,32 +360,34 @@ function onChanCloseConfirm(
 `onRecvPacket` is called by the routing module when a packet addressed to this module has been received.
 
 ```typescript
-function OnRecvPacket(
-	packet channeltypes.Packet,
-) {
-    ack = channeltypes.NewResultAcknowledgement([]byte{byte(1)})
+function OnRecvPacket(packet Packet) {
+    	ack := NewResultAcknowledgement([]byte{byte(1)})
 
-    var data types.IBCAccountPacketData
-    if err = UnmarshalJSON(packet.GetData(), &data); err != nil {
-	ack = channeltypes.NewErrorAcknowledgement(fmt.Sprintf("cannot unmarshal ICS-27 interchain account packet data: %s", err.Error()))
-    }
+	// only attempt the application logic if the packet data
+	// was successfully decoded
+	if ack.Success() {
+		switch data.Type {
+	          case types.EXECUTE_TX:
+		        msgs, err := types.DeserializeTx(data.Data)
+		        if err != nil {
+			      return err
+		        }
 
-    // only attempt the application logic if the packet data
-    // was successfully decoded
-    if ack.Success() {
-        err = am.keeper.OnRecvPacket(ctx, packet)
-        if err != nil {
-            ack = channeltypes.NewErrorAcknowledgement(err.Error())
-        }   
-        // If the packet sequence is 1 add the interchain account address to the 
-        if packet.Seqeunce = 1 {
-            var interchainAccountAddress = GetInterchainAccountAddress(packet.CounterPartyPortId)
-            ack = channeltypes.NewResultAcknowledgement([]byte{byte(interchainAccountAddress)})
-        }
-    }
-    
-    // NOTE: acknowledgement will be written synchronously during IBC handler execution.
-    return ack
+		        if err = executeTx(ctx, packet.SourcePort, packet.DestinationPort, packet.DestinationChannel, msgs); err != nil {
+			      return err
+		        }
+
+		        return nil
+	          default:
+		        return ErrUnknownDataType
+	        }
+	        if err != nil {
+                    ack = NewErrorAcknowledgement(err.Error())
+                }
+	}
+
+	// NOTE: acknowledgement will be written synchronously during IBC handler execution.
+	return ack
 }
 ```
 
@@ -369,30 +397,21 @@ function OnRecvPacket(
 function onAcknowledgePacket(
   packet: Packet,
   acknowledgement: bytes) {
-    if (acknowledgement.result) {
-      onTxSucceeded(packet.sourcePort, packet.sourceChannel, packet.data.data)
-      // If the packet sequence is 1 set the interchain account address in state
-      if packet.Sequence == 1 {
-          setInterchainAccountAddress(sourcePort, String(acknowledgement.result))
-      }
-    } else {
-      onTxFailed(packet.sourcePort, packet.sourceChannel, packet.data.data)
-    }
-    return
+    // call underlying app's OnAcknowledgementPacket callback 
+    // see ICS30 middleware for more information
 }
 ```
 
 ```typescript
 function onTimeoutPacket(packet: Packet) {
-  // Receiving chain should handle this event as if the tx in packet has failed
-    onTxFailed(packet.sourcePort, packet.sourceChannel, packet.data.data)
-    return
+    // call underlying app's OnTimeoutPacket callback 
+    // see ICS30 middleware for more information
 }
 ```
 
 ## Example Implementation
 
-Repository for Cosmos-SDK implementation of ICS27: https://github.com/cosmos/interchain-accounts
+Repository for Cosmos-SDK implementation of ICS-27: https://github.com/cosmos/ibc-go
 
 ## History
 
@@ -408,6 +427,9 @@ July 14, 2020 - Major revisions
 
 April 27, 2021 - Redesign of ics27 specification
 
+November 11, 2021 - Update with latest changes from implementation
+    
 ## Copyright
 
 All content herein is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -211,7 +211,7 @@ TrySendTx(ownerAddress, connectionId, counterPartyConnectionId, data)
 
 4. The host chain upon receiving the IBC packet will call `DeserializeTx`. 
     
-5. The host chain will then call `ExecuteTx` & `AuthenticateTx` for each message and return an acknowledgment containing a success or error.  
+5. The host chain will then call `AuthenticateTx` and `ExecuteTx` for each message and return an acknowledgment containing a success or error.  
 
 Messages are authenticated on the host chain by taking the controller side port identifier and calling `GetInterchainAccountAddress(controllerPortId)` to get the expected interchain account address for the current controller port. If the signer of this message does not match the expected account address then authentication will fail. An example implementation for the cosmos SDK can be seen [here](https://github.com/cosmos/ibc-go/blob/interchain-accounts/modules/apps/27-interchain-accounts/keeper/relay.go#L76).
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -213,7 +213,7 @@ TrySendTx(ownerAddress, connectionId, counterPartyConnectionId, data)
     
 5. The host chain will then call `AuthenticateTx` and `ExecuteTx` for each message and return an acknowledgment containing a success or error.  
 
-Messages are authenticated on the host chain by taking the controller side port identifier and calling `GetInterchainAccountAddress(controllerPortId)` to get the expected interchain account address for the current controller port. If the signer of this message does not match the expected account address then authentication will fail. An example implementation for the cosmos SDK can be seen [here](https://github.com/cosmos/ibc-go/blob/interchain-accounts/modules/apps/27-interchain-accounts/keeper/relay.go#L76).
+Messages are authenticated on the host chain by taking the controller side port identifier and calling `GetInterchainAccountAddress(controllerPortId)` to get the expected interchain account address for the current controller port. If the signer of this message does not match the expected account address then authentication will fail.
 
 ### Packet Data
 `InterchainAccountPacketData` contains an array of messages that an interchain account can execute and a memo string that is sent to the host chain as well as the packet `type`. ICS-27 version 1 has only one type `EXECUTE_TX`.

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -33,7 +33,7 @@ The IBC handler interface & IBC relayer module interface are as defined in [ICS 
 - Fault tolerance: A controller chain must not be able to control accounts registered by other controller chains. For example, in the case of a fork attack on a controller chain, only the interchain accounts registered by the forked chain will be vulnerable
 - The ordering of transactions sent to an interchain account on a host chain must be maintained. Transactions should be executed by an interchain account in the order in which they are sent by the controller chain
 - If a channel closes, the controller chain must be able to regain access to registered interchain accounts by simply opening a new channel
-- Each interchain account is owned by a single account on the controller chain. Only the owner account on the controller chain is authorized to control the interchain account. The controller chain is responsible for enforcing this logic
+- Each interchain account is owned by a single account on the controller chain. Only the owner account on the controller chain is authorized to control the interchain account. The controller chain is responsible for enforcing this logic.
 - The controller chain must store the account address of any owned interchain account's registered on host chains
 - A host chain must have the ability to limit interchain account functionality on its chain as necessary (e.g. a host chain can decide that interchain accounts registered on the host chain cannot take part in staking)
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -209,11 +209,11 @@ icaPacketData = InterchainAccountPacketData{
 TrySendTx(ownerAddress, connectionId, counterPartyConnectionId, data)
 ```
 
-4. The host chain upon receiving the IBC packet will call `DeserializeTx` and then call `AuthenticateTx` for each message. If either of these steps fails an error will be returned
+4. The host chain upon receiving the IBC packet will call `DeserializeTx`. 
     
+5. The host chain will then call `ExecuteTx` & `AuthenticateTx` for each message and return an acknowledgment containing a success or error.  
+
 Messages are authenticated on the host chain by taking the controller side port identifier and calling `GetInterchainAccountAddress(controllerPortId)` to get the expected interchain account address for the current controller port. If the signer of this message does not match the expected account address then authentication will fail. An example implementation for the cosmos SDK can be seen [here](https://github.com/cosmos/ibc-go/blob/interchain-accounts/modules/apps/27-interchain-accounts/keeper/relay.go#L76).
-    
-5. The host chain will then call `ExecuteTx` for each message and return an acknowledgment
 
 ### Packet Data
 `InterchainAccountPacketData` contains an array of messages that an interchain account can execute and a memo string that is sent to the host chain as well as the packet `type`. ICS-27 version 1 has only one type `EXECUTE_TX`.
@@ -380,7 +380,8 @@ function OnRecvPacket(packet Packet) {
 			      return err
 		        }
 
-		        if err = executeTx(ctx, packet.SourcePort, packet.DestinationPort, packet.DestinationChannel, msgs); err != nil {
+                        // ExecuteTx should call the AuthenticateTx function defined above 
+		        if err = ExecuteTx(ctx, packet.SourcePort, packet.DestinationPort, packet.DestinationChannel, msgs); err != nil {
 			      return err
 		        }
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -203,7 +203,7 @@ TrySendTx(ownerAddress, connectionId, counterPartyConnectionId, data)
 
 4. The host chain upon receiving the IBC packet will call `DeserializeTx` and then call `AuthenticateTx` for each message. If either of these steps fails an error will be returned
     
-Messages are authenticated on the host chain by taking the controller side port identifier and calling `GetInterchainAccountAddress(controllerPortId)` to get the expected interchain account address for the current controller port. If the signer of this message does not match the expected account address then authentication will fail. An example implementation for the cosmos SDK can be seen here:
+Messages are authenticated on the host chain by taking the controller side port identifier and calling `GetInterchainAccountAddress(controllerPortId)` to get the expected interchain account address for the current controller port. If the signer of this message does not match the expected account address then authentication will fail. An example implementation for the cosmos SDK can be seen [here](https://github.com/cosmos/ibc-go/blob/interchain-accounts/modules/apps/27-interchain-accounts/keeper/relay.go#L76).
     
 5. The host chain will then call `ExecuteTx` for each message and return an acknowledgment
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -34,7 +34,7 @@ The IBC handler interface & IBC relayer module interface are as defined in [ICS 
 - The ordering of transactions sent to an interchain account on a host chain must be maintained. Transactions should be executed by an interchain account in the order in which they are sent by the controller chain.
 - If a channel closes, the controller chain must be able to regain access to registered interchain accounts by simply opening a new channel.
 - Each interchain account is owned by a single account on the controller chain. Only the owner account on the controller chain is authorized to control the interchain account. The controller chain is responsible for enforcing this logic.
-- The controller chain must store the account address of any owned interchain account's registered on host chains
+- The controller chain must store the account address of any owned interchain accounts registered on host chains.
 - A host chain must have the ability to limit interchain account functionality on its chain as necessary (e.g. a host chain can decide that interchain accounts registered on the host chain cannot take part in staking).
 
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -169,17 +169,14 @@ Due to how the mechanics of ICS-004 channel version negotiation operate the vers
 
 Combined with the one channel per interchain account approach, this method of version negotiation allows us to pass the address of the interchain account back to the controller chain and create a mapping from controller port ID -> interchain account address during the `OnChanOpenAck` callback. As outlined in the [controlling flow](#Controlling-Flow), a controller chain will need to know the address of a registered interchain account in order to send transactions to the account on the host chain.
 
-
 #### Version negotiation summary
 
-| Initiator | Datagram         | Chain acted upon |  Version (Controller, Host) | Port ID (Controller, Host) |
-| --------- | ---------------- | ---------------- |  ---------------------- | ---------------------- |
-| Controller| ChanOpenInit     | Controller       |  (ics27-1, none)        | (ics27-1.0.0.<owner-id>, interchain-account)           |
-| Relayer   | ChanOpenTry      | Host             |  (ics27-1, ics27-1.<owner-id>)        | (ics27-1.0.0.<owner-id>, interchain-account)       |
-| Relayer   | ChanOpenAck      | Controller       |  (ics27-1, ics27-1.<owner-id>)        | (ics27-1.0.0.<owner-id>, interchain-account)        | (ics27-1.0.0.<owner-id>, interchain-account)        |
-| Relayer   | ChanOpenConfirm  | Host             |  (ics27-1, ics27-1.<owner-id>)        | (ics27-1.0.0.<owner-id>, interchain-account)           | (ics27-1.0.0.<owner-id>, interchain-account)           |
-
-
+| Initiator | Datagram         | Chain acted upon |  Version (Controller, Host) |
+| --------- | ---------------- | ---------------- |  ---------------------- | 
+| Controller| ChanOpenInit     | Controller       |  (ics27-1, none)        | 
+| Relayer   | ChanOpenTry      | Host             |  (ics27-1, ics27-1.<interchain-account-address>)        | 
+| Relayer   | ChanOpenAck      | Controller       |  (ics27-1, ics27-1.<interchain-account-address>)        | 
+| Relayer   | ChanOpenConfirm  | Host             |  (ics27-1, ics27-1.<interchain-account-address>)        | 
 
 #### Controlling Flow
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -116,6 +116,12 @@ function SetInterchainAccountAddress(portID string, address string) returns (str
 // Retrieves the interchain account from state.
 function GetInterchainAccountAddress(portID string) returns (string, bool){
 }
+
+
+// DeleteActiveChannelID removes the active channel keyed by the provided portID stored in state
+function (k Keeper) DeleteActiveChannelID(portID string) {
+}
+
 ```
 
 ### Register & Controlling flows
@@ -341,8 +347,8 @@ function onChanOpenConfirm(
 function onChanCloseInit(
   portIdentifier: Identifier,
   channelIdentifier: Identifier) { \
-    // unset the active channel for this owner/interchain account pair
-    DeleteActiveChannel(portIdentifier, channelIdentifier)
+ 	// Disallow user-initiated channel closing for interchain account channels
+  return err
 }
 ```
 
@@ -350,8 +356,8 @@ function onChanCloseInit(
 function onChanCloseConfirm(
   portIdentifier: Identifier,
   channelIdentifier: Identifier) {
-    // unset the active channel for this owner/interchain account pair
-    DeleteActiveChannel(portIdentifier, channelIdentifier)
+    // unset the active channel for given portID 
+    DeleteActiveChannelID(portIdentifier)
 }
 ```
 
@@ -403,6 +409,9 @@ function onAcknowledgePacket(
 
 ```typescript
 function onTimeoutPacket(packet: Packet) {
+    // unset the active channel for given portID
+    DeleteActiveChannelID(portIdentifier)
+
     // call underlying app's OnTimeoutPacket callback 
     // see ICS30 middleware for more information
 }

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -194,7 +194,7 @@ Once an interchain account is registered on the host chain a controller chain ca
 
 1. The controller chain calls `TrySendTx` and passes message(s) that will be executed on the host side by the associated interchain account (determined by the controller side port identifier)
 
-Cosmos SDK psuedo code example:
+Cosmos SDK pseudo-code example:
 
 ```typescript
 interchainAccountAddress := GetInterchainAccountAddress(portId)

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -143,7 +143,7 @@ This port will be used to create channels between the controller & host chain fo
 
 The controller and host chain should keep track of an `active-channel` for each registered interchain account. The `active-channel` is set during the channel creation handshake process. This is a safety mechanism that allows a controller chain to regain access to an interchain account on a host chain in case of a channel closing. 
 
-An active channel on the controller chain will look like this:
+An example of an active channel on the controller chain can look like this:
 
 
 ```typescript

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -140,7 +140,7 @@ ics27-1.{connection-id}.{counterparty-connection-id}.{owner-account-address}
 This port will be used to create channels between the controller & host chain for a specific owner/interchain account pair. Only the account with `{owner-account-address}` matching the bound port will be authorized to send IBC packets over channels created with `ics27-1.{connection-id}.{counterparty-connection-id}.{owner-account-address}`. It is up to each controller chain to enforce this port registration and access on the controller side. 
 
 2. The controller chain emits an event signaling to open a new channel on this port given a connection 
-3. A relayer listening for `OnChannelOpenInit` events will begin the channel creation handshake
+3. A relayer listening for `OnChannelOpenInit` events will continue the channel creation handshake
 4. During the `OnChanOpenTry` callback on the host chain an interchain account will be registered and a mapping of the interchain account address to the owner account address will be stored in state (this is used for authenticating transactions on the host chain at execution time). 
 5. During the `OnChanOpenAck` callback on the controller chain a record of the interchain account address registered on the host chain during `OnChanOpenTry` is set in state with a mapping from portID -> interchain account address. See [version negotiation](#Version-Negotiation) section below for how to implement this
 6. During the `OnChanOpenAck` & `OnChanOpenConfirm` callbacks on the controller & host chains respectively, the [active-channel](#Active-Channels) for this interchain account/owner pair, is set in state

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -177,6 +177,8 @@ Combined with the one channel per interchain account approach, this method of ve
 
 #### Version Negotiation Summary
 
+`interchain-account-address` is the address of the interchain account registered on the host chain by the controller chain.
+
 | Initiator | Datagram         | Chain acted upon |  Version (Controller, Host) |
 | --------- | ---------------- | ---------------- |  ---------------------- | 
 | Controller| ChanOpenInit     | Controller       |  (ics27-1, none)        | 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -174,9 +174,9 @@ Combined with the one channel per interchain account approach, this method of ve
 | Initiator | Datagram         | Chain acted upon |  Version (Controller, Host) |
 | --------- | ---------------- | ---------------- |  ---------------------- | 
 | Controller| ChanOpenInit     | Controller       |  (ics27-1, none)        | 
-| Relayer   | ChanOpenTry      | Host             |  (ics27-1, ics27-1.<interchain-account-address>)        | 
-| Relayer   | ChanOpenAck      | Controller       |  (ics27-1, ics27-1.<interchain-account-address>)        | 
-| Relayer   | ChanOpenConfirm  | Host             |  (ics27-1, ics27-1.<interchain-account-address>)        | 
+| Relayer   | ChanOpenTry      | Host             |  (ics27-1, ics27-1.{interchain-account-address})        | 
+| Relayer   | ChanOpenAck      | Controller       |  (ics27-1, ics27-1.{interchain-account-address})        | 
+| Relayer   | ChanOpenConfirm  | Host             |  (ics27-1, ics27-1.{interchain-account-address})        | 
 
 #### Controlling Flow
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -53,7 +53,7 @@ This specification defines the general way to register an interchain account and
 // * CONTROLLER CHAIN *
 
 // InitInterchainAccount is the entry point to registering an interchain account 
-// It generates a new port identifier using the owner address & connection identifiers
+// It generates a new port identifier using the owner address and connection identifiers
 // The port id will look like: ics27-1.{connection-id}.{counterparty-connection-id}.{owner-address}
 // It will bind to the port identifier and
 // call 04-channel 'ChanOpenInit'. An error is returned if the port identifier is already in use

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -199,7 +199,7 @@ icaPacketData = InterchainAccountPacketData{
 }
 
 // Sends the message to the host chain, where it will eventually be executed 
-TrySendTx(chanCapability, ownerAddress, connectionId, counterPartyConnectionId, data)
+TrySendTx(ownerAddress, connectionId, counterPartyConnectionId, data)
 ```
 
 4. The host chain upon receiving the IBC packet will call `DeserializeTx` and then call `AuthenticateTx` for each message. If either of these steps fails an error will be returned


### PR DESCRIPTION
This PR is updating the spec to have parity with the latest implementation. See [here](https://github.com/cosmos/ibc-go/pull/380).

Some improvements to the UX have been made by making use of ICS-04 channel negotiation (shoutout to @colin-axner  & @AdityaSripal for these ideas) as well as taking advantage of ICS-30 middleware architecture which replaces the previously existing `hooks` functionality for custom logic on `Success/Fail` of ICS-27 packets. 

I have also updated the introduction to be more clear. As well as various small updates throughout in order to align with the latest changes to the implementation. 

To be clear: **These changes are already implemented in code** & primarily effect the UX of the interchain accounts API & developer experience.

