### PR TITLE
ICS20: onChanCloseInit must return error

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -178,7 +178,8 @@ function onChanOpenConfirm(
 function onChanCloseInit(
   portIdentifier: Identifier,
   channelIdentifier: Identifier) {
-  // no action necessary
+    // always abort transaction
+    abortTransactionUnless(FALSE)
 }
 ```
 


### PR DESCRIPTION
Closes #625 

In ICS20, the channel should not close. Thus, the channel closing handshake should be aborted. 