### PR TITLE
ICS27: make `icacontroller-` prefix optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,4 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [\#842](https://github.com/cosmos/ibc/pull/842) Adds metadata field to FungibleTokenPacketData
 - [\#844](https://github.com/cosmos/ibc/pull/844) Adds event emission in `recvPacket` when `packet.sequence < nextSequenceRecv` for ordered channels and when `packetRecepit != null` for unordered channels
 - [\#845](https://github.com/cosmos/ibc/pull/845) Adds explanation about `onRecvPacket` callback returning an error in interchain accounts controller modules
+- [\#886](https://github.com/cosmos/ibc/pull/886) Makes `icacontroller-` prefix optional in ICA controller port identifier

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -587,7 +587,7 @@ function onRecvPacket(packet Packet) {
 
 These are the default formats that the port identifiers on each side of an interchain accounts channel. The controller portID **must** include the owner address so that when a message is sent to the controller module, the sender of the message can be verified against the portID before sending the ICA packet. The controller chain is responsible for proper access control to ensure that the sender of the ICA message has successfully authenticated before the message reaches the controller module.
 
-Controller Port Identifier: optional prefix `icacontroller-` + mandatory `{owner-account-address}`. 
+Controller Port Identifier: optional prefix `icacontroller-` + mandatory `{owner-account-address}`
 
 Host Port Identifier: `icahost`
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -585,11 +585,13 @@ function onRecvPacket(packet Packet) {
 
 ### Identifier formats
 
-These are the default formats that the port identifiers on each side of an interchain accounts channel. THe controller portID **must** include the owner address so that when a message is sent to the controller module, the sender of the message can be verified against the portID before sending the ICA packet. The controller chain is responsible for proper access control to ensure that the sender of the ICA message has successfully authenticated before the message reaches the controller module.
+These are the default formats that the port identifiers on each side of an interchain accounts channel. The controller portID **must** include the owner address so that when a message is sent to the controller module, the sender of the message can be verified against the portID before sending the ICA packet. The controller chain is responsible for proper access control to ensure that the sender of the ICA message has successfully authenticated before the message reaches the controller module.
 
-Controller Port Identifier: `icacontroller-{owner-account-address}`
+Controller Port Identifier: optional prefix `icacontroller-` + mandatory `{owner-account-address}`. 
 
 Host Port Identifier: `icahost`
+
+The `icacontroller-` prefix on the controller port identifier is optional and host chains **must** not enforce that the counterparty port identifier includes it. Controller chains may decide to include it and validate that it is present in their own port identifier.
 
 ## Example Implementation
 


### PR DESCRIPTION
Makes `icacontroller-` optional in controller port identifier.

Closes: #870 