### PR TITLE
fix: consistent use of client state functions

### DIFF
--- a/spec/client/ics-007-tendermint-client/README.md
+++ b/spec/client/ics-007-tendermint-client/README.md
@@ -251,7 +251,7 @@ function verifyHeader(header: Header) {
 Function `checkForMisbehaviour` will check if an update contains evidence of Misbehaviour. If the ClientMessage is a header we check for implicit evidence of misbehaviour by checking if there already exists a conflicting consensus state in the store or if the header breaks time monotonicity.
 
 ```typescript
-function checkForMisbehaviour(clientMsg: clientMessage) => bool {
+function checkForMisbehaviour(clientMsg: clientMessage): bool {
   clientState = provableStore.get("clients/{clientMsg.identifier}/clientState")
   switch typeof(clientMsg) {
     case Header:


### PR DESCRIPTION
I noticed that solo machine functions using the client state assumed that they were part of a `ClientState` class, while the rest of the specs assumed that the client state was passed as an argument. This PR changes solo machine to be consistent with the rest