### PR TITLE
ICS4: write error receipt on existing upgrade attempt if we are reinitializing

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -462,6 +462,17 @@ function chanUpgradeInit(
   // chanUpgradeInit may only be called by addresses authorized by executing chain
   abortTransactionUnless(isAuthorizedUpgrader(msgSender))
 
+  // write error receipt for previous upgrade attempt if it exists, so counterparty can abort it and
+  // move to next upgrade
+  existingUpgrade = provableStore.get(channelUpgradePath(portIdentifier, channelIdentifier))
+  if existingUpgrade != null {
+    errorReceipt = ErrorReceipt{
+      channel.upgradeSequence,
+      "abort the previous upgrade attempt so counterparty can accept the new one", // constant string changeable by implementation
+    }
+    provableStore.set(channelUpgradeErrorPath(portIdentifier, channelIdentifier), errorReceipt)
+  }
+
   upgradeSequence = initUpgradeHandshake(portIdentifier, channelIdentifier, proposedUpgradeFields)
 
   // call modules onChanUpgradeInit callback

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -462,10 +462,11 @@ function chanUpgradeInit(
   // chanUpgradeInit may only be called by addresses authorized by executing chain
   abortTransactionUnless(isAuthorizedUpgrader(msgSender))
 
-  // write error receipt for previous upgrade attempt if it exists, so counterparty can abort it and
-  // move to next upgrade
+  // if a previous upgrade attempt exists, then delete it and write error receipt, so
+  // counterparty can abort it and move to next upgrade
   existingUpgrade = provableStore.get(channelUpgradePath(portIdentifier, channelIdentifier))
   if existingUpgrade != null {
+    provableStore.delete(channelUpgradePath(portIdentifier, channelIdentifier))
     errorReceipt = ErrorReceipt{
       channel.upgradeSequence,
       "abort the previous upgrade attempt so counterparty can accept the new one", // constant string changeable by implementation


### PR DESCRIPTION
Writes error receipt for previous upgrade attempt if we initialize a new one. This allows the counterparty to cancel their upgrade and retry on the latest attempt