### PR TITLE
ICS 06: updates for using unprefixed path in sign bytes

### DIFF
--- a/spec/client/ics-006-solo-machine-client/README.md
+++ b/spec/client/ics-006-solo-machine-client/README.md
@@ -5,7 +5,7 @@ stage: draft
 category: IBC/TAO
 kind: instantiation
 implements: 2
-version compatibility: ibc-go v7.0.0
+version compatibility: ibc-go v7.3.0
 author: Christopher Goes <cwgoes@tendermint.com>
 created: 2019-12-09
 modified: 2019-12-09
@@ -24,6 +24,10 @@ Solo machine clients are roughly analogous to "implicit accounts" and can be use
 ### Definitions
 
 Functions & terms are as defined in [ICS 2](../../core/ics-002-client-semantics).
+
+`getCommitmentPrefix` is as defined in [ICS 24](../../core/ics-024-host-requirements).
+
+`removePrefix` is as defined in [ICS 23](../../core/ics-023-vector-commitments).
 
 ### Desired properties
 
@@ -270,11 +274,18 @@ function verifyMembership(
   // the expected sequence used in the signature
   abortTransactionUnless(!clientState.frozen)
   abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
+
+  // path is prefixed with the store prefix of the commitment proof
+  // e.g. in ibc-go implementation this is "ibc"
+  // since solomachines do not use multi-stores, the prefix needs 
+  // to be removed from the path to retrieve the correct key in the
+  // solomachine store
+  unprefixedPath = removePrefix(getCommitmentPrefix(), path)
   signBytes = SignBytes(
     sequence: clientState.sequence,
     timestamp: proof.timestamp,
     diversifier: clientState.consensusState.diversifier,
-    path: path.String(),
+    path: unprefixedPath,
     data: value,
   )
   proven = checkSignature(clientState.consensusState.publicKey, signBytes, proof.sig)
@@ -308,11 +319,18 @@ function verifyNonMembership(
 ): Error {
   abortTransactionUnless(!clientState.frozen)
   abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
+
+  // path is prefixed with the store prefix of the commitment proof
+  // e.g. in ibc-go implementation this is "ibc"
+  // since solomachines do not use multi-stores, the prefix needs 
+  // to be removed from the path to retrieve the correct key in the
+  // solomachine store
+  unprefixedPath = removePrefix(getCommitmentPrefix(), path)
   signBytes = SignBytes(
     sequence: clientState.sequence,
     timestamp: proof.timestamp,
     diversifier: clientState.consensusState.diversifier,
-    path: path.String(),
+    path: unprefixedPath,
     data: nil,
   )
   proven = checkSignature(clientState.consensusState.publicKey, signBytes, proof.sig)
@@ -354,6 +372,7 @@ Not applicable. Alterations to the client verification algorithm will require a 
 December 9th, 2019 - Initial version
 December 17th, 2019 - Final first draft
 August 15th, 2022 - Changes to align with 02-client-refactor in [\#813](https://github.com/cosmos/ibc/pull/813)
+September 14th, 2022 - Changes to align with changes in [\#4429](https://github.com/cosmos/ibc-go/pull/4429)
 
 ## Copyright
 

--- a/spec/client/ics-009-loopback-cilent/README.md
+++ b/spec/client/ics-009-loopback-cilent/README.md
@@ -25,7 +25,9 @@ Functions & terms are as defined in [ICS 2](../../core/ics-002-client-semantics)
 
 `ConnectionEnd` and `generateIdentifier` are as defined in [ICS 3](../../core/ics-003-connection-semantics)
 
-`getCommitmentPrefix` and `removePrefix` are as defined in [ICS 24](../../core/ics-024-host-requirements).
+`getCommitmentPrefix` is as defined in [ICS 24](../../core/ics-024-host-requirements).
+
+`removePrefix` is as defined in [ICS 23](../../core/ics-023-vector-commitments).
 
 ### Desired Properties
 


### PR DESCRIPTION
Updates for https://github.com/cosmos/ibc-go/pull/4429.