### PR TITLE
ICS28: Use currentTimestamp() >= p.stopTime in StopConsumerChainProposalHandler

### DIFF
--- a/spec/app/ics-028-cross-chain-validation/methods.md
+++ b/spec/app/ics-028-cross-chain-validation/methods.md
@@ -842,7 +842,7 @@ function onChanOpenConfirm(
 // PCF: Provider Chain Function
 // implements governance proposal Handler 
 function StopConsumerChainProposalHandler(p: StopConsumerChainProposal) {
-  if currentTimestamp() > p.stopTime {
+  if currentTimestamp() >= p.stopTime {
     // stop the consumer chain and do not lock the unbonding
     StopConsumerChain(p.chainId, false)
   }


### PR DESCRIPTION
Tackle https://github.com/cosmos/ibc/issues/768