### PR TITLE
docs: add link to eli5 IBC blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Contributions are welcome. See [CONTRIBUTING.md](meta/CONTRIBUTING.md) for contr
 
 See [ROADMAP.md](meta/ROADMAP.md) for a public up-to-date version of our roadmap.
 
+## What is IBC?
+
+For a high-level explanation of what IBC is and how it works, please read [this blog post](https://blog.cosmos.network/eli5-what-is-ibc-a212f518715f).
+
 ## Interchain Standards
 
 All standards at or past the "Draft" stage are listed here in order of their ICS numbers, sorted by category.


### PR DESCRIPTION
Adding link on the README.md to this [blog post](https://blog.cosmos.network/eli5-what-is-ibc-a212f518715f).