### PR TITLE
Remove double call to restore callback.

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -1038,15 +1038,6 @@ function timeoutChannelUpgrade(
   // we must restore the channel since the timeout verification has passed
   // error receipt is written for this sequence, counterparty can call cancelUpgradeHandshake
   restoreChannel(portIdentifier, channelIdentifier)
-
-  // call modules onChanUpgradeRestore callback
-  module = lookupModule(portIdentifier)
-  // restore callback must not return error since counterparty 
-  // successfully restored previous channelEnd
-  module.onChanUpgradeRestore(
-    portIdentifier,
-    channelIdentifier
-  )
 }
 ```
 


### PR DESCRIPTION
this is called in `restoreChannel` so appears this wasn't removed during a refactor.