### PR TITLE
adding parameter to restore channel

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -914,7 +914,9 @@ function cancelChannelUpgrade(
     )
   }
 
-  // cancel upgrade and write error receipt
+  // cancel upgrade and write error receipt 
+  // fastforward channel sequence to higher sequence so that we can start
+  // new handshake on a fresh sequence
   restoreChannel(portIdentifier, channelIdentifier, errorReceipt.Sequence)
 }
 ```


### PR DESCRIPTION
Writing quint tests, we realised that `restoreChannel` function should include in input the `upgradeSequence` parameter and update the `channel.UpgradeSequence` accordingly.  This change aligns specs and implementation, since in the [implementation](https://github.com/cosmos/ibc-go/blob/eaabb85c67adbefb53cd32aecd1ae9680d7e9e9a/modules/core/04-channel/keeper/upgrade.go#L632) we have a `restoreChannel` function with this additional parameter.   

This way we can pass: 
-  `channel.UpgradeSequence` to the `restoreChannel`  in  `chanUpgradeAck`, `chanUpgradeConfirm` and `timeoutChannelUpgrade`. 
- `errorReceipt.Sequence` to the `restoreChannel`  in  `cancelChannelUpgrade`, ensuring that we can start
  a new handshake on a fresh sequence.  

 

