### PR TITLE
specify units of `timeoutTimestamp` in ICS20

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -220,7 +220,8 @@ function sendFungibleTokens(
   sourcePort: string,
   sourceChannel: string,
   timeoutHeight: Height,
-  timeoutTimestamp: uint64): uint64 {
+  timeoutTimestamp: uint64, // in unix nanoseconds
+): uint64 {
     prefix = "{sourcePort}/{sourceChannel}/"
     // we are the source if the denomination is not prefixed
     source = denomination.slice(0, len(prefix)) !== prefix


### PR DESCRIPTION
Previously the units for `timeoutTimestamp` were not specified and it's unclear whether they were unix seconds or nanoseconds.
This specifies that the units are unix nanoseconds as per the Go implementation: https://github.com/cosmos/ibc-go/blob/d0cf5b64dc8756206dad6c922e3530535ab78b79/proto/ibc/applications/transfer/v1/tx.proto#L47