### PR TITLE
Meta: Update contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,7 @@ This repository is the canonical location for development and documentation of t
 
 It shall be used to consolidate design rationale, protocol semantics, and encoding descriptions for IBC, including both the core transport, authentication, & ordering layer (IBC/TAO) and the application layers describing packet encoding & processing semantics (IBC/APP).
 
-Contributions are welcome.
-
-## Standardisation
-
-Please see [ICS 1](spec/ics-001-ics-standard/README.md) for a description of what a standard entails.
-
-To propose a new standard, [open an issue](https://github.com/cosmos/ics/issues/new).
-
-To start a new standardisation document, copy the [template](spec/ics-template.md) and open a PR.
-
-See [PROCESS.md](meta/PROCESS.md) for a description of the standardisation process.
-
-See [STANDARDS_COMMITTEE.md](meta/STANDARDS_COMMITTEE.md) for the membership of the core standardisation committee.
-
-See [CONTRIBUTING.md](meta/CONTRIBUTING.md) for contribution guidelines.
+Contributions are welcome. See [CONTRIBUTING.md](meta/CONTRIBUTING.md) for contribution guidelines.
 
 See [ROADMAP.md](meta/ROADMAP.md) for a public up-to-date version of our roadmap.
 

--- a/meta/CONTRIBUTING.md
+++ b/meta/CONTRIBUTING.md
@@ -1,8 +1,61 @@
-## Contribution Guidelines
+# Contribution Guidelines
 
 Thanks for your interest in contributing to IBC! Contributions are always welcome. 
 
-- Feel free to open an issue to raise a question, explain a concern, or discuss a possible future feature, protocol change, or standard.
-- If you would like to propose a new standard for inclusion in the IBC standards, please see [PROCESS.md](./PROCESS.md) for a detailed description of the standardisation process.
+Contributing to this repo can mean many things such as participating in discussion or proposing changes. To ensure a smooth workflow for all contributors, the general procedure for contributing has been established:
+
+- Feel free to [open](https://github.com/cosmos/ibc/issues/new) an issue to raise a question, explain a concern, or discuss a possible future feature, protocol change, or standard.
+  - Make sure first that the issue does not already [exist](https://github.com/cosmos/ibc/issues).
+  - Participate in thoughtful discussion on the issue.
+
+- If you would like to contribute in fixing / closing an issue:
+  - If the issue is a proposal, ensure that the proposal has been accepted.
+  - Ensure that nobody else has already begun working on this issue. If they have, make sure to contact them to collaborate.
+  - If nobody has been assigned for the issue and you would like to work on it, make a comment on the issue to inform the community of your intentions to begin work.
+  - Follow standard Github best practices: fork the repo, branch from the HEAD of `master`, make some commits, and submit a PR to `master`. 
+    For more details, see the [Pull Requests](#pull-requests) section below. 
+  - Be sure to submit the PR early in `Draft` mode, even if it's incomplete as this indicates to the community you're working on something and allows them to provide comments at an early stage.
+  - When the PR is complete it can be marked `Ready for Review`.
+
+- If you would like to propose a new standard for inclusion in the IBC standards, please take a look at [PROCESS.md](./PROCESS.md) for a detailed description of the standardisation process.
+  - To start a new standardisation document, copy the [template](spec/ics-template.md) and open a PR.
 
 If you have any questions, you can usually find some IBC team members on the [Cosmos Discord](https://discord.gg/rPFPxVJmUZ).
+
+## Pull Requests
+
+To accommodate review process we suggest that PRs are categorically broken up.
+Each PR should address only a single issue and **a single standard**. 
+The PR name should be prefixed by the standard number, 
+e.g., `[ICS 4] Some improvements` should contain only changes to [ICS 4](spec/core/ics-004-channel-and-packet-semantics/README.md).
+If fixing an issue requires changes to multiple standards, create multiple PRs and mention the inter-dependencies.
+
+### Process for reviewing PRs
+
+All PRs require an approval from at least two members of the [standardisation committee](./STANDARDS_COMMITTEE.md) before merge. 
+The PRs submitted by one of the members of the standardisation committee require an approval from only one other member before merge. 
+When reviewing PRs please use the following review explanations:
+- `Approval` through the GH UI means that you understand all the changes proposed in the PR. In addition:
+  - You must also think through anything which ought to be included but is not.
+  - You must think through any potential security issues or incentive-compatibility flaws introduced by the changes.
+  - The changes must be consistent with the other IBC standards, especially the [core IBC standards](../README.md#core). 
+  - The modified standard must be consistent with the description from [ICS 1](spec/ics-001-ics-standard/README.md).
+- If you are only making "surface level" reviews, submit any notes as `Comments` without adding a review.
+
+### PR Targeting
+
+Ensure that you base and target your PR on the `master` branch.
+
+### Development Procedure
+
+- The latest state of development is on `master`.
+- Create a development branch either on `github.com/cosmos/ibc` or your fork (using `git remote add fork`).
+  - To ensure a clear ownership of branches on the ibc repo, branches must be named with the convention `{moniker}/branch-name`
+- Before submitting a pull request, begin `git rebase` on top of `master`. 
+  **Since standards cannot be compiled, make sure that the changes in your PR remains consistent with the new commits on the `master` branch**.
+
+### Pull Merge Procedure
+
+- Ensure all github requirements pass.
+- Squash and merge pull request.
+

--- a/meta/CONTRIBUTING.md
+++ b/meta/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Contributing to this repo can mean many things such as participating in discussi
   - When the PR is complete it can be marked `Ready for Review`.
 
 - If you would like to propose a new standard for inclusion in the IBC standards, please take a look at [PROCESS.md](./PROCESS.md) for a detailed description of the standardisation process.
-  - To start a new standardisation document, copy the [template](spec/ics-template.md) and open a PR.
+  - To start a new standardisation document, copy the [template](../spec/ics-template.md) and open a PR.
 
 If you have any questions, you can usually find some IBC team members on the [Cosmos Discord](https://discord.gg/rPFPxVJmUZ).
 
@@ -27,7 +27,7 @@ If you have any questions, you can usually find some IBC team members on the [Co
 To accommodate review process we suggest that PRs are categorically broken up.
 Each PR should address only a single issue and **a single standard**. 
 The PR name should be prefixed by the standard number, 
-e.g., `[ICS 4] Some improvements` should contain only changes to [ICS 4](spec/core/ics-004-channel-and-packet-semantics/README.md).
+e.g., `[ICS 4] Some improvements` should contain only changes to [ICS 4](../spec/core/ics-004-channel-and-packet-semantics/README.md).
 If fixing an issue requires changes to multiple standards, create multiple PRs and mention the inter-dependencies.
 
 ### Process for reviewing PRs
@@ -39,7 +39,7 @@ When reviewing PRs please use the following review explanations:
   - You must also think through anything which ought to be included but is not.
   - You must think through any potential security issues or incentive-compatibility flaws introduced by the changes.
   - The changes must be consistent with the other IBC standards, especially the [core IBC standards](../README.md#core). 
-  - The modified standard must be consistent with the description from [ICS 1](spec/ics-001-ics-standard/README.md).
+  - The modified standard must be consistent with the description from [ICS 1](../ics-001-ics-standard/README.md).
 - If you are only making "surface level" reviews, submit any notes as `Comments` without adding a review.
 
 ### PR Targeting

--- a/meta/CONTRIBUTING.md
+++ b/meta/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you have any questions, you can usually find some IBC team members on the [Co
 To accommodate review process we suggest that PRs are categorically broken up.
 Each PR should address only a single issue and **a single standard**. 
 The PR name should be prefixed by the standard number, 
-e.g., `[ICS 4] Some improvements` should contain only changes to [ICS 4](../spec/core/ics-004-channel-and-packet-semantics/README.md).
+e.g., `ICS4: Some improvements` should contain only changes to [ICS 4](../spec/core/ics-004-channel-and-packet-semantics/README.md).
 If fixing an issue requires changes to multiple standards, create multiple PRs and mention the inter-dependencies.
 
 ### Process for reviewing PRs

--- a/meta/CONTRIBUTING.md
+++ b/meta/CONTRIBUTING.md
@@ -39,7 +39,7 @@ When reviewing PRs please use the following review explanations:
   - You must also think through anything which ought to be included but is not.
   - You must think through any potential security issues or incentive-compatibility flaws introduced by the changes.
   - The changes must be consistent with the other IBC standards, especially the [core IBC standards](../README.md#core). 
-  - The modified standard must be consistent with the description from [ICS 1](../ics-001-ics-standard/README.md).
+  - The modified standard must be consistent with the description from [ICS 1](../spec/ics-001-ics-standard/README.md).
 - If you are only making "surface level" reviews, submit any notes as `Comments` without adding a review.
 
 ### PR Targeting

--- a/meta/CONTRIBUTING.md
+++ b/meta/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Ensure that you base and target your PR on the `master` branch.
 
 - The latest state of development is on `master`.
 - Create a development branch either on `github.com/cosmos/ibc` or your fork (using `git remote add fork`).
-  - To ensure a clear ownership of branches on the ibc repo, branches must be named with the convention `{moniker}/branch-name`
+  - To ensure a clear ownership of branches on the ibc repo, branches must be named with the convention `{moniker}/{issue#}-branch-name`
 - Before submitting a pull request, begin `git rebase` on top of `master`. 
   **Since standards cannot be compiled, make sure that the changes in your PR remains consistent with the new commits on the `master` branch**.
 

--- a/meta/PROCESS.md
+++ b/meta/PROCESS.md
@@ -20,11 +20,14 @@ IBC standardisation will follow an adaptation of the [TC 39](https://tc39.github
 - _**Entrance Criteria**_:
   * Prose outlining the problem or need and the general shape of a solution in a PR to a `./spec/{area}/ics-{{ .Spec.Number }}-{{ .Spec.Name }}/README.md` file in this repository.
     This file should contain:
-    1. List of expected projects & users within the Cosmos ecosystem who might make use of the specification along with any particular requirements they have
-    1. Discussion of key algorithms, abstractions, and semantics
-    1. High-level application interface outline, where applicable
-    1. Identification of potential design trade-offs and implementation challenges/complexity
-    See [ICS 1](../spec/ics-001-ics-standard) for a more detailed description of standard requirements.
+    - List of expected projects & users within the Cosmos ecosystem who might make use of the specification along with any particular requirements they have
+    - Discussion of key algorithms, abstractions, and semantics
+    - High-level application interface outline, where applicable
+    - Identification of potential design trade-offs and implementation challenges/complexity
+    
+    For a more detailed description of standard requirements, see [ICS 1](../spec/ics-001-ics-standard).
+  
+    For more details on submitting a PR, take a look at the [Pull Requests](./CONTRIBUTING.md/#pull-requests) section in the contribution guidelines.
   * Identified `author(s)` who will advance the proposal in the header of the standard file
   * Any additional reference documentation or media in the `./spec/ics-{{ .Spec.Number }}-{{ .Spec.Name }}` directory
   * The specification team expects that this proposal will be finalised and eventually included in the IBC standard set.

--- a/meta/STANDARDS_COMMITTEE.md
+++ b/meta/STANDARDS_COMMITTEE.md
@@ -3,6 +3,6 @@
 Currently, the core standardisation committee consists of:
 - Aditya Sripal (@adityasripal)
 - Christopher Goes (@cwgoes)
-- Zarko Milosevic (@milosevic)
+- Marius Poke (@mpoke)
 
 A two-of-three quorum is needed to approve pull requests to this repository.


### PR DESCRIPTION
I created a draft of the new contributing guidelines. I used https://github.com/cosmos/ibc-go/blob/main/CONTRIBUTING.md as template. 

Open questions:
- [ ] Do we want to keep the current version of the IBC Standardisation Process (i.e., `PROCESS.md`)?
- [ ] Do we want to have different issue types (e.g., Bug Report, Feature Request, ICS Proposal)? Alternatively, we could have different labels.   