### PR TITLE
Put `ClientState` in `provableStore` and use it in `connOpen{Try,Ack}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,4 +40,4 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## [Unreleased]
 
 ### Improvements
-* \#764 Move `ClientState` to the `provableStore` and add `ClientState` validation in `connOpenTry` and `connOpenAck`
+* [\#802](https://github.com/cosmos/ibc/pull/802) Move `ClientState` to the `provableStore` and add `ClientState` validation in `connOpenTry` and `connOpenAck`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 # Changelog
 
 ## [Unreleased]
+
+### Improvements
+* \#764 Move `ClientState` to the `provableStore` and add `ClientState` validation in `connOpenTry` and `connOpenAck`

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -915,6 +915,8 @@ Jan 13, 2020 - Revisions for client type separation & path alterations
 
 Jan 26, 2020 - Addition of query interface
 
+Jul 27, 2022 - Addition of `verifyClientState` function, and move `ClientState` to the `provableStore`
+
 ## Copyright
 
 All content herein is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -479,7 +479,7 @@ This specification defines a single function to query the state of a client by-i
 
 ```typescript
 function queryClientState(identifier: Identifier): ClientState {
-  return privateStore.get(clientStatePath(identifier))
+  return provableStore.get(clientStatePath(identifier))
 }
 ```
 
@@ -621,7 +621,7 @@ function createClient(
   clientType: ClientType,
   consensusState: ConsensusState) {
     abortTransactionUnless(validateClientIdentifier(id))
-    abortTransactionUnless(privateStore.get(clientStatePath(id)) === null)
+    abortTransactionUnless(provableStore.get(clientStatePath(id)) === null)
     abortSystemUnless(provableStore.get(clientTypePath(id)) === null)
     clientType.initialise(consensusState)
     provableStore.set(clientTypePath(id), clientType)
@@ -656,7 +656,7 @@ function updateClient(
   header: Header) {
     clientType = provableStore.get(clientTypePath(id))
     abortTransactionUnless(clientType !== null)
-    clientState = privateStore.get(clientStatePath(id))
+    clientState = provableStore.get(clientStatePath(id))
     abortTransactionUnless(clientState !== null)
     clientType.checkValidityAndUpdateState(clientState, header)
 }
@@ -673,7 +673,7 @@ function submitMisbehaviourToClient(
   misbehaviour: bytes) {
     clientType = provableStore.get(clientTypePath(id))
     abortTransactionUnless(clientType !== null)
-    clientState = privateStore.get(clientStatePath(id))
+    clientState = provableStore.get(clientStatePath(id))
     abortTransactionUnless(clientState !== null)
     clientType.checkMisbehaviourAndUpdateState(clientState, misbehaviour)
 }
@@ -744,7 +744,7 @@ function initialise(consensusState: ConsensusState): () {
     pastPublicKeys: Set.singleton(consensusState.publicKey),
     verifiedRoots: Map.empty()
   }
-  privateStore.set(identifier, clientState)
+  provableStore.set(identifier, clientState)
 }
 
 // validity predicate function defined by the client type

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -336,6 +336,18 @@ type verifyClientConsensusState = (
   => boolean
 ```
 
