### PR TITLE
ICS Documentation: Grammar and Command Fixes

### DIFF
--- a/meta/CONTRIBUTING.md
+++ b/meta/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If you have any questions, you can usually find some IBC team members on the [Co
 
 ## Pull Requests
 
-To accommodate review process we suggest that PRs are categorically broken up.
+To accommodate the review process we suggest that PRs are categorically broken up.
 Each PR should address only a single issue and **a single standard**. 
 The PR name should be prefixed by the standard number, 
 e.g., `ICS4: Some improvements` should contain only changes to [ICS 4](../spec/core/ics-004-channel-and-packet-semantics/README.md).

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -185,7 +185,7 @@ function PayFee(packet: Packet, forward_relayer: string, reverse_relayer: string
     // NOTE: if forward relayer address is empty, then refund the forward fee to original fee payer(s).
 }
 
-// PayFee is a callback implemented by fee module called by the ICS-4 TimeoutPacket handler.
+// PayTimeoutFee is a callback implemented by fee module called by the ICS-4 TimeoutPacket handler.
 function PayTimeoutFee(packet: Packet, timeout_relayer: string) {
     // pay the timeout fee to the timeout relayer address
     // refund extra tokens to original fee payer(s)

--- a/spec/app/ics-100-atomic-swap/README.md
+++ b/spec/app/ics-100-atomic-swap/README.md
@@ -20,11 +20,11 @@ This standard document specifies packet data structure, state machine handling l
 
 Users may wish to exchange tokens without transferring tokens away from their native chain. ICS-100 enabled chains can facilitate atomic swaps between users and their tokens located on the different chains. This is useful for exchanges between specific users at specific prices, and opens opportunities for new application designs.
 
-For example, a token exchange would require only one transaction from an user, compared to multiple transactions when using ICS-20.  Additionally, users can minimize trade slippage compared to using a liquidity pool, given there is a willing counter-party.
+For example, a token exchange would require only one transaction from a user, compared to multiple transactions when using ICS-20.  Additionally, users can minimize trade slippage compared to using a liquidity pool, given there is a willing counter-party.
 
 ### Definitions
 
-`Atomic Swap`: An exchange of tokens from separate chains without transfering tokens from one blockchain to another.  The exchange either happens or it doesn't -- there is no other alternative.
+`Atomic Swap`: An exchange of tokens from separate chains without transferring tokens from one blockchain to another.  The exchange either happens or it doesn't -- there is no other alternative.
 
 `Order`: An offer to exchange quantity X of token A for quantity Y of token B. Tokens offered are sent to an escrow account (owned by the module).
 
@@ -32,14 +32,14 @@ For example, a token exchange would require only one transaction from an user, c
 
 `Taker`: The counterparty who takes or responds to an order.
 
-`Maker Chain`: The blockchain where a maker makes or initiaties an order.
+`Maker Chain`: The blockchain where a maker makes or initiates an order.
 
 `Taker Chain`: The blockchain where a taker takes or responds to an order.
 
 ### Desired Properties
 
 - `Permissionless`: no need to whitelist connections, modules, or denominations.
-- `Guarantee of exchange`: no occurence of a user receiving tokens without the equivalent promised exchange.
+- `Guarantee of exchange`: no occurrence of a user receiving tokens without the equivalent promised exchange.
 - `Escrow enabled`: an account owned by the module will hold tokens and facilitate exchange.
 - `Refundable`: tokens are refunded by escrow when a timeout occurs, or when an order is cancelled.
 - `Order cancellation`: orders without takers can be cancelled.

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -55,7 +55,7 @@ state updates are considered final) are used to verify state updates.
 The client protocol should also support third-party introduction.
 For example, if `A`, `B`, and `C` are three state machines, with 
 Alice a module on `A`, Bob a module on `B`, and Carol a module on `C`, such that
-Alice knows both Bob and Carol, but Bob knowns only Alice and not Carol, 
+Alice knows both Bob and Carol, but Bob knows only Alice and not Carol, 
 then Alice can utilise an existing channel to Bob to communicate the canonically-serialisable 
 validity predicate for Carol. Bob can then use this validity predicate to open a connection and channel 
 so that Bob and Carol can talk directly.

--- a/spec/core/ics-003-connection-semantics/UPGRADES.md
+++ b/spec/core/ics-003-connection-semantics/UPGRADES.md
@@ -6,7 +6,7 @@ This standard document specifies the interfaces and state machine logic that IBC
 
 ## Motivation
 
-As new features get added to IBC, chains may wish the take advantage of new connection features without abandoning the accumulated state and network effect(s) of an already existing connection. The upgrade protocol proposed would allow chains to renegotiate an existing connection to take advantage of new features without having to create a new connection, thus preserving all existing channels that built on top of the connection.
+As new features get added to IBC, chains may wish to take advantage of new connection features without abandoning the accumulated state and network effect(s) of an already existing connection. The upgrade protocol proposed would allow chains to renegotiate an existing connection to take advantage of new features without having to create a new connection, thus preserving all existing channels that built on top of the connection.
 
 ## Desired Properties
 

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -369,7 +369,7 @@ function restoreChannel(
   // restore callback must not return error since counterpart
   // successfully restored previous channelEnd
   module.onChanUpgradeRestore(
-    portIdentifer,
+    portIdentifier,
     channelIdentifier
   )
 }
@@ -864,7 +864,7 @@ function chanUpgradeOpen(
   module = lookupModule(portIdentifier)
   // open callback must not return error since counterparty successfully upgraded
   module.onChanUpgradeOpen(
-    portIdentifer,
+    portIdentifier,
     channelIdentifier
   )
 }
@@ -1001,7 +1001,7 @@ function timeoutChannelUpgrade(
   // restore callback must not return error since counterparty 
   // successfully restored previous channelEnd
   module.onChanUpgradeRestore(
-    portIdentifer,
+    portIdentifier,
     channelIdentifier
   )
 }

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -580,7 +580,7 @@ function chanUpgradeTry(
   module = lookupModule(portIdentifier)
   version, err = module.onChanUpgradeTry(
     portIdentifier,
-    channelIdentifer,
+    channelIdentifier,
     channel.upgradeSequence,
     upgradeFields.ordering,
     upgradeFields.connectionHops,

--- a/spec/relayer/ics-018-relayer-algorithms/README.md
+++ b/spec/relayer/ics-018-relayer-algorithms/README.md
@@ -262,7 +262,7 @@ Multiple relayers relaying between the same pair of modules & chains may attempt
 
 ### Incentivisation
 
-The relay process must have access to accounts on both chains with sufficient balance to pay for transaction fees. Relayers may employ application-level methods to recoup these fees, such by including a small payment to themselves in the packet data — protocols for relayer fee payment will be described in future versions of this ICS or in separate ICSs.
+The relay process must have access to accounts on both chains with sufficient balance to pay for transaction fees. Relayers may employ application-level methods to recoup these fees, such as by including a small payment to themselves in the packet data — protocols for relayer fee payment will be described in future versions of this ICS or in separate ICSs.
 
 Any number of relayer processes may be safely run in parallel (and indeed, it is expected that separate relayers will serve separate subsets of the interchain). However, they may consume unnecessary fees if they submit the same proof multiple times, so some minimal coordination may be ideal (such as assigning particular relayers to particular packets or scanning mempools for pending transactions).
 


### PR DESCRIPTION
This pull request includes a series of grammatical corrections and command fixes across various ICS standards. These updates aim to enhance the clarity and accuracy of the documentation. Below is a summary of the key changes:

1. **ICS-004 Channel and Packet Semantics:** Corrected "portIdentifer" to "portIdentifier" and "channelIdentifer" to "channelIdentifier" in various sections.
2. **ICS-003 Connection Semantics:** Updated "wish the take advantage" to "wish to take advantage."
3. **ICS-018 Relayer Algorithms:** Fixed "such by including" to "such as by including."
4. **ICS-002 Client Semantics:** Revised "knowns" to "knows."
5. **ICS-100 Atomic Swap:** Addressed multiple errors, changing "occurence" to "occurrence," "transfering" to "transferring," and "an user" to "a user."
6. **ICS-029 Fee Payment:** Modified the comment from "PayFee" to "PayTimeoutFee" for better clarity.
7. **Meta/CONTRIBUTING.md:** Eliminated redundancy in the 'review process' section.

I appreciate the team's hard work and dedication to this project, and I am pleased to contribute to its continual improvement. Please let me know if any further modifications are required.
