### PR TITLE
ICS4: Fix Sequence Paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 # Changelog
 
 ## [Unreleased]
+
+### Bug Fixes
+
+- [\#808](https://github.com/cosmos/ibc/pull/808) Fix channel sequence paths in ICS4

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -200,15 +200,15 @@ The `nextSequenceSend`, `nextSequenceRecv`, and `nextSequenceAck` unsigned integ
 
 ```typescript
 function nextSequenceSendPath(portIdentifier: Identifier, channelIdentifier: Identifier): Path {
-    return "seqSends/ports/{portIdentifier}/channels/{channelIdentifier}/nextSequenceSend"
+    return "nextSequenceSend/ports/{portIdentifier}/channels/{channelIdentifier}"
 }
 
 function nextSequenceRecvPath(portIdentifier: Identifier, channelIdentifier: Identifier): Path {
-    return "seqRecvs/ports/{portIdentifier}/channels/{channelIdentifier}/nextSequenceRecv"
+    return "nextSequenceRecv/ports/{portIdentifier}/channels/{channelIdentifier}"
 }
 
 function nextSequenceAckPath(portIdentifier: Identifier, channelIdentifier: Identifier): Path {
-    return "seqAcks/ports/{portIdentifier}/channels/{channelIdentifier}/nextSequenceAck"
+    return "nextSequenceAck/ports/{portIdentifier}/channels/{channelIdentifier}"
 }
 ```
 


### PR DESCRIPTION
Fix sequence paths in ICS4 to align with ICS24 and implementation