### PR TITLE
fix: use port ID and channel ID as inputs of the escrow address generation

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -135,7 +135,7 @@ function onChanOpenInit(
   // as the version for this channel
   abortTransactionUnless(version === "ics20-1" || version === "")
   // allocate an escrow address
-  channelEscrowAddresses[channelIdentifier] = newAddress()
+  channelEscrowAddresses[channelIdentifier] = newAddress(portIdentifier, channelIdentifier)
   return "ics20-1", nil
 }
 ```
@@ -154,7 +154,7 @@ function onChanOpenTry(
   // assert that version is "ics20-1"
   abortTransactionUnless(counterpartyVersion === "ics20-1")
   // allocate an escrow address
-  channelEscrowAddresses[channelIdentifier] = newAddress()
+  channelEscrowAddresses[channelIdentifier] = newAddress(portIdentifier, channelIdentifier)
   // return version that this chain will use given the
   // counterparty version
   return "ics20-1", nil


### PR DESCRIPTION
Fixes one item mentioned in https://github.com/cosmos/ibc-go/issues/65:

> Spec uses undefined newAddress() in [onChanOpenInit](https://github.com/cosmos/ics/tree/eb31a56467a48cd7eb4c2232705ad0fc632f9a19/spec/ics-020-fungible-token-transfer#routing-module-callbacks) and onChanOpenTry and stores it in a map under the channel id. Code uses a deterministic function of the portID and channelID, ie. newAddress(portID, channelID). With crossing-hellos we could have a safety problem according to this spec as we can execute onChanOpenInit (creates escrow address E1), then createOutgoingPacket using E1, then onChanOpenTry we creates a new escrow address E2 that replaces E1, so money is gone. It seems that at code level we don't have this problem as implementation does not follow spec, i.e., it generates escrow account based on portId/channelID. But if someone follows the spec, then we have safety problem.