### PR TITLE
ICS20: Use `result` instead of `success` in acknowledgement

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -58,7 +58,7 @@ type FungibleTokenPacketAcknowledgement = FungibleTokenPacketSuccess | FungibleT
 
 interface FungibleTokenPacketSuccess {
   // This is binary 0x01 base64 encoded
-  success: "AQ=="
+  result: "AQ=="
 }
 
 interface FungibleTokenPacketError {


### PR DESCRIPTION
This PR updates the `FungibleTokenPacketSuccess` description in ICS20 to use `result` instead of `success`.

As `@simpletrondip` noticed in the [Agoric Discord](https://discord.com/channels/585576150827532298/766087740336635924/943031884580003890), there is a discrepancy between ICS20 and ICS04's descriptions of a successful acknowledgement.

In [the ICS20 spec](https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#data-structures), the success data structure is described as:

```
interface FungibleTokenPacketSuccess {
  // This is binary 0x01 base64 encoded
  success: "AQ=="
}
```

however, in the [ICS004 spec](https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#acknowledgement-envelope), there exists only `result` and `error`:
```
message Acknowledgement {
  oneof response {
    bytes result = 21;
    string error = 22;
  }
}
```
