### PR TITLE
add version compatibility column

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -5,6 +5,7 @@ stage: draft
 category: IBC/APP
 requires: 25, 26
 kind: instantiation
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@interchain.berlin>
 created: 2019-07-15 
 modified: 2020-02-24

--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -5,7 +5,7 @@ stage: draft
 category: IBC/APP
 requires: 25, 26
 kind: instantiation
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@interchain.berlin>
 created: 2019-07-15 
 modified: 2020-02-24

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -5,7 +5,7 @@ stage: Draft
 category: IBC/APP
 requires: 25, 26
 kind: instantiation
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Tony Yun <tony@chainapsis.com>, Dogemos <josh@tendermint.com>, Sean King <sean@interchain.io>
 created: 2019-08-01
 modified: 2020-07-14

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -5,6 +5,7 @@ stage: Draft
 category: IBC/APP
 requires: 25, 26
 kind: instantiation
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Tony Yun <tony@chainapsis.com>, Dogemos <josh@tendermint.com>, Sean King <sean@interchain.io>
 created: 2019-08-01
 modified: 2020-07-14

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -5,7 +5,7 @@ stage: draft
 category: IBC/APP
 requires: 4, 25, 26, 30
 kind: instantiation
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Aditya Sripal <aditya@interchain.berlin>, Ethan Frey <ethan@confio.tech>
 created: 2021-06-01
 modified: 2022-07-06

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -5,6 +5,7 @@ stage: draft
 category: IBC/APP
 requires: 4, 25, 26, 30
 kind: instantiation
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Aditya Sripal <aditya@interchain.berlin>, Ethan Frey <ethan@confio.tech>
 created: 2021-06-01
 modified: 2022-07-06

--- a/spec/app/ics-030-middleware/README.md
+++ b/spec/app/ics-030-middleware/README.md
@@ -5,7 +5,7 @@ stage: draft
 category: IBC/APP
 requires: 4, 25, 26
 kind: instantiation
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Aditya Sripal <aditya@interchain.berlin>, Ethan Frey <ethan@confio.tech>
 created: 2021-06-01
 modified: 2022-07-06

--- a/spec/app/ics-030-middleware/README.md
+++ b/spec/app/ics-030-middleware/README.md
@@ -5,6 +5,7 @@ stage: draft
 category: IBC/APP
 requires: 4, 25, 26
 kind: instantiation
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Aditya Sripal <aditya@interchain.berlin>, Ethan Frey <ethan@confio.tech>
 created: 2021-06-01
 modified: 2022-07-06

--- a/spec/client/ics-006-solo-machine-client/README.md
+++ b/spec/client/ics-006-solo-machine-client/README.md
@@ -5,6 +5,7 @@ stage: draft
 category: IBC/TAO
 kind: instantiation
 implements: 2
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-12-09
 modified: 2019-12-09

--- a/spec/client/ics-006-solo-machine-client/README.md
+++ b/spec/client/ics-006-solo-machine-client/README.md
@@ -5,7 +5,7 @@ stage: draft
 category: IBC/TAO
 kind: instantiation
 implements: 2
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-12-09
 modified: 2019-12-09

--- a/spec/client/ics-007-tendermint-client/README.md
+++ b/spec/client/ics-007-tendermint-client/README.md
@@ -5,7 +5,7 @@ stage: draft
 category: IBC/TAO
 kind: instantiation
 implements: 2
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-12-10
 modified: 2019-12-19

--- a/spec/client/ics-007-tendermint-client/README.md
+++ b/spec/client/ics-007-tendermint-client/README.md
@@ -5,6 +5,7 @@ stage: draft
 category: IBC/TAO
 kind: instantiation
 implements: 2
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-12-10
 modified: 2019-12-19

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -6,7 +6,7 @@ category: IBC/TAO
 kind: interface
 requires: 23, 24
 required-by: 3
