### PR TITLE
ICS-29: fix typos, update modified date

### DIFF
--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -259,7 +259,7 @@ function onChanOpenInit(
 
     // check that feeVersion is supported
     if !isSupported(metadata.feeVersion) {
-        return "", error
+        return error
     }
     // call the underlying applications OnChanOpenInit callback
     app.onChanOpenInit(

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -223,7 +223,7 @@ The fee middleware will negotiate its fee protocol version with the counterparty
 
 Channel Version: 
 ```json
-{"fee_version":<fee_protocol_version>,"app_version":<application_version>}
+{"fee_version":"<fee_protocol_version>","app_version":"<application_version>"}
 ```
 
 Ex: 

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -7,7 +7,7 @@ requires: 4, 25, 26, 30
 kind: instantiation
 author: Aditya Sripal <aditya@interchain.berlin>, Ethan Frey <ethan@confio.tech>
 created: 2021-06-01
-modified: 2021-06-18
+modified: 2022-07-06
 ---
 
 ## Synopsis
@@ -191,7 +191,6 @@ function PayTimeoutFee(packet: Packet, timeout_relayer: string) {
 }
 ```
 
-
 The fee module should also expose the following queries so that relayers may query their expected fee:
 
 ```typescript
@@ -257,7 +256,7 @@ function onChanOpenInit(
     // otherwise, pass version directly to app callback.
     metadata, err = UnmarshalJSON(version)
     if err != nil {
-        // call the underlying applications OnChanOpenInit callback
+        // call the underlying application's OnChanOpenInit callback
         return app.onChanOpenInit(
             order,
             connectionHops,
@@ -273,7 +272,7 @@ function onChanOpenInit(
     if !isSupported(metadata.feeVersion) {
         return "", error
     }
-    // call the underlying applications OnChanOpenInit callback.
+    // call the underlying application's OnChanOpenInit callback.
     // if the version string is empty, OnChanOpenInit is expected to return
     // a default version string representing the version(s) it supports
     appVersion, err = app.onChanOpenInit(
@@ -305,10 +304,12 @@ function onChanOpenTry(
   counterpartyPortIdentifier: Identifier,
   counterpartyChannelIdentifier: Identifier,
   counterpartyVersion: string): (version: string, err: Error) {
-    // select mutually compatible fee version
+    // try to unmarshal JSON-encoded version string and pass 
+    // the app-specific version to app callback.
+    // otherwise, pass version directly to app callback.
     cpMetadata, err = UnmarshalJSON(counterpartyVersion)
     if err != nil {
-        // call the underlying applications OnChanOpenTry callback
+        // call the underlying application's OnChanOpenTry callback
         return app.onChanOpenTry(
             order,
             connectionHops,
@@ -320,12 +321,13 @@ function onChanOpenTry(
         )
     }
 
+    // select mutually compatible fee version
     if !isCompatible(cpMetadata.feeVersion) {
         return "", error
     }
     feeVersion = selectFeeVersion(cpMetadata.feeVersion)
 
-    // call the underlying applications OnChanOpenTry callback
+    // call the underlying application's OnChanOpenTry callback
     appVersion, err = app.onChanOpenTry(
         order,
         connectionHops,
@@ -339,10 +341,9 @@ function onChanOpenTry(
         return "", err
     }
     
-    // a new version string is constructed with the finall fee version
+    // a new version string is constructed with the final fee version
     // that is selected and the app version returned by the underlying
-    // application (which may be differents different than the one
-    // passed by the caller
+    // application (which may be different than the one passed by the caller)
     version = constructVersion(feeVersion, appVersion)
 
     return version, nil
@@ -355,7 +356,7 @@ function onChanOpenAck(
   counterpartyVersion: string) {
     cpMetadata, err = UnmarshalJSON(counterpartyVersion)
     if err != nil {
-        // call the underlying applications OnChanOpenAck callback
+        // call the underlying application's OnChanOpenAck callback
         return app.onChanOpenAck(
             portIdentifier, 
             channelIdentifier, 
@@ -367,7 +368,7 @@ function onChanOpenAck(
     if !isSupported(cpMetadata.feeVersion) {
         return error
     }  
-    // call the underlying applications OnChanOpenAck callback
+    // call the underlying application's OnChanOpenAck callback
     return app.onChanOpenAck(
         portIdentifier, 
         channelIdentifier, 
@@ -582,6 +583,8 @@ Coming soon.
 June 8 2021 - Switched to middleware solution from implementing callbacks in ICS-4 directly.
 
 June 1 2021 - Draft written
+
+July 6, 2022 - Update with latest changes from implementation
 
 ## Copyright
 

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -223,7 +223,7 @@ The fee middleware will negotiate its fee protocol version with the counterparty
 
 Channel Version: 
 ```json
-{"fee_version":<fee_protocol_version>,"app_version":<application_version>}`
+{"fee_version":<fee_protocol_version>,"app_version":<application_version>}
 ```
 
 Ex: 
@@ -448,10 +448,10 @@ function constructIncentivizedAck(
   forward_relayer: string, 
   success: boolean): Acknowledgement {
     return Acknowledgement{
-		appAcknowledgement:    app_ack,
-		forwardRelayerAddress: relayer,
+	appAcknowledgement:    app_ack,
+	forwardRelayerAddress: relayer,
         underlyingAppSuccess:  success,
-	}
+    }
 }
 
 function getForwardRelayer(ack: Acknowledgement): string {

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -94,7 +94,7 @@ Alternate flow:
 ### Fee details
 
 For an example implementation in the Cosmos SDK, we consider 3 potential fee payments, which may be defined. Each one may be
-paid out in a different token. Imagine a connection between IrisNet and the Cosmos Hub. They may define:
+paid out in a different token. Imagine a connection between IrisNet and the Cosmos Hub. To incentivize a packet from IrisNet to the Cosmos Hub, they may define:
 
 - ReceiveFee: 0.003 channel-7/ATOM vouchers (ATOMs already on IrisNet via ICS20)
 - AckFee: 0.001 IRIS
@@ -102,7 +102,7 @@ paid out in a different token. Imagine a connection between IrisNet and the Cosm
 
 Ideally the fees can easily be redeemed in native tokens on both sides, but relayers may select others. In this example, the relayer collects a fair bit of IRIS, covering its costs there and more. It also collects channel-7/ATOM vouchers from many packets. After relaying a few thousand packets, the account on the Cosmos Hub is running low, so the relayer will send those channel-7/ATOM vouchers back over channel-7 to it's account on the Hub to replenish the supply there. 
 
-The sender chain will escrow 0.003 channel-7/ATOM and 0.002 IRIS from the fee payers' account. In the case that a forward relayer submits the `recvPacket` and a reverse relayer submits the `ackPacket`, the forward relayer is rewarded 0.003 channel-7/ATOM and the reverse relayer is rewarded 0.001 IRIS while 0.001 IRIS is refunded to the original fee payer. In the case where the packet times out, the timeout relayer receives 0.002 IRIS and 0.003 channel-7/ATOM is refunded to the original fee payer.
+The sender chain will escrow 0.003 channel-7/ATOM and 0.002 IRIS from the fee payers' account. In the case that a forward relayer submits the `recvPacket` and a reverse relayer submits the `ackPacket`, the forward relayer is rewarded 0.003 channel-7/ATOM and the reverse relayer is rewarded 0.001 IRIS while 0.002 IRIS is refunded to the original fee payer. In the case where the packet times out, the timeout relayer receives 0.002 IRIS and 0.003 channel-7/ATOM is refunded to the original fee payer.
 
 The logic involved in collecting fees from users and then paying it out to the relevant relayers is encapsulated by a separate fee module and may vary between implementations. However, all fee modules must implement a uniform interface such that the ICS-4 handlers can correctly pay out fees to the right relayers, and so that relayers themselves can easily determine the fees they can expect for relaying a packet.
 

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -367,7 +367,7 @@ function onRecvPacket(packet: Packet, relayer: string): bytes {
     sourceAddress = getCounterpartyPayeeAddress(relayer)
 
     // wrap the acknowledgement with forward relayer and return marshalled bytes
-    // constructIncentivizedAck takes the app-specific acknowledgement and receive-packet relayer (forward relayer), and 
+    // constructIncentivizedAck takes the app-specific acknowledgement and receive-packet relayer (forward relayer)
     // and constructs the incentivized acknowledgement struct with the forward relayer and app-specific acknowledgement embedded.
     ack = constructIncentivizedAck(app_acknowledgment, sourceAddress)
     return marshal(ack)

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -515,7 +515,7 @@ function sendPacket(
 
 **User sending Packets**
 
-A user may specify a fee to incentivize the relaying during packet submission, by submitting a fee payment message atomically with the application-specific "send packet" message (e.g. ICS-20 MsgTransfer). The fee middleware will escrow the fee for the packet that is created atomically with the escrow. The fee payment message itself is not specified in this document as it may vary greatly across implementations. In some middleware, there may be no fee payment message at all if the fees are being paid out from an altruistic pool.
+A user may specify a fee to incentivize the relaying during packet submission, by submitting a fee payment message atomically with the application-specific "send packet" message (e.g. ICS-20 `MsgTransfer`). The fee middleware will escrow the fee for the packet that is created atomically with the escrow. The fee payment message itself is not specified in this document as it may vary greatly across implementations. In some middleware, there may be no fee payment message at all if the fees are being paid out from an altruistic pool.
 
 Since the fee middleware does not need to modify the outgoing packet, the fee payment message may be placed before or after the send packet message. However in order to maintain consistency with other middleware messages, it is recommended that fee middleware require their messages to be placed before the send packet message and escrow fees for the **next sequence** on the given channel. This way when the messages are atomically committed, the next sequence on the channel is the send packet message sent by the user, and the user escrows their fee for the created packet.
 

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -136,9 +136,9 @@ function relayerAddressForAsyncAckPath(packet: Packet): Path {
 
 ### Fee Middleware Contract
 
-While the details may vary between fee modules, all Fee modules **must** ensure it does the following:
+While the details may vary between fee modules, all fee modules **must** ensure they does the following:
 
-- It must allow relayers to register their counterparty payee address.
+- It must allow relayers to register their counterparty payee address (i.e. source address).
 - It must have in escrow the maximum fees that all outstanding packets may pay out (or it must have ability to mint required amount of tokens)
 - It must pay the receive fee for a packet to the forward relayer specified in `PayFee` callback (if unspecified, it must refund forward fee to original fee payer(s))
 - It must pay the ack fee for a packet to the reverse relayer specified in `PayFee` callback
@@ -146,23 +146,31 @@ While the details may vary between fee modules, all Fee modules **must** ensure 
 - It must refund any remainder fees in escrow to the original fee payer(s) if applicable
 
 ```typescript
-// RegisterCounterpartyPayee is called by the relayer on each channelEnd and allows them to specify their counterparty payee address before relaying
-// This ensures they will be properly compensated for forward relaying since destination chain must send back relayer's source address (counterparty payee address) in acknowledgement
-// This function may be called more than once by relayer, in which case, latest counterparty payee address is always used.
+// RegisterCounterpartyPayee is called by the relayer on each channelEnd and 
+// allows them to specify their counterparty payee address before relaying.
+// This ensures they will be properly compensated for forward relaying since 
+// destination chain must send back relayer's source address (counterparty 
+// payee address) in acknowledgement.
+// This function may be called more than once by relayer, in which case, latest 
+// counterparty payee address is always used.
 function RegisterCounterpartyPayee(relayer: string, counterPartyAddress: string) {
     // set mapping between relayer address and counterparty payee address
 }
 
-// EscrowPacketFee is an open callback that may be called by any module/user that wishes to escrow funds in order to
-// incentivize the relaying of the given packet.
-// NOTE: These fees are escrowed in addition to any previously escrowed amount for the packet. In the case where the previous amount is zero,
-// the provided fees are the initial escrow amount.
+// EscrowPacketFee is an open callback that may be called by any module/user 
+// that wishes to escrow funds in order to incentivize the relaying of the 
+// given packet.
+// NOTE: These fees are escrowed in addition to any previously escrowed amount 
+// for the packet. In the case where the previous amount is zero, the provided 
+// fees are the initial escrow amount.
 // They may set a separate receiveFee, ackFee, and timeoutFee to be paid
-// for each step in the packet flow. The caller must send max(receiveFee+ackFee, timeoutFee) to the fee module to be locked
-// in escrow to provide payout for any potential packet flow.
-// The caller may optionally specify an array of relayer addresses. This MAY be used by the fee module to modify fee payment logic
-// based on ultimate relayer address. For example, fee module may choose to only pay out relayer if the relayer address was specified in
-// the `EscrowPacketFee`.
+// for each step in the packet flow. The caller must send max(receiveFee+ackFee, timeoutFee)
+// to the fee module to be locked in escrow to provide payout for any potential 
+// packet flow.
+// The caller may optionally specify an array of relayer addresses. This MAY be
+// used by the fee module to modify fee payment logic based on ultimate relayer
+// address. For example, fee module may choose to only pay out relayer if the 
+// relayer address was specified in the `EscrowPacketFee`.
 function EscrowPacketFee(packet: Packet, receiveFee: Fee, ackFee: Fee, timeoutFee: Fee, relayers: []string) {
     // escrow max(receiveFee+ackFee, timeoutFee) for this packet
     // do custom logic with provided relayer addresses if necessary

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -429,7 +429,8 @@ function onAcknowledgePacket(packet: Packet, acknowledgement: bytes, relayer: st
     forward_relayer = getForwardRelayer(ack)
     PayFee(packet, forward_relayer, relayer)
 
-    // unwrap the raw acknowledgement bytes sent by counterparty application and pass it to the application callback.
+    // unwrap the raw acknowledgement bytes sent by counterparty application
+    // and pass it to the application callback.
     app_ack = getAppAcknowledgement(acknowledgement)
 
     app.OnAcknowledgePacket(packet, app_ack, relayer)
@@ -579,6 +580,7 @@ Coming soon.
 ## History
 
 June 8 2021 - Switched to middleware solution from implementing callbacks in ICS-4 directly.
+
 June 1 2021 - Draft written
 
 ## Copyright


### PR DESCRIPTION
This just fixes some typos and adds an entry in the` History` section and updates the `modified` date, which should have been done in the [previous PR](https://github.com/cosmos/ibc/pull/779).