### PR TITLE
fix: update allowed range for trust level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 - [\#808](https://github.com/cosmos/ibc/pull/808) Fix channel sequence paths in ICS4
+- [\#863](https://github.com/cosmos/ibc/pull/863) Fix allowed range for `trustLevel`
 
 ### Improvements
 

--- a/spec/client/ics-007-tendermint-client/README.md
+++ b/spec/client/ics-007-tendermint-client/README.md
@@ -174,7 +174,7 @@ function initialise(
   upgradePath: []string, maxClockDrift: uint64, proofSpecs: []ProofSpec): ClientState {
     assert(trustingPeriod < unbondingPeriod)
     assert(height > 0)
-    assert(trustLevel > 0 && trustLevel < 1)
+    assert(trustLevel >= 1/3 && trustLevel <= 1)
     // implementations may define a identifier generation function
     identifier = generateClientIdentifier()
     set("clients/{identifier}/consensusStates/{height}", consensusState)


### PR DESCRIPTION
closes: #857 