-version-compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version-compatibility: ibc-go v7.0.0
 author: Juwoon Yun <joon@tendermint.com>, Christopher Goes <cwgoes@tendermint.com>, Aditya Sripal <aditya@interchain.io>
 created: 2019-02-25
 modified: 2022-08-04

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -6,7 +6,7 @@ category: IBC/TAO
 kind: interface
 requires: 23, 24
 required-by: 3
-version-compatibility: ibc-go v7.0.0
+version compatibility: ibc-go v7.0.0
 author: Juwoon Yun <joon@tendermint.com>, Christopher Goes <cwgoes@tendermint.com>, Aditya Sripal <aditya@interchain.io>
 created: 2019-02-25
 modified: 2022-08-04

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -6,7 +6,7 @@ category: IBC/TAO
 kind: interface
 requires: 23, 24
 required-by: 3
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version-compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Juwoon Yun <joon@tendermint.com>, Christopher Goes <cwgoes@tendermint.com>, Aditya Sripal <aditya@interchain.io>
 created: 2019-02-25
 modified: 2022-08-04

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -6,6 +6,7 @@ category: IBC/TAO
 kind: interface
 requires: 23, 24
 required-by: 3
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Juwoon Yun <joon@tendermint.com>, Christopher Goes <cwgoes@tendermint.com>, Aditya Sripal <aditya@interchain.io>
 created: 2019-02-25
 modified: 2022-08-04

--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -6,7 +6,7 @@ category: IBC/TAO
 kind: instantiation
 requires: 2, 24
 required-by: 4, 25
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@tendermint.com>, Juwoon Yun <joon@tendermint.com>
 created: 2019-03-07
 modified: 2019-08-25

--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -6,6 +6,7 @@ category: IBC/TAO
 kind: instantiation
 requires: 2, 24
 required-by: 4, 25
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@tendermint.com>, Juwoon Yun <joon@tendermint.com>
 created: 2019-03-07
 modified: 2019-08-25

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -5,7 +5,7 @@ stage: draft
 category: IBC/TAO
 kind: instantiation
 requires: 2, 3, 5, 24
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-03-07
 modified: 2019-08-25

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -5,6 +5,7 @@ stage: draft
 category: IBC/TAO
 kind: instantiation
 requires: 2, 3, 5, 24
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-03-07
 modified: 2019-08-25

--- a/spec/core/ics-005-port-allocation/README.md
+++ b/spec/core/ics-005-port-allocation/README.md
@@ -6,6 +6,7 @@ requires: 24
 required-by: 4
 category: IBC/TAO
 kind: interface
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-06-20
 modified: 2019-08-25

--- a/spec/core/ics-005-port-allocation/README.md
+++ b/spec/core/ics-005-port-allocation/README.md
@@ -6,7 +6,7 @@ requires: 24
 required-by: 4
 category: IBC/TAO
 kind: interface
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-06-20
 modified: 2019-08-25

--- a/spec/core/ics-023-vector-commitments/README.md
+++ b/spec/core/ics-023-vector-commitments/README.md
@@ -5,7 +5,7 @@ stage: draft
 required-by: 2, 24
 category: IBC/TAO
 kind: interface
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-04-16
 modified: 2019-08-25

--- a/spec/core/ics-023-vector-commitments/README.md
+++ b/spec/core/ics-023-vector-commitments/README.md
@@ -5,6 +5,7 @@ stage: draft
 required-by: 2, 24
 category: IBC/TAO
 kind: interface
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-04-16
 modified: 2019-08-25

--- a/spec/core/ics-024-host-requirements/README.md
+++ b/spec/core/ics-024-host-requirements/README.md
@@ -6,6 +6,7 @@ category: IBC/TAO
 kind: interface
 requires: 23
 required-by: 2, 3, 4, 5, 18
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-04-16
 modified: 2022-09-14

