### PR TITLE
update `FungibleTokenPacketData` marshalling to match rest of spec

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -244,7 +244,7 @@ function sendFungibleTokens(
       sourceChannel,
       timeoutHeight,
       timeoutTimestamp,
-      protobuf.marshal(data) // protobuf-marshalled bytes of packet data
+      json.marshal(data) // json-marshalled bytes of packet data
     )
 
     return sequence


### PR DESCRIPTION
The `FungibleTokenPacketData` marshalling in the pseudocode was using protobuf, but the rest of the spec says "Note that both the `FungibleTokenPacketData` as well as `FungibleTokenPacketAcknowledgement` must be JSON-encoded (not Protobuf encoded) when they serialized into packet data." this is also what the ibc-go implementation does.