### PR TITLE
ICS 02: remove concept of client type

### DIFF
--- a/spec/client/ics-006-solo-machine-client/README.md
+++ b/spec/client/ics-006-solo-machine-client/README.md
@@ -131,12 +131,11 @@ interface Signature {
 The solo machine client `initialise` function starts an unfrozen client with the initial consensus state.
 
 ```typescript
-function initialise(identifier: Identifier, consensusState: ConsensusState): ClientState {
+function initialise(identifier: Identifier, clientState: ClientState, consensusState: ConsensusState) {
+  assert(clientState.consensusState === consensusState)
+
+  provableStore.set("clients/{identifier}/clientState", clientState)
   provableStore.set("clients/{identifier}/consensusStates/{height}", consensusState)
-  return ClientState{
-    frozen: false,
-    consensusState
-  }
 }
 ```
 
@@ -234,7 +233,7 @@ function updateState(clientMessage: ClientMessage) {
   clientState.consensusState.diversifier = header.newDiversifier
   clientState.consensusState.timestamp = header.timestamp
   clientState.consensusState.sequence++
-  provableStore.set("clients/{identifier}/clientState", clientState)
+  provableStore.set("clients/{clientMsg.identifier}/clientState", clientState)
 }
 ```
 
@@ -245,7 +244,7 @@ function updateStateOnMisbehaviour(clientMessage: ClientMessage) {
   clientState = provableStore.get("clients/{clientMsg.identifier}/clientState")
   // freeze the client
   clientState.frozen = true
-  provableStore.set("clients/{identifier}/clientState", clientState)
+  provableStore.set("clients/{clientMsg.identifier}/clientState", clientState)
 }
 ```
 

--- a/spec/client/ics-007-tendermint-client/README.md
+++ b/spec/client/ics-007-tendermint-client/README.md
@@ -170,25 +170,16 @@ Tendermint client initialisation requires a (subjectively chosen) latest consens
 
 ```typescript
 function initialise(
-  identifier: Identifier, chainID: string, consensusState: ConsensusState,
-  trustLevel: Fraction, height: Height, trustingPeriod: uint64, unbondingPeriod: uint64,
-  upgradePath: []string, maxClockDrift: uint64, proofSpecs: []ProofSpec
-): ClientState {
-  assert(trustingPeriod < unbondingPeriod)
-  assert(height > 0)
-  assert(trustLevel >= 1/3 && trustLevel <= 1)
+  identifier: Identifier, 
+  clientState: ClientState, 
+  consensusState: ConsensusState
+) {
+  assert(clientState.trustingPeriod < clientState.unbondingPeriod)
+  assert(clientState.height > 0)
+  assert(clientState.trustLevel >= 1/3 && clientState.trustLevel <= 1)
+
+  provableStore.set("clients/{identifier}/clientState", clientState)
   provableStore.set("clients/{identifier}/consensusStates/{height}", consensusState)
-  return ClientState{
-    chainID,
-    trustLevel,
-    latestHeight: height,
-    trustingPeriod,
-    unbondingPeriod,
-    frozenHeight: null,
-    upgradePath,
-    maxClockDrift,
-    proofSpecs
-  }
 }
 ```
 

--- a/spec/client/ics-009-loopback-cilent/README.md
+++ b/spec/client/ics-009-loopback-cilent/README.md
@@ -87,11 +87,11 @@ Implementations **may** choose to implement loopback such that the next message 
 Loopback client initialisation requires the latest height of the local ledger.
 
 ```typescript
-function initialise(height: Height): ClientState {
-  assert(height > 0)
-  return ClientState{
-    latestHeight: height
-  }
+function initialise(identifier: Identifier, clientState: ClientState, consensusState: ConsensusState) {
+  assert(clientState.latestHeight > 0)
+  assert(consensusState === nil)
+  
+  provableStore.set("clients/{identifier}/clientState", clientState)
 }
 ```
 

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -221,10 +221,10 @@ but they must expose this common set of query functions to the IBC handler.
 type ClientState = bytes
 ```
 
-Client types MUST define a method to initialise a client state with the provided client identifier and consensus state, writing to internal state as appropriate.
+Client types MUST define a method to initialise a client state with the provided client identifier, client state and consensus state, writing to internal state as appropriate.
 
 ```typescript
-type initialise = (identifier: Identifier, consensusState: ConsensusState) => ClientState
+type initialise = (identifier: Identifier, clientState: ClientState, consensusState: ConsensusState) => Void
 ```
 
 Client types MUST define a method to fetch the current height (height of the most recent validated state update).
@@ -549,15 +549,14 @@ logical correctness.
 
 #### Create
 
-Calling `createClient` with the client type and initial consensus state creates a new client.
+Calling `createClient` with the client state and initial consensus state creates a new client.
 
 ```typescript
-function createClient(consensusState: ConsensfusState) {
+function createClient(clientState: clientState, consensusState: ConsensusState) {
   // implementations may define a identifier generation function
   identifier = generateClientIdentifier()
   abortTransactionUnless(provableStore.get(clientStatePath(identifier)) === null)
-  clientState = initialise(identifier, consensusState)
-  provableStore.set(clientStatePath(identifier), clientState)
+  initialise(identifier, clientState, consensusState)
 }
 ```
 

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -552,15 +552,12 @@ logical correctness.
 Calling `createClient` with the client type and initial consensus state creates a new client.
 
 ```typescript
-function createClient(
-  clientType: ClientType,
-  consensusState: ConsensusState) {
-    // implementations may define a identifier generation function
-    identifier = generateClientIdentifier()
-    abortTransactionUnless(provableStore.get(clientStatePath(identifier)) === null)
-    abortSystemUnless(provableStore.get(clientTypePath(identifier)) === null)
-    clientType.initialise(identifier, consensusState)
-    provableStore.set(clientTypePath(identifier), clientType)
+function createClient(consensusState: ConsensfusState) {
+  // implementations may define a identifier generation function
+  identifier = generateClientIdentifier()
+  abortTransactionUnless(provableStore.get(clientStatePath(identifier)) === null)
+  clientState = initialise(identifier, consensusState)
+  provableStore.set(clientStatePath(identifier), clientState)
 }
 ```
 

--- a/spec/core/ics-024-host-requirements/README.md
+++ b/spec/core/ics-024-host-requirements/README.md
@@ -118,7 +118,6 @@ Note that the client-related paths listed below reflect the Tendermint client as
 
 | Store          | Path format                                                                    | Value type        | Defined in |
 | -------------- | ------------------------------------------------------------------------------ | ----------------- | ---------------------- |
-| provableStore  | "clients/{identifier}/clientType"                                              | ClientType        | [ICS 2](../ics-002-client-semantics) |
 | provableStore  | "clients/{identifier}/clientState"                                             | ClientState       | [ICS 2](../ics-002-client-semantics) |
 | provableStore  | "clients/{identifier}/consensusStates/{height}"                                | ConsensusState    | [ICS 7](../../client/ics-007-tendermint-client) |
 | privateStore   | "clients/{identifier}/connections                                              | []Identifier      | [ICS 3](../ics-003-connection-semantics) |

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -263,14 +263,13 @@ No message signatures or data validity checks are assumed beyond those which are
 ```typescript
 interface ClientCreate {
   identifier: Identifier
-  type: ClientType
   consensusState: ConsensusState
 }
 ```
 
 ```typescript
 function handleClientCreate(datagram: ClientCreate) {
-    handler.createClient(datagram.type, datagram.consensusState)
+    handler.createClient(datagram.consensusState)
 }
 ```
 

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -263,13 +263,14 @@ No message signatures or data validity checks are assumed beyond those which are
 ```typescript
 interface ClientCreate {
   identifier: Identifier
+  clientState: ClientState
   consensusState: ConsensusState
 }
 ```
 
 ```typescript
 function handleClientCreate(datagram: ClientCreate) {
-    handler.createClient(datagram.consensusState)
+    handler.createClient(datagram.clientState, datagram.consensusState)
 }
 ```
 


### PR DESCRIPTION
Remove deprecated concept of `ClientType`

closes: https://github.com/cosmos/ibc/issues/810
closes: https://github.com/cosmos/ibc/issues/856