### PR TITLE
ICS31: small change in path to follow consistency

### DIFF
--- a/spec/app/ics-031-crosschain-queries/README.md
+++ b/spec/app/ics-031-crosschain-queries/README.md
@@ -164,7 +164,7 @@ The result query path is a private path that stores the result of completed quer
 
 ```typescript
 function queryResultPath(id: Identifier): Path {
-    return "queries/{id}/result"
+    return "result/queries/{id}"
 }
 ```
 


### PR DESCRIPTION
This is a tiny change to make the path more consistent with the format used in [ICS24](https://github.com/cosmos/ibc/blob/main/spec/core/ics-024-host-requirements/README.md#path-space).