### PR TITLE
ICS4: Add ORDERED_ALLOW_TIMEOUT channel type

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -643,7 +643,7 @@ function recvPacket(
             TIMEOUT_RECEIPT
           )
         }
-        break;
+        return;
 
       default:
         // unsupported channel type

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -630,11 +630,12 @@ function recvPacket(
         abortTransactionUnless(packet.timeoutHeight === 0 || getConsensusHeight() < packet.timeoutHeight)
         abortTransactionUnless(packet.timeoutTimestamp === 0 || currentTimestamp() < packet.timeoutTimestamp)
         break;
+
       case ORDERED_ALLOW_TIMEOUT:
         // for ORDERED_ALLOW_TIMEOUT, we do not abort on timeout
         // instead increment next sequence recv and write the sentinel timeout value in packet receipt
         // then return
-        if getConsensusHeight() > packet.timeoutHeight || packet.timeoutTimestamp > currentTimestamp() {
+        if (getConsensusHeight() > packet.timeoutHeight && packet.timeoutHeight != 0) || (currentTimestamp() > packet.timeoutTimestamp && packet.timeoutTimestamp != 0) {
           nextSequenceRecv = nextSequenceRecv + 1
           provableStore.set(nextSequenceRecvPath(packet.destPort, packet.destChannel), nextSequenceRecv)
           provableStore.set(

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -642,6 +642,11 @@ function recvPacket(
             TIMEOUT_RECEIPT
           )
         }
+        break;
+
+      default:
+        // unsupported channel type
+        abortTransactionUnless(true)
     }
 
     abortTransactionUnless(connection.verifyPacketData(
@@ -673,6 +678,11 @@ function recvPacket(
           packetReceiptPath(packet.destPort, packet.destChannel, packet.sequence),
           SUCCESFUL_RECEIPT
         )
+      break;
+
+      default:
+        // unsupported channel type
+        abortTransactionUnless(true)
     }
     
     // log that a packet has been received
@@ -870,6 +880,8 @@ function timeoutPacket(
           packet.destChannel,
           nextSequenceRecv
         ))
+        break;
+
       case UNORDERED:
         // unordered channel: verify absence of receipt at packet index
         abortTransactionUnless(connection.verifyPacketReceiptAbsence(
@@ -879,6 +891,10 @@ function timeoutPacket(
           packet.destChannel,
           packet.sequence
         ))
+        break;
+
+      // NOTE: For ORDERED_ALLOW_TIMEOUT, the relayer must first attempt the receive on the destination chain
+      // before the timeout receipt can be written and subsequently proven on the sender chain in timeoutPacket
       case ORDERED_ALLOW_TIMEOUT:
         abortTransactionUnless(connection.verifyPacketReceipt(
           proofHeight,
@@ -887,6 +903,11 @@ function timeoutPacket(
           packet.destChannel,
           TIMEOUT_RECEIPT,
         ))
+        break;
+
+      default:
+        // unsupported channel type
+        abortTransactionUnless(true)
     } 
 
     // all assertions passed, we can alter state

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -859,6 +859,11 @@ function timeoutPacket(
       channel.state = CLOSED
       provableStore.set(channelPath(packet.sourcePort, packet.sourceChannel), channel)
     }
+    // on ORDERED_ALLOW_TIMEOUT, increment NextSequenceRecv so that next packet sequence can be received once this packet times out.
+    if channel.order === ORDERED_ALLOW_TIMEOUT {
+      nextSequenceRecv = nextSequenceRecv + 1
+      provableStore.set(nextSequenceRecvPath(packet.destPort, packet.destChannel), nextSequenceRecv)
+    }
 
     // return transparent packet
     return packet


### PR DESCRIPTION
Allow for ORDERED_ALLOW_TIMEOUT, by writing a timeout receipt on destination chain if packet is received after timeout. Once the timeout receipt is written, it can be proven on counterparty chain to timeout packet without closing the channel