### PR TITLE
fix: set upgrade timeout after `startFlushUpgradeHandshake in `chanUpgradeAck`

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -647,16 +647,16 @@ function chanUpgradeAck(
     )
   )
 
-  upgrade = provableStore.get(channelUpgradePath(portIdentifier, channelIdentifier))
+  existingUpgrade = provableStore.get(channelUpgradePath(portIdentifier, channelIdentifier))
 
   // optimistically accept version that TRY chain proposes and pass this to callback for confirmation.
   // in the crossing hello case, we do not modify version that our TRY call returned and instead 
   // enforce that both TRY calls returned the same version
   if (channel.state == OPEN) {
-    upgrade.fields.version == counterpartyUpgrade.fields.version
+    existingUpgrade.fields.version == counterpartyUpgrade.fields.version
   }
   // if upgrades are not compatible by ACK step, then we restore the channel
-  if (!isCompatibleUpgradeFields(upgrade.fields, counterpartyUpgrade.fields)) {
+  if (!isCompatibleUpgradeFields(existingUpgrade.fields, counterpartyUpgrade.fields)) {
     restoreChannel(portIdentifier, channelIdentifier)
     return
   }
@@ -666,6 +666,10 @@ function chanUpgradeAck(
     // if we are already at flushing, then no state changes occur
     // upgrade is blocked on this channelEnd from progressing until flush completes on both ends
     startFlushUpgradeHandshake(portIdentifier, channelIdentifier)
+    // startFlushUpgradeHandshake sets the timeout for the upgrade
+    // so retrieve upgrade again here and use that timeout value
+    upgrade = provableStore.get(channelUpgradePath(portIdentifier, channelIdentifier))
+    existingUpgrade.timeout = upgrade.timeout
   }
 
   timeout = counterpartyUpgrade.timeout
@@ -705,7 +709,7 @@ function chanUpgradeAck(
   }
 
   // if no error, agree on final version
-  provableStore.set(channelUpgradePath(portIdentifier, channelIdentifier), upgrade)
+  provableStore.set(channelUpgradePath(portIdentifier, channelIdentifier), existingUpgrade)
 }
 ```
 


### PR DESCRIPTION
Found this small bug when run the happy path quint test.

cc @AdityaSripal @sangier 