### PR TITLE
fix usage of generic verify functions

### DIFF
--- a/spec/app/ics-031-crosschain-queries/README.md
+++ b/spec/app/ics-031-crosschain-queries/README.md
@@ -258,7 +258,7 @@ function CrossChainQueryResponse(
     abortTransactionUnless(query !== null)
 
     // Retrieve client state of the queried chain.
-    client = queryClientState(query.clientId)
+    clientState = queryClientState(query.clientId)
     abortTransactionUnless(client !== null)
 
     // Check that the relier executed the query at the requested height at the queried chain.
@@ -273,8 +273,8 @@ function CrossChainQueryResponse(
     // Verify query result using the local light client of the queried chain.
     // If the response carries data, then verify that the data is indeed the value associated with query.path at query.queryHeight at the queried chain.
     if (data !== null) {    
-        abortTransactionUnless(client.verifyMembership(
-            client,
+        abortTransactionUnless(verifyMembership(
+            clientState,
             proofHeight,
             delayPeriodTime,
             delayPeriodBlocks,
@@ -285,8 +285,8 @@ function CrossChainQueryResponse(
         result = SUCCESS
     // If there response does not carry any data, verify that query.path does not exist at query.queryHeight at the queried chain.
     } else {
-        abortTransactionUnless(client.verifyNonMembership(
-            client,
+        abortTransactionUnless(verifyNonMembership(
+            clientState,
             proofHeight,
             delayPeriodTime,
             delayPeriodBlocks,

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -253,6 +253,24 @@ A `ClientMessage` is an opaque data structure defined by a client type which pro
 type ClientMessage = bytes
 ```
 
+### Store paths
+
+Client state paths are stored under a unique client identifier.
+
+```typescript
+function clientStatePath(id: Identifier): Path {
+  return "clients/{id}/clientState"
+}
+```
+
+Consensus state paths are stored under a unique combination of client identifier and height:
+
+```typescript
+function consensusStatePath(id: Identifier, height: Height): Path {
+  return "clients/{id}/consensusStates/{height}"
+}
+```
+
 #### Validity predicate
 
 A validity predicate is an opaque function defined by a client type to verify `ClientMessage`s depending on the current `ConsensusState`.

--- a/spec/core/ics-003-connection-semantics/UPGRADES.md
+++ b/spec/core/ics-003-connection-semantics/UPGRADES.md
@@ -120,12 +120,12 @@ function verifyConnectionUpgradeError(
   proof: CommitmentProof,
   upgradeErrorReceipt: []byte, 
 ) {
-    client = queryClient(connection.clientIdentifier)
+    clientState = queryClientState(connection.clientIdentifier)
     // construct CommitmentPath
     path = applyPrefix(connection.counterpartyPrefix, connectionErrorPath(connection.counterpartyConnectionIdentifier))
     // verify upgradeErrorReceipt is stored under the constructed path
     // delay period is unnecessary for non-packet verification so pass in 0 for delay period fields
-    return client.verifyMembership(height, 0, 0, proof, path, upgradeErrorReceipt)
+    return verifyMembership(clientState, height, 0, 0, proof, path, upgradeErrorReceipt)
 }
 ```
 
@@ -136,12 +136,12 @@ function verifyConnectionUpgradeErrorAbsence(
   height: Height,
   proof: CommitmentProof,
 ) {
-    client = queryClient(connection.clientIdentifier)
+    clientState = queryClientState(connection.clientIdentifier)
     // construct CommitmentPath
     path = applyPrefix(connection.counterpartyPrefix, connectionErrorPath(connection.counterpartyConnectionIdentifier))
     // verify upgradeError path is empty
     // delay period is unnecessary for non-packet verification so pass in 0 for delay period fields
-    return client.verifyNonMembership(height, 0, 0, proof, path)
+    return verifyNonMembership(clientState, height, 0, 0, proof, path)
 }
 ```
 
@@ -165,12 +165,12 @@ function verifyConnectionUpgradeTimeout(
   proof: CommitmentProof,
   upgradeTimeout: UpgradeTimeout, 
 ) {
-    client = queryClient(connection.clientIdentifier)
+    clientState = queryClientState(connection.clientIdentifier)
     // construct CommitmentPath
     path = applyPrefix(connection.counterpartyPrefix, connectionTimeoutPath(connection.counterpartyConnectionIdentifier))
     // marshal upgradeTimeout into bytes with standardized protobuf codec
     timeoutBytes = protobuf.marshal(upgradeTimeout)
-    client.verifyMembership(height, 0, 0, proof, path, timeoutBytes)
+    return verifyMembership(clientState, height, 0, 0, proof, path, timeoutBytes)
 }
 ```
 

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -117,9 +117,9 @@ function verifyChannelUpgradeSequence(
   counterpartyChannelIdentifier: Identifier,
   sequence: uint64
 ) {
-    client = queryClient(connection.clientIdentifier)
+    clientState = queryClientState(connection.clientIdentifier)
     path = applyPrefix(connection.counterpartyPrefix, channelUpgradeSequencePath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
-    client.verifyMembership(height, 0, 0, proof, path, sequence)
+    return verifyMembership(clientState, height, 0, 0, proof, path, sequence)
 }
 ```
 
@@ -155,9 +155,9 @@ function verifyChannelUpgradeError(
   counterpartyChannelIdentifier: Identifier,
   upgradeErrorReceipt: ErrorReceipt
 ) {
-    client = queryClient(connection.clientIdentifier)
+    clientState = queryClientState(connection.clientIdentifier)
     path = applyPrefix(connection.counterpartyPrefix, channelUpgradeErrorPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
-    client.verifyMembership(height, 0, 0, proof, path, upgradeErrorReceipt)
+    return verifyMembership(clientState, height, 0, 0, proof, path, upgradeErrorReceipt)
 }
 ```
 
@@ -170,9 +170,9 @@ function verifyChannelUpgradeErrorAbsence(
   counterpartyPortIdentifier: Identifier,
   counterpartyChannelIdentifier: Identifier,
 ) {
-    client = queryClient(connection.clientIdentifier)
+    clientState = queryClientState(connection.clientIdentifier)
     path = applyPrefix(connection.counterpartyPrefix, channelUpgradeErrorPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
-    client.verifyNonMembership(height, 0, 0, proof, path)
+    return verifyNonMembership(clientState, height, 0, 0, proof, path)
 }
 ```
 
@@ -198,9 +198,9 @@ function verifyChannelUpgradeTimeout(
   counterpartyChannelIdentifier: Identifier,
   upgradeTimeout: UpgradeTimeout, 
 ) {
-    client = queryClient(connection.clientIdentifier)
+    clientState = queryClientState(connection.clientIdentifier)
     path = applyPrefix(connection.counterpartyPrefix, channelUpgradeTimeoutPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
-    client.verifyMembership(height, 0, 0, proof, path, upgradeTimeout)
+    return verifyMembership(clientState, height, 0, 0, proof, path, upgradeTimeout)
 }
 ```
 

--- a/spec/core/ics-025-handler-interface/README.md
+++ b/spec/core/ics-025-handler-interface/README.md
@@ -36,7 +36,7 @@ Associated definitions are as defined in referenced prior standards (where the f
 
 By default, clients are unowned: any module may create a new client, query any existing client, update any existing client, and delete any existing client not in use.
 
-The handler interface exposes `createClient`, `updateClient`, `queryClientConsensusState`, `queryClient`, and `submitMisbehaviourToClient` as defined in [ICS 2](../ics-002-client-semantics).
+The handler interface exposes `createClient`, `updateClient`, `queryConsensusState`, `queryClientState`, and `submitMisbehaviourToClient` as defined in [ICS 2](../ics-002-client-semantics).
 
 ### Connection lifecycle management
 

--- a/spec/relayer/ics-018-relayer-algorithms/README.md
+++ b/spec/relayer/ics-018-relayer-algorithms/README.md
@@ -112,14 +112,14 @@ function pendingDatagrams(chain: Chain, counterparty: Chain): List<Set<Datagram>
   // ICS2 : Clients
   // - Determine if light client needs to be updated (local & counterparty)
   height = chain.latestHeight()
-  clientState = counterparty.queryClientConsensusState(chain)
-  if clientState.height < height {
+  client = counterparty.queryClientConsensusState(chain)
+  if client.height < height {
     header = chain.latestHeader()
     counterpartyDatagrams.push(ClientUpdate{chain, header})
   }
   counterpartyHeight = counterparty.latestHeight()
-  clientState = chain.queryClientConsensusState(counterparty)
-  if clientState.height < counterpartyHeight {
+  client = chain.queryClientConsensusState(counterparty)
+  if client.height < counterpartyHeight {
     header = counterparty.latestHeader()
     localDatagrams.push(ClientUpdate{counterparty, header})
   }

--- a/spec/relayer/ics-018-relayer-algorithms/README.md
+++ b/spec/relayer/ics-018-relayer-algorithms/README.md
@@ -112,14 +112,14 @@ function pendingDatagrams(chain: Chain, counterparty: Chain): List<Set<Datagram>
   // ICS2 : Clients
   // - Determine if light client needs to be updated (local & counterparty)
   height = chain.latestHeight()
-  client = counterparty.queryClientConsensusState(chain)
-  if client.height < height {
+  clientState = counterparty.queryClientConsensusState(chain)
+  if clientState.height < height {
     header = chain.latestHeader()
     counterpartyDatagrams.push(ClientUpdate{chain, header})
   }
   counterpartyHeight = counterparty.latestHeight()
-  client = chain.queryClientConsensusState(counterparty)
-  if client.height < counterpartyHeight {
+  clientState = chain.queryClientConsensusState(counterparty)
+  if clientState.height < counterpartyHeight {
     header = counterparty.latestHeader()
     localDatagrams.push(ClientUpdate{counterparty, header})
   }


### PR DESCRIPTION
This PR:

- closes #888 
- fixes the inconsistencies in naming between `queryClient` and `queryClientState` in favour of the latter.
- fixes the inconsistencies of using the generic `verifyMembership` and `verifyNonMembership` functions declared in ICS 02 where the client state is passed as first argument.

closes: #888 