### PR TITLE
ICS4: Fix crossing hellos removal for channel handshake

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -381,7 +381,7 @@ function chanOpenAck(
   proofTry: CommitmentProof,
   proofHeight: Height) {
     channel = provableStore.get(channelPath(portIdentifier, channelIdentifier))
-    abortTransactionUnless(channel.state === INIT || channel.state === TRYOPEN)
+    abortTransactionUnless(channel.state === INIT)
     abortTransactionUnless(authenticateCapability(channelCapabilityPath(portIdentifier, channelIdentifier), capability))
     connection = provableStore.get(connectionPath(channel.connectionHops[0]))
     abortTransactionUnless(connection !== null)


### PR DESCRIPTION
Thanks to @colin-axner , a change was missed in removing crossing hellos in #629 