### PR TITLE
remove ProofSpecs from Wasm spec

### DIFF
--- a/spec/client/ics-008-wasm-client/README.md
+++ b/spec/client/ics-008-wasm-client/README.md
@@ -49,7 +49,6 @@ interface ClientState {
   codeId: []byte
   data: []byte
   latestHeight: Height
-  proofSpecs: []ProofSpec
 }
 ```
 
@@ -374,7 +373,6 @@ pub enum ValidityPredicate {
 pub enum QueryMsg {
    IsValid(ValidityPredicate),
    LatestClientHeight(Vec<byte>),
-   ProofSpec(Vec<byte>)
 }
 
 ```


### PR DESCRIPTION
@AdityaSripal originally indicated [here](https://github.com/cosmos/ibc/pull/571#discussion_r654342052) that proof specs were necessary to fulfill the client interface, but than later specified that these are [no longer necessary](https://github.com/cosmos/ibc/pull/571#issuecomment-958946566)

In the ibc-go implementation case, I think the conclusion is that we would only expect the counterparty to use either use a 07-tendermint client or a 10-wasm client (with a connected tendermint client)?