+`verifyClientState` verifies a proof of the client state of the specified client stored on the target machine.
+
+```typescript
+type verifyClientState = (
+  height: Height,
+  prefix: CommitmentPrefix,
+  proof: CommitmentProof,
+  clientIdentifier: Identifier,
+  clientState: ClientState)
+  => boolean
+```
+
 `verifyConnectionState` verifies a proof of the connection state of the specified connection end stored on the target machine.
 
 ```typescript

--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -415,10 +415,10 @@ function connOpenAck(
         (connection.state === INIT && connection.version.indexOf(version) !== -1)
         || (connection.state === TRYOPEN && connection.version === version))
     expectedConsensusState = getConsensusState(consensusHeight)
-    expected = ConnectionEnd{TRYOPEN, identifier, getCommitmentPrefix(),
+    expectedConnectionEnd = ConnectionEnd{TRYOPEN, identifier, getCommitmentPrefix(),
                              connection.counterpartyClientIdentifier, connection.clientIdentifier,
                              version, connection.delayPeriodTime, connection.delayPeriodBlocks}
-    abortTransactionUnless(connection.verifyConnectionState(proofHeight, proofTry, counterpartyIdentifier, expected))
+    abortTransactionUnless(connection.verifyConnectionState(proofHeight, proofTry, counterpartyIdentifier, expectedConnectionEnd))
     abortTransactionUnless(connection.verifyClientState(proofHeight, proofClient, clientState))
     abortTransactionUnless(connection.verifyClientConsensusState(
       proofHeight, proofConsensus, connection.counterpartyClientIdentifier, consensusHeight, expectedConsensusState))

--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -144,7 +144,7 @@ function verifyClientConsensusState(
   consensusStateHeight: Height,
   consensusState: ConsensusState) {
     client = queryClient(connection.clientIdentifier)
-    return client.verifyClientConsensusState(connection, height, connection.counterpartyPrefix, proof, connection.clientIdentifier, consensusStateHeight, consensusState)
+    return client.verifyClientConsensusState(connection, height, connection.counterpartyPrefix, proof, clientIdentifier, consensusStateHeight, consensusState)
 }
 
 function verifyClientState(

--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -377,6 +377,7 @@ function connOpenTry(
       // generate a new identifier if the passed identifier was the sentinel empty-string
       identifier = generateIdentifier()
     }
+    abortTransactionUnless(validateSelfClient(clientState))
     abortTransactionUnless(consensusHeight < getCurrentHeight())
     expectedConsensusState = getConsensusState(consensusHeight)
     expectedConnectionEnd = ConnectionEnd{INIT, "", getCommitmentPrefix(), counterpartyClientIdentifier,
@@ -408,6 +409,7 @@ function connOpenAck(
   proofHeight: Height,
   consensusHeight: Height) {
     abortTransactionUnless(consensusHeight < getCurrentHeight())
+    abortTransactionUnless(validateSelfClient(clientState))
     connection = provableStore.get(connectionPath(identifier))
     abortTransactionUnless(
         (connection.state === INIT && connection.version.indexOf(version) !== -1)

--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -399,9 +399,11 @@ function connOpenTry(
 ```typescript
 function connOpenAck(
   identifier: Identifier,
+  clientState: ClientState,
   version: string,
   counterpartyIdentifier: Identifier,
   proofTry: CommitmentProof,
+  proofClient: CommitmentProof,
   proofConsensus: CommitmentProof,
   proofHeight: Height,
   consensusHeight: Height) {
@@ -415,6 +417,7 @@ function connOpenAck(
                              connection.counterpartyClientIdentifier, connection.clientIdentifier,
                              version, connection.delayPeriodTime, connection.delayPeriodBlocks}
     abortTransactionUnless(connection.verifyConnectionState(proofHeight, proofTry, counterpartyIdentifier, expected))
+    abortTransactionUnless(connection.verifyClientState(proofHeight, proofClient, clientState))
     abortTransactionUnless(connection.verifyClientConsensusState(
       proofHeight, proofConsensus, connection.counterpartyClientIdentifier, consensusHeight, expectedConsensusState))
     connection.state = OPEN

--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -485,6 +485,8 @@ May 17, 2019 - Draft finalised
 
 Jul 29, 2019 - Revisions to track connection set associated with client
 
+Jul 27, 2022 - Addition of `ClientState` validation in `connOpenTry` and `connOpenAck`
+
 ## Copyright
 
 All content herein is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -203,7 +203,7 @@ Constant-size commitments to packet data fields are stored under the packet sequ
 
 ```typescript
 function packetCommitmentPath(portIdentifier: Identifier, channelIdentifier: Identifier, sequence: uint64): Path {
-    return "commitments/ports/{portIdentifier}/channels/{channelIdentifier}/packets/" + sequence
+    return "commitments/ports/{portIdentifier}/channels/{channelIdentifier}/packets/{sequence}"
 }
 ```
 
@@ -213,7 +213,7 @@ Packet receipt data are stored under the `packetReceiptPath`
 
 ```typescript
 function packetReceiptPath(portIdentifier: Identifier, channelIdentifier: Identifier, sequence: uint64): Path {
-    return "receipts/ports/{portIdentifier}/channels/{channelIdentifier}/receipts/" + sequence
+    return "receipts/ports/{portIdentifier}/channels/{channelIdentifier}/receipts/{sequence}"
 }
 ```
 
@@ -221,7 +221,7 @@ Packet acknowledgement data are stored under the `packetAcknowledgementPath`:
 
 ```typescript
 function packetAcknowledgementPath(portIdentifier: Identifier, channelIdentifier: Identifier, sequence: uint64): Path {
-    return "acks/ports/{portIdentifier}/channels/{channelIdentifier}/acknowledgements/" + sequence
+    return "acks/ports/{portIdentifier}/channels/{channelIdentifier}/sequences/{sequence}"
 }
 ```
 

--- a/spec/core/ics-024-host-requirements/README.md
+++ b/spec/core/ics-024-host-requirements/README.md
@@ -397,6 +397,8 @@ Aug 18, 2019 - Revisions to module system, definitions
 
 Jul 05, 2022 - Lower the minimal allowed length of a channel identifier to 8
 
+Jul 27, 2022 - Move `ClientState` to the `provableStore`, and add "Client state validation" section
+
 ## Copyright
 
 All content herein is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/spec/core/ics-024-host-requirements/README.md
+++ b/spec/core/ics-024-host-requirements/README.md
@@ -119,7 +119,7 @@ Note that the client-related paths listed below reflect the Tendermint client as
 | Store          | Path format                                                                    | Value type        | Defined in |
 | -------------- | ------------------------------------------------------------------------------ | ----------------- | ---------------------- |
 | provableStore  | "clients/{identifier}/clientType"                                              | ClientType        | [ICS 2](../ics-002-client-semantics) |
-| privateStore   | "clients/{identifier}/clientState"                                             | ClientState       | [ICS 2](../../client/ics-007-tendermint-client) |
+| provableStore  | "clients/{identifier}/clientState"                                             | ClientState       | [ICS 2](../ics-002-client-semantics) |
 | provableStore  | "clients/{identifier}/consensusStates/{height}"                                | ConsensusState    | [ICS 7](../../client/ics-007-tendermint-client) |
 | privateStore   | "clients/{identifier}/connections                                              | []Identifier      | [ICS 3](../ics-003-connection-semantics) |
 | provableStore  | "connections/{identifier}"                                                     | ConnectionEnd     | [ICS 3](../ics-003-connection-semantics) |


### PR DESCRIPTION
Closes: #764

I wasn't sure where to define the `validateSelfClient()` function. ibc-go puts it in the ICS-2 client keeper, with the Tendermint implementation. However, `validateSelfClient()` is a function that should be provided by the host, and so belongs in ICS-24 in my opinion. Since ICS-24 doesn't have any per-consensus-protocol sections, I opted for writing the generic declaration of `validateSelfClient()` in a new "Client state validation" section, and provide the Tendermint implementation as an example. I'm open to better ideas on how to organize this.

I faced another challenge. In [ibc-go](https://github.com/cosmos/ibc-go/blob/85893eebee1002f7ef74514b49c0981215405ceb/modules/core/02-client/keeper/keeper.go#L270), `validateSelfClient()` takes an `sdk.Context` as parameter and compares the appropriate fields against the fields of the `ClientState` passed in as argument. The most elegant way I found to abstract this use of the `sdk.Context` is to require the hosts to implement 

```typescript
type getHostClientState = (height: Height) => ClientState
```
which asks the host to "represent itself as a `ClientState`". In the case of the sdk, this would be implemented by building the `ClientState` from the appropriate fields in the `sdk.Context`. My only concern with this abstraction is that it might confuse users, as the `ClientState` is a light client abstraction, not a host chain one. Hopefully, the example provided is enough to clear up any confusion. Again, I'm open to better ways of doing it!