### PR TITLE
META: add CCQ to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ All standards at or past the "Draft" stage are listed here in order of their ICS
 | [28](spec/app/ics-028-cross-chain-validation/README.md)  | Cross-Chain Validation  | Draft | |
 | [29](spec/app/ics-029-fee-payment) | General Relayer Incentivisation Mechanism | Candidate | [ibc-go](https://github.com/cosmos/ibc-go/tree/main/modules/apps/29-fee) |
 | [30](spec/app/ics-030-middleware) | IBC Application Middleware | N/A | N/A |
+| [31](spec/app/ics-031-crosschain-queries) | Cross-Chain Queries | Draft | N/A |
 | [721](spec/app/ics-721-nft-transfer) | Non-Fungible Token Transfer | Candidate | [bianjieai](https://github.com/bianjieai/ibc-go/tree/ics-721-nft-transfer) |


### PR DESCRIPTION
Adds a link in README to the cross-chain queries spec