### PR TITLE
fix: update spec organisation for CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All standards at or past the "Draft" stage are listed here in order of their ICS
 | ---------------------------------------- | -------------------------- | ----- | ------------- |
 | [1](spec/ics-001-ics-standard/README.md) | ICS Specification Standard | N/A   | Protocol team |
 
-### Transport/Core
+### Core Transport 
 
 | Interchain Standard Number                                    | Standard Title             | Stage     | Implementations | Maintainer    |
 | ------------------------------------------------------------- | -------------------------- | --------- | --------------- | ------------- |
@@ -39,7 +39,7 @@ All standards at or past the "Draft" stage are listed here in order of their ICS
 | [26](spec/core/ics-026-routing-module/README.md)              | Routing Module             | Candidate | [ibc-go](https://github.com/cosmos/ibc-go), [ibc-rs](https://github.com/cosmos/ibc-rs) | Protocol team |
 | [33](spec/core/ics-033-multi-hop/README.md)                   | Multi-hop Messaging        | Candidate | [ibc-go](https://github.com/cosmos/ibc-go) | Protocol team |
 
-### Client
+### Light Clients
 
 | Interchain Standard Number                                      | Standard Title             | Stage | Implementations | Maintainer    |
 | --------------------------------------------------------------- | -------------------------- | ----- | --------------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All standards at or past the "Draft" stage are listed here in order of their ICS
 | ---------------------------------------- | -------------------------- | ----- | ------------- |
 | [1](spec/ics-001-ics-standard/README.md) | ICS Specification Standard | N/A   | Protocol team |
 
-### Core
+### Transport/Core
 
 | Interchain Standard Number                                    | Standard Title             | Stage     | Implementations | Maintainer    |
 | ------------------------------------------------------------- | -------------------------- | --------- | --------------- | ------------- |


### PR DESCRIPTION
I went thru a few different configurations and ultimately think this is the easiest way to ask for the CTA. If people integrate just these Transport/Core standards, they should be able to interoperate w IBC regardless of what their underlying client/relayer impl looks like, this is why I didn't add those in. 

We want people to contribute to specific client/relayer impl if they wish as well, but those are not essential for interoperability, as the 02-client, 03-connection, 04-channel etc etc specs are. 