### PR TITLE
ICS 004, ICS 026: add counterparty channel identifier argument to function call

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -159,10 +159,11 @@ function onChanOpenTry(
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  version: string) {
+  counterpartyChannelIdentifier: Identifier,
+  counterpartyVersion: string) {
   // port has already been validated
-  // assert that version is "ics20-1"
-  abortTransactionUnless(version === "ics20-1")
+  // assert that counterparty selected version is "ics20-1"
+  abortTransactionUnless(counterpartyVersion === "ics20-1")
 }
 ```
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -422,6 +422,7 @@ function onChanOpenTry(
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
+  counterpartyChannelIdentifier,
   counterpartyVersion: string) {
 
   // validate counterparty metadata decided by host chain

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -255,8 +255,9 @@ function OnChanOpenTry(
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  version: string) {
-      feeVersion, appVersion = splitFeeVersion(version)
+  counterpartyChannelIdentifier: Identifier,
+  counterpartyVersion: string) {
+      feeVersion, appVersion = splitFeeVersion(counterpartyVersion)
       if !isSupported(feeVersion) {
           return error
       }

--- a/spec/app/ics-030-middleware/README.md
+++ b/spec/app/ics-030-middleware/README.md
@@ -129,8 +129,9 @@ function OnChanOpenTry(
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  version: string) {
-      middlewareVersion, appVersion = splitMiddlewareVersion(version)
+  counterpartyChannelIdentifier: Identifier,
+  counterpartyVersion: string) {
+      middlewareVersion, appVersion = splitMiddlewareVersion(counterpartyVersion)
       if !isCompatible(middlewareVersion) {
           return error
       }

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -362,8 +362,8 @@ counterparty module on the other chain.
 function chanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  counterpartyVersion: string,
   counterpartyChannelIdentifier: Identifier,
+  counterpartyVersion: string,
   proofTry: CommitmentProof,
   proofHeight: Height) {
     channel = provableStore.get(channelPath(portIdentifier, channelIdentifier))

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -363,7 +363,7 @@ function chanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
   counterpartyVersion: string,
-  counterpartyChannelIdentifier: string,
+  counterpartyChannelIdentifier: Identifier,
   proofTry: CommitmentProof,
   proofHeight: Height) {
     channel = provableStore.get(channelPath(portIdentifier, channelIdentifier))

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -102,7 +102,8 @@ is invalid to abort the handshake. It may also perform custom ACK logic.
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  version: string) {
+  counterpartyVersion: string, 
+  counterpartyChannelIdentifier: Identifier) {
     // defined by the module
 }
 ```
@@ -510,7 +511,7 @@ function handleChanOpenAck(datagram: ChanOpenAck) {
     handler.chanOpenAck(
       datagram.portIdentifier,
       datagram.channelIdentifier,
-      datagram.version,
+      datagram.counterpartyVersion,
       datagram.counterpartyChannelIdentifier,
       datagram.proofTry,
       datagram.proofHeight

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -511,6 +511,7 @@ function handleChanOpenAck(datagram: ChanOpenAck) {
       datagram.portIdentifier,
       datagram.channelIdentifier,
       datagram.version,
+      datagram.counterpartyChannelIdentifier,
       datagram.proofTry,
       datagram.proofHeight
     )

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -493,8 +493,8 @@ function handleChanOpenTry(datagram: ChanOpenTry) {
 interface ChanOpenAck {
   portIdentifier: Identifier
   channelIdentifier: Identifier
-  counterpartyVersion: string
   counterpartyChannelIdentifier: Identifier
+  counterpartyVersion: string
   proofTry: CommitmentProof
   proofHeight: Height
 }
@@ -511,8 +511,8 @@ function handleChanOpenAck(datagram: ChanOpenAck) {
     handler.chanOpenAck(
       datagram.portIdentifier,
       datagram.channelIdentifier,
-      datagram.counterpartyVersion,
       datagram.counterpartyChannelIdentifier,
+      datagram.counterpartyVersion,
       datagram.proofTry,
       datagram.proofHeight
     )

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -102,7 +102,8 @@ is invalid to abort the handshake. It may also perform custom ACK logic.
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  version: string) {
+  counterpartyChannelIdentifier: Identifier, 
+  counterpartyVersion: string) {
     // defined by the module
 }
 ```
@@ -505,7 +506,8 @@ function handleChanOpenAck(datagram: ChanOpenAck) {
     err = module.onChanOpenAck(
       datagram.portIdentifier,
       datagram.channelIdentifier,
-      datagram.version
+      datagram.counterpartyChannelIdentifier,
+      datagram.counterpartyVersion
     )
     abortTransactionUnless(err === nil)
     handler.chanOpenAck(

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -493,7 +493,8 @@ function handleChanOpenTry(datagram: ChanOpenTry) {
 interface ChanOpenAck {
   portIdentifier: Identifier
   channelIdentifier: Identifier
-  version: string
+  counterpartyVersion: string
+  counterpartyChannelIdentifier: Identifier
   proofTry: CommitmentProof
   proofHeight: Height
 }

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -102,8 +102,7 @@ is invalid to abort the handshake. It may also perform custom ACK logic.
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  counterpartyVersion: string, 
-  counterpartyChannelIdentifier: Identifier) {
+  version: string) {
     // defined by the module
 }
 ```


### PR DESCRIPTION
aligns ICS 026 usage with function signature in ICS 004

closed #675, #674