### PR TITLE
Add missing method to ModuleCallbacks interface

### DIFF
--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -163,6 +163,7 @@ interface ModuleCallbacks {
   onChanOpenTry: onChanOpenTry,
   onChanOpenAck: onChanOpenAck,
   onChanOpenConfirm: onChanOpenConfirm,
+  onChanCloseInit: onChanCloseInit,
   onChanCloseConfirm: onChanCloseConfirm
   onRecvPacket: onRecvPacket
   onTimeoutPacket: onTimeoutPacket


### PR DESCRIPTION
This PR will add a missing method to the ModuleCallbacks interface required by the [IBCModule](https://github.com/cosmos/ibc-go/blob/main/modules/core/05-port/types/module.go#L14) interface.

The missing method is OnChanCloseInit which is required to allow a module to initiale a closing of a channel and is referred to in the same [ICS-026](https://github.com/cosmos/ibc/tree/main/spec/core/ics-026-routing-module). An example of its implementation in the transfer module can be found [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/ibc_module.go#L148).