### PR TITLE
ICS3: fix inconsistencies in the spec and code of connection handshake

### DIFF
--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -125,7 +125,6 @@ function clientConnectionsPath(clientIdentifier: Identifier): Path {
 function addConnectionToClient(
   clientIdentifier: Identifier,
   connectionIdentifier: Identifier) {
-    abortTransactionUnless(queryClientState(clientIdentifier) !== null)
     conns = privateStore.get(clientConnectionsPath(clientIdentifier))
     conns.add(connectionIdentifier)
     privateStore.set(clientConnectionsPath(clientIdentifier), conns)
@@ -344,8 +343,12 @@ function connOpenInit(
   version: string,
   delayPeriodTime: uint64,
   delayPeriodBlocks: uint64) {
+    // generate a new identifier
     identifier = generateIdentifier()
+
+    abortTransactionUnless(queryClientState(clientIdentifier) !== null)
     abortTransactionUnless(provableStore.get(connectionPath(identifier)) == null)
+    
     state = INIT
     if version != "" {
       // manually selected version must be one we can support
@@ -383,6 +386,7 @@ function connOpenTry(
     // generate a new identifier
     identifier = generateIdentifier()
     
+    abortTransactionUnless(queryClientState(clientIdentifier) !== null)
     abortTransactionUnless(validateSelfClient(clientState))
     abortTransactionUnless(consensusHeight < getCurrentHeight())
     expectedConsensusState = getConsensusState(consensusHeight, hostConsensusStateProof)

--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -360,7 +360,7 @@ function connOpenInit(
     connection = ConnectionEnd{state, "", counterpartyPrefix,
       clientIdentifier, counterpartyClientIdentifier, versions, delayPeriodTime, delayPeriodBlocks}
     provableStore.set(connectionPath(identifier), connection)
-    addConnectionToClient(clientIdentifier, identifier) // aborts transaction if no client state is found
+    addConnectionToClient(clientIdentifier, identifier)
 }
 ```
 
@@ -405,7 +405,7 @@ function connOpenTry(
       proofHeight, proofConsensus, counterpartyClientIdentifier, consensusHeight, expectedConsensusState))
 
     provableStore.set(connectionPath(identifier), connection)
-    addConnectionToClient(clientIdentifier, identifier) // aborts transaction if no client state is found
+    addConnectionToClient(clientIdentifier, identifier)
 }
 ```
 


### PR DESCRIPTION
This PR addresses the comments of #530 that were still relevant. I will copy those here:

- In connOpenInit() and connOpenTry(), there is no error handling in the [spec](https://github.com/cosmos/ics/tree/master/spec/ics-003-connection-semantics#opening-handshake) when calling addConnectionToClient(). In the [code](https://github.com/cosmos/cosmos-sdk/blob/fe8a891f11dcefe708e43d53549beec808f98687/x/ibc/core/03-connection/keeper/keeper.go#L158), the transaction is aborted if the client does not exist.

- In the code of connOpenTry(), but not in the spec: 
  - getting a consensus state from a given height [aborts on error](https://github.com/cosmos/cosmos-sdk/blob/fe8a891f11dcefe708e43d53549beec808f98687/x/ibc/core/03-connection/keeper/handshake.go#L93).

- In the code of connOpenAck(), but not in the spec: 
  - there is [error handling](https://github.com/cosmos/cosmos-sdk/blob/fe8a891f11dcefe708e43d53549beec808f98687/x/ibc/core/03-connection/keeper/handshake.go#L133) when getting the connection end by ID from the provable store.
  - getting a consensus state from a given height [aborts on error](https://github.com/cosmos/cosmos-sdk/blob/fe8a891f11dcefe708e43d53549beec808f98687/x/ibc/core/03-connection/keeper/handshake.go#L133).

- In the code of ConnOpenConfirm(), but not in the spec: there is [error handling](https://github.com/cosmos/cosmos-sdk/blob/fe8a891f11dcefe708e43d53549beec808f98687/x/ibc/core/03-connection/keeper/handshake.go#L133) when getting the connection end by ID from the provable store.

Besides that I also fixed some inconsistencies in the usage of the `versions` field in the connection end.

Closes: #530 
Closes: #894 