### PR TITLE
add commas after interface's methods

### DIFF
--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -163,11 +163,11 @@ interface ModuleCallbacks {
   onChanOpenTry: onChanOpenTry,
   onChanOpenAck: onChanOpenAck,
   onChanOpenConfirm: onChanOpenConfirm,
-  onChanCloseConfirm: onChanCloseConfirm
-  onRecvPacket: onRecvPacket
-  onTimeoutPacket: onTimeoutPacket
+  onChanCloseConfirm: onChanCloseConfirm,
+  onRecvPacket: onRecvPacket,
+  onTimeoutPacket: onTimeoutPacket,
   onAcknowledgePacket: onAcknowledgePacket,
-  onTimeoutPacketClose: onTimeoutPacketClose
+  onTimeoutPacketClose: onTimeoutPacketClose,
 }
 ```
 


### PR DESCRIPTION
This PR is a followup of #993 to add missing commas inside the interface.