### PR TITLE
fix: allow recv packet when channel state is flush complete

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -826,7 +826,7 @@ function recvPacket(
 
     channel = provableStore.get(channelPath(packet.destPort, packet.destChannel))
     abortTransactionUnless(channel !== null)
-    abortTransactionUnless(channel.state === OPEN || (channel.state === FLUSHING))
+    abortTransactionUnless(channel.state === OPEN || (channel.state === FLUSHING) || (channel.state === FLUSHCOMPLETE))
     counterpartyUpgrade = privateStore.get(counterpartyUpgradePath(packet.destPort, packet.destChannel))
     // defensive check that ensures chain does not process a packet higher than the last packet sent before
     // counterparty went into FLUSHING mode. If the counterparty is implemented correctly, this should never abort


### PR DESCRIPTION
Found during review of https://github.com/cosmos/ibc-go/pull/5668.