### PR TITLE
Upgradability fixes

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -140,7 +140,7 @@ interface ErrorReceipt {
 
 #### Upgrade Channel Path
 
-The chain must store the proposed upgrade until the upgrade handshake successfully. This must be stored in the publice store. It may be deleted once the upgrade is successful.
+The chain must store the proposed upgrade upon initiating an upgrade. The proposed upgrade must be stored in the public store. It may be deleted once the upgrade is successful or has been aborted.
 
 ```typescript
 function channelUpgradePath(portIdentifier: Identifier, channelIdentifier: Identifier): Path {
@@ -148,7 +148,7 @@ function channelUpgradePath(portIdentifier: Identifier, channelIdentifier: Ident
  }
 ```
 
-The upgrade path has an associated verification membership added to the connection interface so that a counterparty may verify that chain has stored the provided counterparty upgrade.
+The upgrade path has an associated verification of membership method added to the connection interface so that a counterparty may verify that chain has stored the provided counterparty upgrade.
 
 ```typescript
 // Connection VerifyChannelUpgrade method

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -656,6 +656,8 @@ function chanUpgradeAck(
 }
 ```
 
+`chanUpgradeOpen` may only be called once both sides have moved to FLUSHCOMPLETE. If there exists unprocessed packets in the queue when the handshake goes into `FLUSHING` mode, then the packet handlers must move the channelEnd to `FLUSHCOMPLETE` once the last packet on the channelEnd has been processed.
+
 ```typescript
 function chanUpgradeOpen(
     portIdentifier: Identifier,

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -39,7 +39,7 @@ enum ChannelState {
 
 - The chain that is proposing the upgrade should set the channel state from `OPEN` to `INITUPGRADE`
 - The counterparty chain that accepts the upgrade should set the channel state from `OPEN` to `TRYUPGRADE`
-- Once the initiating chain verifies the counterparty is in `TRYUPGRADE`, it must move to `ACKUPGRADE` in the case where there still exist in-flight packets on **both ends** or complete the upgrade and move to `OPEN`
+- Once the initiating chain verifies the counterparty is in `TRYUPGRADE`, it must move to `ACKUPGRADE` unless all in-flight packets are already flushed on both ends, in which case it must move directly to `OPEN`.
 - The `TRYUPGRADE` chain must prove the counterparty is in `ACKUPGRADE` or completed the upgrade in `OPEN` AND have no in-flight packets on **both ends** before it can complete the upgrade and move to `OPEN`.
 - The `ACKUPGRADE` chain may OPEN once in-flight packets on **both ends** have been flushed.
 

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -15,7 +15,7 @@ As new features get added to IBC, chains may wish to take advantage of new chann
 - The channel upgrade protocol is atomic, i.e., 
   - either it is unsuccessful and then the channel MUST fall-back to the original channel parameters; 
   - or it is successful and then both channel ends MUST adopt the new channel parameters and the applications must process packet data appropriately.
-- Packets sent under the previously negotiated parameters must be processed under the previously negotiated parameters, packets sent under the newly negotiated parameters must be processed under the newly negotiated parameters. Thus, in-flight packets sent before upgrade handshake is complete will be processed according to the original parameters.
+- Packets sent under the previously negotiated parameters must be processed under the previously negotiated parameters, packets sent under the newly negotiated parameters must be processed under the newly negotiated parameters. Thus, in-flight packets sent before the upgrade handshake is complete will be processed according to the original parameters.
 - The channel upgrade protocol MUST NOT modify the channel identifiers.
 
 ## Technical Specification
@@ -240,7 +240,7 @@ function initUpgradeHandshake(
 ): uint64 {
     // current channel must be OPEN
     currentChannel = provableStore.get(channelPath(portIdentifier, channelIdentifier))
-    abortTransactionUnless(channel.state == OPEN)
+    abortTransactionUnless(currentChannel.state == OPEN)
 
     // new channel version must be nonempty
     abortTransactionUnless(proposedUpgradeFields.Version != "")
@@ -301,7 +301,6 @@ function startFlushUpgradeHandshake(
 
     // get underlying connection for proof verification
     connection = getConnection(currentChannel.connectionIdentifier)
-    counterpartyHops = getCounterpartyHops(connection)
 
     // verify proofs of counterparty state
     abortTransactionUnless(verifyChannelState(connection, proofHeight, proofChannel, currentChannel.counterpartyPortIdentifier, currentChannel.counterpartyChannelIdentifier, counterpartyChannel))
@@ -349,7 +348,7 @@ function startFlushUpgradeHandshake(
         currentChannel.flushState = FLUSHCOMPLETE
     }
 
-    publicStore.set(channelPath(portIdentifier, channelIdentifier), channel)
+    publicStore.set(channelPath(portIdentifier, channelIdentifier), currentChannel)
 
     privateStore.set(channelCounterpartyLastPacketSequencePath(portIdentifier, channelIdentifier), counterpartyUpgrade.lastPacketSent)
 }

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -590,8 +590,6 @@ function chanUpgradeConfirm(
     channelIdentifier: Identifier,
     counterpartyChannelState: ChannelState,
     proofChannel: CommitmentProof,
-    proofUpgradeError: CommitmentProof,
-    proofUpgradeSequence: CommitmentProof,
     proofHeight: Height,
 ) {
     // if packet commitments are not empty then abort the transaction

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -221,7 +221,7 @@ function verifyChannelUpgradeErrorAbsence(
 
 ## Sub-Protocols
 
-The channel upgrade process consists of the following sub-protocols: `InitUpgradeHandshake`, `BlockUpgradeHandshake`, `OpenUpgradeHandshake`, `CancelChannelUpgrade`, and `TimeoutChannelUpgrade`. In the case where both chains approve of the proposed upgrade, the upgrade handshake protocol should complete successfully and the `ChannelEnd` should upgrade to the new parameters in OPEN state.
+The channel upgrade process consists of the following sub-protocols: `InitUpgradeHandshake`, `StartFlushUpgradeHandshake`, `OpenUpgradeHandshake`, `CancelChannelUpgrade`, and `TimeoutChannelUpgrade`. In the case where both chains approve of the proposed upgrade, the upgrade handshake protocol should complete successfully and the `ChannelEnd` should upgrade to the new parameters in OPEN state.
 
 ### Utility Functions
 

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -346,7 +346,7 @@ function openUpgradeHandshake(
 }
 ```
 
-`restoreChannel` will write an error receipt, set the original channel and delete upgrade information when the executing channel needs to abort the upgrade handshake and return to the original parameters.
+`restoreChannel` will write an error receipt, set the channel back to its original state and delete upgrade information when the executing channel needs to abort the upgrade handshake and return to the original parameters.
 
 ```typescript
 // restoreChannel signature may be modified to take a custom error
@@ -767,7 +767,7 @@ It is possible for the channel upgrade process to stall indefinitely on TRYUPGRA
 
 In this case, we do not want the initializing chain to be stuck indefinitely in the `INITUPGRADE` step. Thus, the `ChannelUpgradeInitMsg` message will contain a `TimeoutHeight` and `TimeoutTimestamp`. The counterparty chain is expected to reject `ChannelUpgradeTryMsg` message if the specified timeout has already elapsed.
 
-A relayer must then submit an `ChannelUpgradeTimeoutMsg` message to the initializing chain which proves that the counterparty is still in its original state. If the proof succeeds, then the initializing chain shall also restore its original channel and cancel the upgrade.
+A relayer must then submit an `ChannelUpgradeTimeoutMsg` message to the initializing chain which proves that the counterparty is still in its original state. If the proof succeeds, then the initializing chain shall also restore its original channel to `OPEN` and cancel the upgrade.
 
 ```typescript
 function timeoutChannelUpgrade(

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -39,11 +39,11 @@ enum ChannelState {
 
 - The chain that is proposing the upgrade should set the channel state from `OPEN` to `INITUPGRADE`
 - The counterparty chain that accepts the upgrade should set the channel state from `OPEN` to `TRYUPGRADE`
-- Once the initiating chain verifies the counterparty is in `TRYUPGRADE`, it must move to `ACKUPGRADE` in the case where there still exist in-flight packets on its end or complete the upgrade and move to `OPEN`
-- The `TRYUPGRADE` chain must prove the counterparty is in `ACKUPGRADE` or completed the upgrade in `OPEN` AND have no in-flight packets before it can complete the upgrade and move to `OPEN`.
-- The `ACKUPGRADE` chain may OPEN as soon as the in-flight packets on its end have been flushed.
+- Once the initiating chain verifies the counterparty is in `TRYUPGRADE`, it must move to `ACKUPGRADE` in the case where there still exist in-flight packets on **both ends** or complete the upgrade and move to `OPEN`
+- The `TRYUPGRADE` chain must prove the counterparty is in `ACKUPGRADE` or completed the upgrade in `OPEN` AND have no in-flight packets on **both ends** before it can complete the upgrade and move to `OPEN`.
+- The `ACKUPGRADE` chain may OPEN once in-flight packets on **both ends** have been flushed.
 
-Both `TRYUPGRADE` and `ACKUPGRADE` are "blocking" states in that they will prevent the upgrade handshake from proceeding until the in-flight packets are flushed. The `TRYUPGRADE` state must additionally prove the counterparty state before proceeding to open, while the `ACKUPGRADE` state may move to `OPEN` unilaterally once packets are flushed on its end.
+Both `TRYUPGRADE` and `ACKUPGRADE` are "blocking" states in that they will prevent the upgrade handshake from proceeding until the in-flight packets on both channel ends are flushed. The `TRYUPGRADE` state must additionally prove the counterparty state before proceeding to open, while the `ACKUPGRADE` state may move to `OPEN` unilaterally once packets are flushed on both ends.
 
 #### `ChannelEnd`
 


### PR DESCRIPTION
Refactor according to @colin-axner suggestions

- Store upgrade in separate path and keep original channel in state until channel is OPEN
- Pause new packets and flush in-flight packets before channel can reopen

----

Happy path handshake is done

Cancel/Timeout still needs to change