--- a/spec/core/ics-024-host-requirements/README.md
+++ b/spec/core/ics-024-host-requirements/README.md
@@ -6,7 +6,7 @@ category: IBC/TAO
 kind: interface
 requires: 23
 required-by: 2, 3, 4, 5, 18
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-04-16
 modified: 2022-09-14

--- a/spec/core/ics-025-handler-interface/README.md
+++ b/spec/core/ics-025-handler-interface/README.md
@@ -5,7 +5,7 @@ stage: draft
 category: IBC/TAO
 kind: instantiation
 requires: 2, 3, 4, 23, 24
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-04-23
 modified: 2019-08-25

--- a/spec/core/ics-025-handler-interface/README.md
+++ b/spec/core/ics-025-handler-interface/README.md
@@ -5,6 +5,7 @@ stage: draft
 category: IBC/TAO
 kind: instantiation
 requires: 2, 3, 4, 23, 24
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-04-23
 modified: 2019-08-25

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -4,7 +4,7 @@ title: Routing Module
 stage: Draft
 category: IBC/TAO
 kind: instantiation
-version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
+version compatibility: ibc-go v7.0.0
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-06-09
 modified: 2019-08-25

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -4,6 +4,7 @@ title: Routing Module
 stage: Draft
 category: IBC/TAO
 kind: instantiation
+version compatibility: [ibc-go v7.0.0](https://github.com/cosmos/ibc-go/releases/tag/v7.0.0)
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-06-09
 modified: 2019-08-25

--- a/spec/ics-001-ics-standard/README.md
+++ b/spec/ics-001-ics-standard/README.md
@@ -71,7 +71,7 @@ See [README.md](../../README.md) for a description of the ICS acceptance stages.
 
 `replaced-by` - Another ICS standard which replaces or supplants this standard, if applicable.
 
-`version-compatibility` - List of versions of implementations compatible with the ICS standard.
+`version compatibility` - List of versions of implementations compatible with the ICS standard.
 
 ### Synopsis
 

--- a/spec/ics-001-ics-standard/README.md
+++ b/spec/ics-001-ics-standard/README.md
@@ -71,6 +71,8 @@ See [README.md](../../README.md) for a description of the ICS acceptance stages.
 
 `replaced-by` - Another ICS standard which replaces or supplants this standard, if applicable.
 
+`version-compatibility` - List of versions of implementations compatible with the ICS standard.
+
 ### Synopsis
 
 Following the header, an ICS should include a brief (~200 word) synopsis providing a high-level

--- a/spec/ics-template.md
+++ b/spec/ics-template.md
@@ -10,7 +10,7 @@ modified: (modification date)
 requires: (optional list of ics numbers)
 required-by: (optional list of ics numbers)
 implements: (optional list of ics numbers)
-version-compatibility: (optional list of compatible implementations' releases)
+version compatibility: (optional list of compatible implementations' releases)
 ---
 
 ## Synopsis

--- a/spec/ics-template.md
+++ b/spec/ics-template.md
@@ -10,7 +10,7 @@ modified: (modification date)
 requires: (optional list of ics numbers)
 required-by: (optional list of ics numbers)
 implements: (optional list of ics numbers)
-version compatibility: (optional list of implementations' releases)
+version-compatibility: (optional list of compatible implementations' releases)
 ---
 
 ## Synopsis

--- a/spec/ics-template.md
+++ b/spec/ics-template.md
@@ -10,6 +10,7 @@ modified: (modification date)
 requires: (optional list of ics numbers)
 required-by: (optional list of ics numbers)
 implements: (optional list of ics numbers)
+version compatibility: (optional list of implementations' releases)
 ---
 
 ## Synopsis


### PR DESCRIPTION
The PR adds a column to the table on the top of each spec for an optional list of implementations' versions that are compatible with the spec. 

This is [an example](https://github.com/cosmos/ibc/blob/carlos/add-version-compatibility-column/spec/core/ics-002-client-semantics/README.md) of how it looks. Unfortunately the table is too width and needs a scroll bar.