### PR TITLE
ICS4: Implement Packet Sequence Logic for upgrades

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -827,10 +827,10 @@ function recvPacket(
     channel = provableStore.get(channelPath(packet.destPort, packet.destChannel))
     abortTransactionUnless(channel !== null)
     abortTransactionUnless(channel.state === OPEN || (channel.state === FLUSHING))
-    counterpartyNextPacketSend = privateStore.get(counterpartyNextPacketSendSequence(packet.destPort, packet.destChannel))
+    counterpartyNextSequenceSend = privateStore.get(counterpartyNextSequenceSendSequence(packet.destPort, packet.destChannel))
     // defensive check that ensures chain does not process a packet higher than the last packet sent before
     // counterparty went into FLUSHING mode. If the counterparty is implemented correctly, this should never abort
-    abortTransactionUnless(counterpartyNextPacketSend == 0 || packet.sequence < counterpartyNextPacketSend)
+    abortTransactionUnless(counterpartyNextSequenceSend == 0 || packet.sequence < counterpartyNextSequenceSend)
     abortTransactionUnless(authenticateCapability(channelCapabilityPath(packet.destPort, packet.destChannel), capability))
     abortTransactionUnless(packet.sourcePort === channel.counterpartyPortIdentifier)
     abortTransactionUnless(packet.sourceChannel === channel.counterpartyChannelIdentifier)

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -827,10 +827,10 @@ function recvPacket(
     channel = provableStore.get(channelPath(packet.destPort, packet.destChannel))
     abortTransactionUnless(channel !== null)
     abortTransactionUnless(channel.state === OPEN || (channel.state === FLUSHING))
-    counterpartyNextSequenceSend = privateStore.get(counterpartyNextSequenceSendSequence(packet.destPort, packet.destChannel))
+    counterpartyUpgrade = privateStore.get(counterpartyUpgradePath(packet.destPort, packet.destChannel))
     // defensive check that ensures chain does not process a packet higher than the last packet sent before
     // counterparty went into FLUSHING mode. If the counterparty is implemented correctly, this should never abort
-    abortTransactionUnless(counterpartyNextSequenceSend == 0 || packet.sequence < counterpartyNextSequenceSend)
+    abortTransactionUnless(counterpartyUpgrade.nextSequenceSend == 0 || packet.sequence < counterpartyUpgrade.nextSequenceSend)
     abortTransactionUnless(authenticateCapability(channelCapabilityPath(packet.destPort, packet.destChannel), capability))
     abortTransactionUnless(packet.sourcePort === channel.counterpartyPortIdentifier)
     abortTransactionUnless(packet.sourceChannel === channel.counterpartyChannelIdentifier)

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -827,6 +827,10 @@ function recvPacket(
     channel = provableStore.get(channelPath(packet.destPort, packet.destChannel))
     abortTransactionUnless(channel !== null)
     abortTransactionUnless(channel.state === OPEN || (channel.state === FLUSHING))
+    counterpartyNextPacketSend = privateStore.get(counterpartyNextPacketSendSequence(packet.destPort, packet.destChannel))
+    // defensive check that ensures chain does not process a packet higher than the last packet sent before
+    // counterparty went into FLUSHING mode. If the counterparty is implemented correctly, this should never abort
+    abortTransactionUnless(counterpartyNextPacketSend == 0 || packet.sequence < counterpartyNextPacketSend)
     abortTransactionUnless(authenticateCapability(channelCapabilityPath(packet.destPort, packet.destChannel), capability))
     abortTransactionUnless(packet.sourcePort === channel.counterpartyPortIdentifier)
     abortTransactionUnless(packet.sourceChannel === channel.counterpartyChannelIdentifier)

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -336,7 +336,7 @@ function openUpgradeHandshake(
     selfNextSequenceSend = provableStore.get(nextSequenceSendPath(portIdentifier, channelIdentifier))
     counterpartyUpgrade = privateStore.get(counterpartyUpgradePath(portIdentifier, channelIdentifier))
 
-    // set nextSequenceRecv to the counterpartyNextSequenceSend since all packets were flushed
+    // set nextSequenceRecv to the counterparty nextSequenceSend since all packets were flushed
     provableStore.set(nextSequenceRecvPath(portIdentifier, channelIdentifier), counterpartyUpgrade.nextSequenceSend)
     // set nextSequenceAck to our own nextSequenceSend since all packets were flushed
     provableStore.set(nextSequenceAckPath(portIdentifier, channelIdentifier), selfNextSequenceSend)

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -158,13 +158,13 @@ function verifyChannelUpgrade(
 }
 ```
 
-#### CounterpartyNextPacketSendSequence Path
+#### CounterpartyNextSequenceSend Path
 
-The chain must store the counterparty's last packet sequence on `startFlushUpgradeHandshake`. This will be stored in the `counterpartyNextPacketSendSequence` path on the private store.
+The chain must store the counterparty's next sequence send on `startFlushUpgradeHandshake`. This will be stored in the `counterpartyNextSequenceSend` path on the private store.
 
 ```typescript
-function counterpartyNextPacketSendSequencePath(portIdentifier: Identifier, channelIdentifier: Identifier): Path {
-    return "channelUpgrades/counterpartyNextPacketSendSequence/ports/{portIdentifier}/channels/{channelIdentifier}"
+function counterpartyNextSequenceSendPath(portIdentifier: Identifier, channelIdentifier: Identifier): Path {
+    return "channelUpgrades/counterpartyNextSequenceSend/ports/{portIdentifier}/channels/{channelIdentifier}"
 }
 ```
 
@@ -246,7 +246,7 @@ function initUpgradeHandshake(
   // new order must be supported by the new connection
   abortTransactionUnless(isSupported(proposedConnection, proposedUpgradeFields.ordering))
 
-  // nextPacketSendSequence and timeout will be filled when we move to FLUSHING
+  // nextPacketSend and timeout will be filled when we move to FLUSHING
   upgrade = Upgrade{
     fields: proposedUpgradeFields,
   }
@@ -343,8 +343,8 @@ function openUpgradeHandshake(
   // if channel order changed, we need to set
   // the recv and ack sequences appropriately
   if channel.order == "UNORDERED" && upgrade.fields.ordering == "ORDERED" {
-    selfNextSequenceSendSeq = provableStore.get(nextSequenceSendPath(portIdentifier, channelIdentifier))
-    counterpartyNextSequenceSendSeq = privateStore.get(counterpartyNextPacketSendSequencePath(portIdentifier, channelIdentifier))
+    selfNextSequenceSend = provableStore.get(nextSequenceSendPath(portIdentifier, channelIdentifier))
+    counterpartyNextSequenceSend = privateStore.get(counterpartyNextPacketSendSequencePath(portIdentifier, channelIdentifier))
 
     // set nextSequenceRecv to the counterpartyNextSequenceSend since all packets were flushed
     provableStore.set(nextSequenceRecvPath(portIdentifier, channelIdentifier), counterpartyNextSequenceSendSeq)
@@ -366,8 +366,8 @@ function openUpgradeHandshake(
 
   // IMPLEMENTATION DETAIL: Implementations may choose to prune stale acknowledgements and receipts at this stage
   // Since flushing has completed, any acknowledgement or receipt written before the chain went into flushing has
-  // already been processed by the counterparty can be removed.
-  // Implementatins may do this pruning work over multiple blocks for gas reasons. In this case, they should be sure
+  // already been processed by the counterparty and can be removed.
+  // Implementations may do this pruning work over multiple blocks for gas reasons. In this case, they should be sure
   // to only prune stale acknowledgements/receipts and not new ones that have been written after the channel has reopened.
   // Implementations may use the counterparty NextSequenceSend as a way to determine which acknowledgement/receipts
   // were already processed by counterparty when flushing completed

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -107,11 +107,11 @@ The upgrade type will represent a particular upgrade attempt on a channel end.
 interface Upgrade {
   fields: UpgradeFields
   timeout: UpgradeTimeout
-  nextPacketSend: uint64
+  nextSequenceSend: uint64
 }
 ```
 
-The upgrade contains the proposed upgrade for the channel end on the executing chain, the timeout for the upgrade attempt, and the next packet send sequence for the channel. The `nextPacketSend` allows the counterparty to know which packets need to be flushed before the channel can reopen with the newly negotiated parameters. Any packet sent to the channel end with a packet sequence greater than or equal to the `nextPacketSend` will be rejected until the upgrade is complete. The `nextPacketSend` will also be used to set the new sequences for the counterparty when it opens for a new upgrade.
+The upgrade contains the proposed upgrade for the channel end on the executing chain, the timeout for the upgrade attempt, and the next packet send sequence for the channel. The `nextSequenceSend` allows the counterparty to know which packets need to be flushed before the channel can reopen with the newly negotiated parameters. Any packet sent to the channel end with a packet sequence greater than or equal to the `nextSequenceSend` will be rejected until the upgrade is complete. The `nextSequenceSend` will also be used to set the new sequences for the counterparty when it opens for a new upgrade.
 
 #### `ErrorReceipt`
 
@@ -246,7 +246,7 @@ function initUpgradeHandshake(
   // new order must be supported by the new connection
   abortTransactionUnless(isSupported(proposedConnection, proposedUpgradeFields.ordering))
 
-  // nextPacketSend and timeout will be filled when we move to FLUSHING
+  // nextSequenceSend and timeout will be filled when we move to FLUSHING
   upgrade = Upgrade{
     fields: proposedUpgradeFields,
   }
@@ -317,7 +317,7 @@ function startFlushUpgradeHandshake(
   nextSequenceSend = provableStore.get(nextSequenceSendPath(portIdentifier, channelIdentifier))
 
   upgrade.timeout = upgradeTimeout
-  upgrade.nextPacketSend = nextSequenceSend
+  upgrade.nextSequenceSend = nextSequenceSend
   
   // store upgrade in public store for counterparty proof verification
   provableStore.set(channelPath(portIdentifier, channelIdentifier), channel)
@@ -748,7 +748,7 @@ function chanUpgradeAck(
   } else {
     privateStore.set(counterpartyUpgradeTimeout(portIdentifier, channelIdentifier), timeout)
   }
-  privateStore.set(counterpartyNextSequenceSend(portIdentifier, channelIdentifier), counterpartyUpgrade.nextPacketSend)
+  privateStore.set(counterpartyNextSequenceSend(portIdentifier, channelIdentifier), counterpartyUpgrade.nextSequenceSend)
 
   provableStore.set(channelPath(portIdentifier, channelIdentifier), channel)
 
@@ -844,7 +844,7 @@ function chanUpgradeConfirm(
   } else {
     privateStore.set(counterpartyUpgradeTimeout(portIdentifier, channelIdentifier), timeout)
   }
-  privateStore.set(counterpartyNextSequenceSend(portIdentifier, channelIdentifier), counterpartyUpgrade.nextPacketSend)
+  privateStore.set(counterpartyNextSequenceSend(portIdentifier, channelIdentifier), counterpartyUpgrade.nextSequenceSend)
 
   // if both chains are already in flushcomplete we can move to OPEN
   if (channel.state == FLUSHCOMPLETE && counterpartyChannelState == FLUSHCOMPLETE) {

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -337,9 +337,9 @@ function openUpgradeHandshake(
     counterpartyUpgrade = privateStore.get(counterpartyUpgradePath(portIdentifier, channelIdentifier))
 
     // set nextSequenceRecv to the counterpartyNextSequenceSend since all packets were flushed
-    provableStore.set(nextSequenceRecvPath(portIdentifier, channelIdentifier), counterpartyUpgrade.nextSequenceSendSeq)
+    provableStore.set(nextSequenceRecvPath(portIdentifier, channelIdentifier), counterpartyUpgrade.nextSequenceSend)
     // set nextSequenceAck to our own nextSequenceSend since all packets were flushed
-    provableStore.set(nextSequenceAckPath(portIdentifier, channelIdentifier), selfNextSequenceSendSeq)
+    provableStore.set(nextSequenceAckPath(portIdentifier, channelIdentifier), selfNextSequenceSend)
   } else if channel.order == "ORDERED" && upgrade.fields.ordering == "UNORDERED" {
     // reset recv and ack sequences to 1 for UNORDERED channel
     provableStore.set(nextSequenceRecvPath(portIdentifier, channelIdentifier), 1)

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -401,7 +401,7 @@ function restoreChannel(
 
   // delete auxiliary state
   provableStore.delete(channelUpgradePath(portIdentifier, channelIdentifier))
-  privateStore.delete(channelCounterpartyUpgradeTimeout(portIdentifier, channelIdentifier))
+  privateStore.delete(counterpartyUpgradeTimeout(portIdentifier, channelIdentifier))
   privateStore.delete(counterpartyNextPacketSendSequencePath(portIdentifier, channelIdentifier))
 
   // call modules onChanUpgradeRestore callback

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -297,7 +297,7 @@ function isCompatibleUpgradeFields(
 // startFlushUpgradeHandshake will verify that the channel
 // is in a valid precondition for calling the startFlushUpgradeHandshake.
 // it will set the channel to flushing state.
-// it will store the nextPacketSendSequence and upgrade timeout in the upgrade state.
+// it will store the nextSequenceSend and upgrade timeout in the upgrade state.
 function startFlushUpgradeHandshake(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
@@ -314,10 +314,10 @@ function startFlushUpgradeHandshake(
   // either timeout height or timestamp must be non-zero
   abortTransactionUnless(upgradeTimeout.timeoutHeight != 0 || upgradeTimeout.timeoutTimestamp != 0)
 
-  nextPacketSendSequence = provableStore.get(nextSequenceSendPath(portIdentifier, channelIdentifier))
+  nextSequenceSend = provableStore.get(nextSequenceSendPath(portIdentifier, channelIdentifier))
 
   upgrade.timeout = upgradeTimeout
-  upgrade.nextPacketSend = nextPacketSendSequence
+  upgrade.nextPacketSend = nextSequenceSend
   
   // store upgrade in public store for counterparty proof verification
   provableStore.set(channelPath(portIdentifier, channelIdentifier), channel)
@@ -344,7 +344,7 @@ function openUpgradeHandshake(
   // the recv and ack sequences appropriately
   if channel.order == "UNORDERED" && upgrade.fields.ordering == "ORDERED" {
     selfNextSequenceSend = provableStore.get(nextSequenceSendPath(portIdentifier, channelIdentifier))
-    counterpartyNextSequenceSend = privateStore.get(counterpartyNextPacketSendSequencePath(portIdentifier, channelIdentifier))
+    counterpartyNextSequenceSend = privateStore.get(counterpartyNextSequenceSendPath(portIdentifier, channelIdentifier))
 
     // set nextSequenceRecv to the counterpartyNextSequenceSend since all packets were flushed
     provableStore.set(nextSequenceRecvPath(portIdentifier, channelIdentifier), counterpartyNextSequenceSendSeq)
@@ -375,7 +375,7 @@ function openUpgradeHandshake(
   // delete auxiliary state
   provableStore.delete(channelUpgradePath(portIdentifier, channelIdentifier))
   privateStore.delete(counterpartyUpgradeTimeout(portIdentifier, channelIdentifier))
-  privateStore.delete(counterpartyNextPacketSendSequencePath(portIdentifier, channelIdentifier))
+  privateStore.delete(counterpartyNextSequenceSendPath(portIdentifier, channelIdentifier))
 }
 ```
 
@@ -402,7 +402,7 @@ function restoreChannel(
   // delete auxiliary state
   provableStore.delete(channelUpgradePath(portIdentifier, channelIdentifier))
   privateStore.delete(counterpartyUpgradeTimeout(portIdentifier, channelIdentifier))
-  privateStore.delete(counterpartyNextPacketSendSequencePath(portIdentifier, channelIdentifier))
+  privateStore.delete(counterpartyNextSequenceSendPath(portIdentifier, channelIdentifier))
 
   // call modules onChanUpgradeRestore callback
   module = lookupModule(portIdentifier)

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -160,7 +160,7 @@ function verifyChannelUpgrade(
 
 #### CounterpartyNextSequenceSend Path
 
-The chain must store the counterparty's next sequence send on `startFlushUpgradeHandshake`. This will be stored in the `counterpartyNextSequenceSend` path on the private store.
+The chain must store the counterparty's next sequence send on `chanUpgradeAck` and chanUpgradeConfirm. This will be stored in the `counterpartyNextSequenceSend` path on the private store.
 
 ```typescript
 function counterpartyNextSequenceSendPath(portIdentifier: Identifier, channelIdentifier: Identifier): Path {
@@ -748,6 +748,7 @@ function chanUpgradeAck(
   } else {
     privateStore.set(counterpartyUpgradeTimeout(portIdentifier, channelIdentifier), timeout)
   }
+  privateStore.set(counterpartyNextSequenceSend(portIdentifier, channelIdentifier), counterpartyUpgrade.nextPacketSend)
 
   provableStore.set(channelPath(portIdentifier, channelIdentifier), channel)
 
@@ -843,6 +844,7 @@ function chanUpgradeConfirm(
   } else {
     privateStore.set(counterpartyUpgradeTimeout(portIdentifier, channelIdentifier), timeout)
   }
+  privateStore.set(counterpartyNextSequenceSend(portIdentifier, channelIdentifier), counterpartyUpgrade.nextPacketSend)
 
   // if both chains are already in flushcomplete we can move to OPEN
   if (channel.state == FLUSHCOMPLETE && counterpartyChannelState == FLUSHCOMPLETE) {

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -160,7 +160,7 @@ function verifyChannelUpgrade(
 
 #### CounterpartyUpgrade Path
 
-The chain must store the counterpartyUpgrade on `chanUpgradeAck` and `chanUpgradeConfirm`. This will be stored in the `counterpartyUpgrade` path on the private store.
+The chain must store the counterparty upgrade on `chanUpgradeAck` and `chanUpgradeConfirm`. This will be stored in the `counterpartyUpgrade` path on the private store.
 
 ```typescript
 function counterpartyUpgradePath(portIdentifier: Identifier, channelIdentifier: Identifier): Path {

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -297,7 +297,7 @@ function isCompatibleUpgradeFields(
 // startFlushUpgradeHandshake will verify that the channel
 // is in a valid precondition for calling the startFlushUpgradeHandshake.
 // it will set the channel to flushing state.
-// it will store the counterparty's nextPacketSendSequence and upgrade timeout in the upgrade state.
+// it will store the nextPacketSendSequence and upgrade timeout in the upgrade state.
 function startFlushUpgradeHandshake(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -364,6 +364,14 @@ function openUpgradeHandshake(
   channel.state = OPEN
   provableStore.set(channelPath(portIdentifier, channelIdentifier), channel)
 
+  // IMPLEMENTATION DETAIL: Implementations may choose to prune stale acknowledgements and receipts at this stage
+  // Since flushing has completed, any acknowledgement or receipt written before the chain went into flushing has
+  // already been processed by the counterparty can be removed.
+  // Implementatins may do this pruning work over multiple blocks for gas reasons. In this case, they should be sure
+  // to only prune stale acknowledgements/receipts and not new ones that have been written after the channel has reopened.
+  // Implementations may use the counterparty NextSequenceSend as a way to determine which acknowledgement/receipts
+  // were already processed by counterparty when flushing completed
+
   // delete auxiliary state
   provableStore.delete(channelUpgradePath(portIdentifier, channelIdentifier))
   privateStore.delete(counterpartyUpgradeTimeout(portIdentifier, channelIdentifier))


### PR DESCRIPTION
Closes: #1060 
Closes: #1061 

- Add NextSequenceSend field to upgrade struct
- Add path for counterpartyNextSequenceSend in private store
- Correctly set packet recv and ack sequences if order has changed
- Defensive check on RecvPacket
- Comment detailing implementation details for pruning