### PR TITLE
Fix README.md link to the Rust relayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ All standards at or past the "Draft" stage are listed here in order of their ICS
 
 | Interchain Standard Number                                       | Standard Title             | Stage | Implementations | Maintainer    |
 | ---------------------------------------------------------------- | -------------------------- | ----- | --------------- | ------------- |
-| [18](spec/relayer/ics-018-relayer-algorithms/README.md)          | Relayer Algorithms         | Finalized | [go-relayer](https://github.com/cosmos/relayer), [rust-relayer](https://github.com/informalsystems/ibc-rs), [ts-relayer](https://github.com/confio/ts-relayer) | Protocol team |
+| [18](spec/relayer/ics-018-relayer-algorithms/README.md)          | Relayer Algorithms         | Finalized | [go-relayer](https://github.com/cosmos/relayer), [rust-relayer](https://github.com/informalsystems/hermes), [ts-relayer](https://github.com/confio/ts-relayer) | Protocol team |
 
 ### App
 


### PR DESCRIPTION
Fixed the github repo hyperlink for the relayer in Rust