### PR TITLE
ICS4: fix off-by-one error in non-crossing-hello case

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -553,9 +553,9 @@ function chanUpgradeTry(
     expectedUpgradeSequence = channel.UpgradeSequence
   } else {
     // at the end of the TRY step, the current upgrade sequence will be incremented in the non-crossing
-		// hello case due to calling chanUpgradeInit, we should use this expected upgrade sequence for
-		// sequence mismatch comparison
-		expectedUpgradeSequence = channel.UpgradeSequence + 1
+    // hello case due to calling chanUpgradeInit, we should use this expected upgrade sequence for
+    // sequence mismatch comparison
+    expectedUpgradeSequence = channel.UpgradeSequence + 1
   }
 
   // NON CROSSING HELLO CASE:


### PR DESCRIPTION
If on TRY, the sequence is the same but the upgrade doesn't exist. Then the counterparty upgrade is stale so we must write upgrade error for that sequence