### PR TITLE
extend 03-connection with a proof object for chains that can't introspect their own consensus state.

### DIFF
--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -360,14 +360,15 @@ function connOpenTry(
   proofClient: CommitmentProof,
   proofConsensus: CommitmentProof,
   proofHeight: Height,
-  proofHostConsensusState: CommitmentProof,
-  consensusHeight: Height) {
+  consensusHeight: Height,
+  hostConsensusStateProof?: bytes,
+) {
     // generate a new identifier
     identifier = generateIdentifier()
     
     abortTransactionUnless(validateSelfClient(clientState))
     abortTransactionUnless(consensusHeight < getCurrentHeight())
-    expectedConsensusState = getConsensusState(consensusHeight, proofHostConsensusState)
+    expectedConsensusState = getConsensusState(consensusHeight, hostConsensusStateProof)
     expectedConnectionEnd = ConnectionEnd{INIT, "", getCommitmentPrefix(), counterpartyClientIdentifier,
                              clientIdentifier, counterpartyVersions, delayPeriodTime, delayPeriodBlocks}
 
@@ -397,14 +398,15 @@ function connOpenAck(
   proofTry: CommitmentProof,
   proofClient: CommitmentProof,
   proofConsensus: CommitmentProof,
-  proofHostConsensusState: CommitmentProof,
   proofHeight: Height,
-  consensusHeight: Height) {
+  consensusHeight: Height,
+  hostConsensusStateProof?: bytes,
+) {
     abortTransactionUnless(consensusHeight < getCurrentHeight())
     abortTransactionUnless(validateSelfClient(clientState))
     connection = provableStore.get(connectionPath(identifier))
     abortTransactionUnless((connection.state === INIT && connection.version.indexOf(version) !== -1)
-    expectedConsensusState = getConsensusState(consensusHeight, proofHostConsensusState)
+    expectedConsensusState = getConsensusState(consensusHeight, hostConsensusStateProof)
     expectedConnectionEnd = ConnectionEnd{TRYOPEN, identifier, getCommitmentPrefix(),
                              connection.counterpartyClientIdentifier, connection.clientIdentifier,
                              version, connection.delayPeriodTime, connection.delayPeriodBlocks}

--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -360,13 +360,14 @@ function connOpenTry(
   proofClient: CommitmentProof,
   proofConsensus: CommitmentProof,
   proofHeight: Height,
+  proofHostConsensusState: CommitmentProof,
   consensusHeight: Height) {
     // generate a new identifier
     identifier = generateIdentifier()
     
     abortTransactionUnless(validateSelfClient(clientState))
     abortTransactionUnless(consensusHeight < getCurrentHeight())
-    expectedConsensusState = getConsensusState(consensusHeight)
+    expectedConsensusState = getConsensusState(consensusHeight, proofHostConsensusState)
     expectedConnectionEnd = ConnectionEnd{INIT, "", getCommitmentPrefix(), counterpartyClientIdentifier,
                              clientIdentifier, counterpartyVersions, delayPeriodTime, delayPeriodBlocks}
 
@@ -396,13 +397,14 @@ function connOpenAck(
   proofTry: CommitmentProof,
   proofClient: CommitmentProof,
   proofConsensus: CommitmentProof,
+  proofHostConsensusState: CommitmentProof,
   proofHeight: Height,
   consensusHeight: Height) {
     abortTransactionUnless(consensusHeight < getCurrentHeight())
     abortTransactionUnless(validateSelfClient(clientState))
     connection = provableStore.get(connectionPath(identifier))
     abortTransactionUnless((connection.state === INIT && connection.version.indexOf(version) !== -1)
-    expectedConsensusState = getConsensusState(consensusHeight)
+    expectedConsensusState = getConsensusState(consensusHeight, proofHostConsensusState)
     expectedConnectionEnd = ConnectionEnd{TRYOPEN, identifier, getCommitmentPrefix(),
                              connection.counterpartyClientIdentifier, connection.clientIdentifier,
                              version, connection.delayPeriodTime, connection.delayPeriodBlocks}

--- a/spec/core/ics-024-host-requirements/README.md
+++ b/spec/core/ics-024-host-requirements/README.md
@@ -170,12 +170,12 @@ Host state machines MUST define a unique `ConsensusState` type fulfilling the re
 Host state machines MUST provide the ability to introspect their own consensus state, with `getConsensusState`:
 
 ```typescript
-type getConsensusState = (height: Height, proof?: []byte) => ConsensusState
+type getConsensusState = (height: Height, proof?: bytes) => ConsensusState
 ```
 
 `getConsensusState` MUST return the consensus state for at least some number `n` of contiguous recent heights, where `n` is constant for the host state machine. Heights older than `n` MAY be safely pruned (causing future calls to fail for those heights).
 
-We provide an optional proof object which comes from the `MsgConnectionOpenAck` or `MsgConnectionOpenTry` for host state machines which are unable to introspect their own `ConsensusState` and must rely on off-chain data.
+We provide an optional proof data which comes from the `MsgConnectionOpenAck` or `MsgConnectionOpenTry` for host state machines which are unable to introspect their own `ConsensusState` and must rely on off-chain data.
 <br />
 In this case host state machines MUST maintain a map of `n` block numbers to header hashes where the proof would contain full header which can be hashed and compared with the on-chain record.
 

--- a/spec/core/ics-024-host-requirements/README.md
+++ b/spec/core/ics-024-host-requirements/README.md
@@ -8,7 +8,7 @@ requires: 23
 required-by: 2, 3, 4, 5, 18
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-04-16
-modified: 2022-07-05
+modified: 2022-09-14
 ---
 
 ## Synopsis
@@ -170,10 +170,14 @@ Host state machines MUST define a unique `ConsensusState` type fulfilling the re
 Host state machines MUST provide the ability to introspect their own consensus state, with `getConsensusState`:
 
 ```typescript
-type getConsensusState = (height: Height) => ConsensusState
+type getConsensusState = (height: Height, proof?: []byte) => ConsensusState
 ```
 
 `getConsensusState` MUST return the consensus state for at least some number `n` of contiguous recent heights, where `n` is constant for the host state machine. Heights older than `n` MAY be safely pruned (causing future calls to fail for those heights).
+
+We provide an optional proof object which comes from the `MsgConnectionOpenAck` or `MsgConnectionOpenTry` for host state machines which are unable to introspect their own `ConsensusState` and must rely on off-chain data.
+<br />
+In this case host state machines MUST maintain a map of `n` block numbers to header hashes where the proof would contain full header which can be hashed and compared with the on-chain record.
 
 Host state machines MUST provide the ability to introspect this stored recent consensus state count `n`, with `getStoredRecentConsensusStateCount`:
 


### PR DESCRIPTION
Hey guys, Protocol Lead for composable here. We've been working on extending ibc beyond cosmos and we've been working with the core ibc team on making this happen. Through this relationship we requested the 02-client refactor and now finally we're requesting this 03-connection extension.

## The Problem

03-connection as is requires that host state machines can introspect their own consensus state. Unfortunately this requirement is incompatible with every single blockchain we're working with (substrate, NEAR, ethereum). All of whom do not provide this sort of api to query past headers from within the blockchain runtime.

## The solution

Inorder to keep to the IBC 03-connection specification and not skip the counterparty consensus state verification. We replace the requirement of host `ConsensusState` introspection, with a requirement of an on-chain map of block numbers to header hashes which can then be used to verify the `proofHostConsensusState` (aka full header)