### PR TITLE
ICS721: Add classData and memo fields to PacketData

### DIFF
--- a/spec/app/ics-721-nft-transfer/README.md
+++ b/spec/app/ics-721-nft-transfer/README.md
@@ -67,8 +67,8 @@ Both `tokenData` entries and `classData` MUST be Base64 encoded strings which SH
 
 ```json
 {
-  "key1" : { "value":"...", "mime":"..."},
-  "key2" : { "value":"...", "mime":"..."},
+  "key1" : { "value":"...", "mime":"..." },
+  "key2" : { "value":"...", "mime":"..." },
   ...
 }
 ```
@@ -82,7 +82,7 @@ An example of `classData` content (raw JSON before being Base64 encoded) is show
 ```json
 {
   "opensea:name" : { "value":"Crypto Creatures" },
-  "opensea:image" : { "value":"...(Base64 encoded media binary)", "mime":"image/png"},
+  "opensea:image" : { "value":"...(Base64 encoded media binary)", "mime":"image/png" },
   "opensea:seller_fee_basis_points" : { "value":"100" }
 }
 ```

--- a/spec/app/ics-721-nft-transfer/README.md
+++ b/spec/app/ics-721-nft-transfer/README.md
@@ -7,14 +7,14 @@ requires: 25, 26
 kind: instantiation
 author: Haifeng Xi <haifeng@bianjie.ai>
 created: 2021-11-10
-modified: 2022-11-08
+modified: 2022-12-14
 ---
 
 > This standard document follows the same design principles of [ICS 20](../ics-020-fungible-token-transfer) and inherits most of its content therefrom, while replacing `bank` module based asset tracking logic with that of the `nft` module.
 
 ## Synopsis
 
-This standard document specifies packet data structure, state machine handling logic, and encoding details for the transfer of non-fungible tokens over an IBC channel between two modules on separate chains. The state machine logic presented allows for safe multi-chain `classId` handling with permissionless channel opening. This logic constitutes a _non-fungible token transfer bridge module_, interfacing between the IBC routing module and an existing asset tracking module on the host state machine, which could be either a Cosmos-style native module or a smart contract running in a virtual machine.
+This standard document specifies packet data structure, state machine handling logic, and encoding details for the transfer of non-fungible tokens over an IBC channel between two modules on separate chains. In this document, `class`, `collection` and `contract` are used interchangeably. The state machine logic presented allows for safe multi-chain `classId` handling with permissionless channel opening. This logic constitutes a _non-fungible token transfer bridge module_, interfacing between the IBC routing module and an existing asset tracking module on the host state machine, which could be either a Cosmos-style native module or a smart contract running in a virtual machine.
 
 ### Motivation
 
