### PR TITLE
update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 
 /spec/apps @adityasripal @cwgoes @colin-axner @angbrav
 
-/spec/apps/ics-028-cross-chain-validation @mpoke
+/spec/apps/ics-028-cross-chain-validation @mpoke @adityasripal @cwgoes @angbrav

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,13 @@
 # 2/n quorum required for merge
 
 *       @mpoke @adityasripal @cwgoes @colin-axner @angbrav
+
+# CODEOWNERS for the CODEOWNER file
+
+/.github/CODEOWNERS @mpoke @adityasripal @cwgoes @colin-axner @angbrav
+
+# CODEOWNERS for the specs
+
+/spec/apps @adityasripal @cwgoes @colin-axner @angbrav
+
+/spec/apps/ics-028-cross-chain-validation @mpoke


### PR DESCRIPTION
As requested by @mpoke, this change should keep him as owner for core and clients, but owner only of ics28 for apps.