### PR TITLE
Fix mistyped variable name

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -289,7 +289,7 @@ function onAcknowledgePacket(
   packet: Packet,
   acknowledgement: bytes) {
   // if the transfer failed, refund the tokens
-  if (!ack.success)
+  if (!acknowledgement.success)
     refundTokens(packet)
 }
 ```

--- a/spec/app/ics-100-atomic-swap/README.md
+++ b/spec/app/ics-100-atomic-swap/README.md
@@ -523,7 +523,7 @@ function onAcknowledgePacket(
   packet: channeltypes.Packet
   acknowledgement: bytes) {
   // ack is failed
-  if (!ack.success) {
+  if (!acknowledgement.success) {
     refundTokens(packet) 
   } else {
     

--- a/spec/app/ics-721-nft-transfer/README.md
+++ b/spec/app/ics-721-nft-transfer/README.md
@@ -379,7 +379,7 @@ function ProcessReceivedPacketData(data: NonFungibleTokenPacketData) {
 ```typescript
 function onAcknowledgePacket(packet: Packet, acknowledgement: bytes) {
   // if the transfer failed, refund the tokens
-  if (!ack.success) refundToken(packet)
+  if (!acknowledgement.success) refundToken(packet)
 }
 ```
 


### PR DESCRIPTION
ICS 20, 100, and 721 contain a mistyped variable name in the pseudocode definition of `onAcknowledgePacket`:
The formal parameter name is `acknowledgement`, but in the function body it is referred to by `ack`.

Since this is a small fix, I did not open an issue or update the ICS metadata. Please lmk if I should do so.

&nbsp;
&nbsp;
_Found while writing the [ICS-20 spec in Quint](https://github.com/informalsystems/quint/tree/main/examples/cosmos/ics20), simply by copy-pasting._