@@ -35,29 +35,35 @@ The IBC handler interface & IBC routing module interface are as defined in [ICS 
 
 ### Data Structures
 
-Only one packet data type is required: `NonFungibleTokenPacketData`, which specifies the class id, class uri, token id's, token uri's, sender address, and receiver address.
+Only one packet data type is required: `NonFungibleTokenPacketData`, which specifies the class id, class uri, class data, token id array, token uri array, token data array, sending address, and receiving address.
 
 ```typescript
 interface NonFungibleTokenPacketData {
   classId: string
   classUri: string
+  classData: byte[]
   tokenIds: string[]
   tokenUris: string[]
   tokenData: byte[][]
   sender: string
   receiver: string
+  memo: string
 }
 ```
 
 `classId` uniquely identifies the class/collection which the tokens being transferred belong to in the sending chain. In the case of an ERC-1155 compliant smart contract, for example, this could be a string representation of the top 128 bits of the token ID.
 
-`classUri` is optional, but will be extremely beneficial for cross-chain interoperability with NFT marketplaces like OpenSea, where [class/collection metadata](https://docs.opensea.io/docs/contract-level-metadata) can be added for better user experience.
+`classUri` is an optional field which, if present, contains off-chain [class metadata](https://docs.opensea.io/docs/contract-level-metadata) that could be extremely beneficial for cross-chain interoperability with NFT marketplaces like OpenSea.
+
+`classData`is an optional field which, if present, contains opaque on-chain class metadata such as royalty related parameters.
 
 `tokenIds` uniquely identifies some tokens of the given class that are being transferred. In the case of an ERC-1155 compliant smart contract, for example, a `tokenId` could be a string representation of the bottom 128 bits of the token ID.
 
-Each `tokenId` has a corresponding entry in `tokenUris` which, if present, refers to an off-chain resource that is typically an immutable JSON file containing the token's metadata.
+Each `tokenId` has a corresponding entry in `tokenUris` which, if not empty, refers to an off-chain resource that is typically an immutable JSON file containing the token's metadata.
 
-Each `tokenId` has another corresponding entry in `tokenData` which, if present, contains some opaque application data associated with the token (e.g., royalty parameters).
+Each `tokenId` has another corresponding entry in `tokenData` which, if not null, contains opaque on-chain application data associated with the token.
+
+The `memo` field is not used within the token transfer, however, it may be used either for external off-chain users (i.e. exchanges) or for middleware wrapping transfer that can parse and execute custom logic on the basis of the passed in memo. If the memo is intended to be parsed and interpreted by higher-level middleware, then these middlewares are advised to namespace their additions to the memo string so that they do not overwrite each other. Chains should ensure that there is some length limit on the entire packet data to ensure that the packet does not become a DOS vector. However, these do not need to be protocol-defined limits. If the receiver cannot accept a packet because of length limitations, this will lead to a timeout on the sender side.
 
 As tokens are sent across chains using the ICS-721 protocol, they begin to accrue a record of channels across which they have been transferred. This record information is encoded into the `classId` field.
 
@@ -110,40 +116,30 @@ The sub-protocols described herein should be implemented in a "non-fungible toke
 The NFT asset tracking module should implement the following functions:
 
 ```typescript
-function SaveClass(classId: string, classUri: string) {
+function SaveClass(classId: string, classUri: string, classData: string) {
   // creates a new NFT Class identified by classId
+  // if classId already exists, app logic may choose to update class metadata accordingly
 }
 ```
 
 ```typescript
-function Mint(
-  classId: string,
-  tokenId: string,
-  tokenUri: string,
-  tokenData: byte[],
-  receiver: string
-) {
+function Mint(classId: string, tokenId: string, tokenUri: string, tokenData: byte[], receiver: string) {
   // creates a new NFT identified by <classId,tokenId>
   // receiver becomes owner of the newly minted NFT
 }
 ```
 
 ```typescript
-function Transfer(classId: string, tokenId: string, receiver: string) {
+function Transfer(classId: string, tokenId: string, receiver: string, tokenData: byte[]) {
   // transfers the NFT identified by <classId,tokenId> to receiver
   // receiver becomes new owner of the NFT
+  // if tokenData is not null, app logic may choose to update token data accordingly
 }
 ```
 
 ```typescript
 function Burn(classId: string, tokenId: string) {
   // destroys the NFT identified by <classId,tokenId>
-}
-```
-
-```typescript
-function Update(token: nft.NFT) {
-  // updates the NFT identified by <token.classId,token.tokenId>
 }
 ```
 
@@ -318,7 +314,7 @@ function createOutgoingPacket(
     // ensure that sender is token owner
     abortTransactionUnless(sender === nft.GetOwner(classId, tokenId))
     if source { // we are source chain, escrow token
-      nft.Transfer(classId, tokenId, channelEscrowAddresses[sourceChannel])
+      nft.Transfer(classId, tokenId, channelEscrowAddresses[sourceChannel], null)
     } else { // we are sink chain, burn voucher
       nft.Burn(classId, tokenId)
     }
@@ -351,18 +347,10 @@ function ProcessReceivedPacketData(data: NonFungibleTokenPacketData) {
   source = data.classId.slice(0, len(prefix)) === prefix
   for (var i in data.tokenIds) {
     if source { // we are source chain, un-escrow token to receiver
-      if (data.tokenData[i] !== nil) { // update token data
-        token = nft.GetNFT(data.classId.slice(len(prefix)), data.tokenIds[i])
-        token.SetData(data.tokenData[i])
-        nft.Update(token)
-      }
-      nft.Transfer(data.classId.slice(len(prefix)), data.tokenIds[i], data.receiver)
+      nft.Transfer(data.classId.slice(len(prefix)), data.tokenIds[i], data.receiver, data.tokenData[i])
     } else { // we are sink chain, mint voucher to receiver
       prefixedClassId = data.destPort + '/' + data.destChannel + '/' + data.classId
-      // create NFT class if it doesn't exist already
-      if (nft.HasClass(prefixedClassId) === false) {
-        nft.SaveClass(data.classId, data.classUri)
-      }
+      nft.SaveClass(prefixedClassId, data.classUri, data.classData)
       nft.Mint(prefixedClassId, data.tokenIds[i], data.tokenUris[i], data.tokenData[i], data.receiver)
     }
   }
@@ -397,7 +385,7 @@ function refundToken(packet: Packet) {
   source = data.classId.slice(0, len(prefix)) !== prefix
   for (var i in data.tokenIds) {
     if source { // we are source chain, un-escrow token back to sender
-      nft.Transfer(data.classId, data.tokenIds[i], data.sender)
+      nft.Transfer(data.classId, data.tokenIds[i], data.sender, null)
     } else { // we are sink chain, mint voucher back to sender
       nft.Mint(data.classId, data.tokenIds[i], data.tokenUris[i], data.tokenData[i], data.sender)
     }
@@ -463,6 +451,7 @@ Coming soon.
 | Mar 30, 2022 | Added NFT module definition and fixed pseudo-code errors |
 | May 18, 2022 | Added paragraph about NFT metadata mutability            |
 | Nov 08, 2022 | Added `tokenData` to PacketData                          |
+| Dec 14, 2022 | Added `classData` and `memo` to PacketData               |
 
 ## Copyright
 

--- a/spec/app/ics-721-nft-transfer/README.md
+++ b/spec/app/ics-721-nft-transfer/README.md
@@ -57,7 +57,7 @@ interface NonFungibleTokenPacketData {
 
 `classData` is an optional field which, if present, MUST be non-empty and contain on-chain class metadata such as royalty related parameters.
 
-`tokenIds` array is an optional field which, if present, MUST have a size greater than zero and hold non-empty entries that uniquely identify tokens (of the given class) that are being transferred. In the case of an ERC-1155 compliant smart contract, for example, a `tokenId` could be a string representation of the bottom 128 bits of the token ID.
+`tokenIds` array is a required field that MUST have a size greater than zero and hold non-empty entries that uniquely identify tokens (of the given class) that are being transferred. In the case of an ERC-1155 compliant smart contract, for example, a `tokenId` could be a string representation of the bottom 128 bits of the token ID.
 
 `tokenUris` array is an optional field which, if present, MUST have the same size as `tokenIds` and hold non-empty entries each of which refers to an off-chain resource that is typically an immutable JSON file containing metadata associated with the token identified by the corresponding `tokenIds` entry.
 

--- a/spec/app/ics-721-nft-transfer/README.md
+++ b/spec/app/ics-721-nft-transfer/README.md
@@ -51,19 +51,19 @@ interface NonFungibleTokenPacketData {
 }
 ```
 
-`classId` is a required field that SHOULD never be empty, it uniquely identifies the class/collection/contract which the tokens being transferred belong to in the sending chain. In the case of an ERC-1155 compliant smart contract, for example, this could be a string representation of the top 128 bits of the token ID.
+`classId` is a required field that MUST never be empty, it uniquely identifies the class/collection/contract which the tokens being transferred belong to in the sending chain. In the case of an ERC-1155 compliant smart contract, for example, this could be a string representation of the top 128 bits of the token ID.
 
-`classUri` is an optional field which, if present and not empty, contains off-chain [class metadata](https://docs.opensea.io/docs/contract-level-metadata) that could be extremely beneficial for cross-chain interoperability with NFT marketplaces like OpenSea.
+`classUri` is an optional field which, if present, MUST be non-empty and refer to an off-chain resource that is typically a JSON file containing the [class metadata](https://docs.opensea.io/docs/contract-level-metadata); this could be extremely beneficial for cross-chain interoperability with NFT marketplaces like OpenSea.
 
-`classData`is an optional field which, if present and not empty, contains on-chain class metadata such as royalty related parameters.
+`classData` is an optional field which, if present, MUST be non-empty and contain on-chain class metadata such as royalty related parameters.
 
-`tokenIds` array is an optional field which, if present, SHOULD have a size greater than zero and contain non-empty entries that uniquely identify tokens (of the given class) that are being transferred. In the case of an ERC-1155 compliant smart contract, for example, a `tokenId` could be a string representation of the bottom 128 bits of the token ID.
+`tokenIds` array is an optional field which, if present, MUST have a size greater than zero and hold non-empty entries that uniquely identify tokens (of the given class) that are being transferred. In the case of an ERC-1155 compliant smart contract, for example, a `tokenId` could be a string representation of the bottom 128 bits of the token ID.
 
-`tokenUris` array is an optional field which, if present, SHOULD have the same size as `tokenIds`. Each `tokenUris` entry, if not empty, refers to an off-chain resource that is typically an immutable JSON file containing metadata associated with the token identified by the corresponding `tokenIds` entry.
+`tokenUris` array is an optional field which, if present, MUST have the same size as `tokenIds` and hold non-empty entries each of which refers to an off-chain resource that is typically an immutable JSON file containing metadata associated with the token identified by the corresponding `tokenIds` entry.
 
-`tokenData` array is an optional field which, if present, SHOULD have the same size as `tokenIds`. Each `tokenData` entry, if not empty, contains on-chain application data associated with the token identified by the corresponding `tokenIds` entry.
+`tokenData` array is an optional field which, if present, MUST have the same size as `tokenIds` and hold non-empty entries each of which contains on-chain application data associated with the token identified by the corresponding `tokenIds` entry.
 
-Both `tokenData` entries and `classData` SHOULD be Base64 encoded JSON strings that have the following structure:
+Both `tokenData` entries and `classData` MUST be Base64 encoded strings which SHOULD have the following JSON structure:
 
 ```json
 {

--- a/spec/app/ics-721-nft-transfer/README.md
+++ b/spec/app/ics-721-nft-transfer/README.md
@@ -116,7 +116,7 @@ The sub-protocols described herein should be implemented in a "non-fungible toke
 The NFT asset tracking module should implement the following functions:
 
 ```typescript
-function SaveClass(classId: string, classUri: string, classData: string) {
+function CreateOrUpdateClass(classId: string, classUri: string, classData: byte[]) {
   // creates a new NFT Class identified by classId
   // if classId already exists, app logic may choose to update class metadata accordingly
 }
@@ -350,7 +350,7 @@ function ProcessReceivedPacketData(data: NonFungibleTokenPacketData) {
       nft.Transfer(data.classId.slice(len(prefix)), data.tokenIds[i], data.receiver, data.tokenData[i])
     } else { // we are sink chain, mint voucher to receiver
       prefixedClassId = data.destPort + '/' + data.destChannel + '/' + data.classId
-      nft.SaveClass(prefixedClassId, data.classUri, data.classData)
+      nft.CreateOrUpdateClass(prefixedClassId, data.classUri, data.classData)
       nft.Mint(prefixedClassId, data.tokenIds[i], data.tokenUris[i], data.tokenData[i], data.receiver)
     }
   }


### PR DESCRIPTION
Putting class/collection/contract level metadata into its own field `classData` instead of squeezing everything into `tokenData` is a better design that is called for by Stargaze/Ark/Juno teams who are relying on WASM contracts to implement and support ICS721.

As for the `memo` field, we are borrowing it from ICS20, there have been thorough discussions about why this field is introduced and how it's supposed to be used (please see #584 #842 #877).