### PR TITLE
Remove deprecated comment from ICS4 and ICS26 READMEs

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -334,7 +334,7 @@ function chanOpenTry(
   counterpartyChosenChannelIdentifer: Identifier,
   counterpartyPortIdentifier: Identifier,
   counterpartyChannelIdentifier: Identifier,
-  version: string, // deprecated
+  version: string,
   counterpartyVersion: string,
   proofInit: CommitmentProof,
   proofHeight: Height): CapabilityKey {

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -455,7 +455,7 @@ interface ChanOpenTry {
   channelIdentifier: Identifier
   counterpartyPortIdentifier: Identifier
   counterpartyChannelIdentifier: Identifier
-  version: string // deprecated
+  version: string
   counterpartyVersion: string
   proofInit: CommitmentProof
   proofHeight: Height


### PR DESCRIPTION
Fixes #859 