### PR TITLE
ICS28: Add consumer UnbondingPeriod

### DIFF
--- a/spec/app/ics-028-cross-chain-validation/data_structures.md
+++ b/spec/app/ics-028-cross-chain-validation/data_structures.md
@@ -216,6 +216,7 @@ This section describes the internal state of the CCV module. For simplicity, the
 [&uparrow; Back to Outline](#outline)
 
 - `ConsumerPortId = "consumer"` is the port ID the consumer CCV module is expected to bind to.
+- `consumerUnbondingPeriod: Duration"` is the unbonding period on the consumer chain. 
 - `providerClient: Identifier` identifies the client of the provider chain (on the consumer chain) that the CCV channel is build upon.
 - `providerChannel: Identifier` identifies the consumer's channel end of the CCV channel.
 - `validatorSet: <string, CrossChainValidator>` is a mapping that stores the validators in the validator set of the consumer chain. Each validator is described by a `CrossChainValidator` data structure, which is defined as


### PR DESCRIPTION
The consumer chain unbonding period is computed from the provider chain unbonding period. 

Closes https://github.com/cosmos/ibc/issues/673