### PR TITLE
ics27: host fills its own connection ID in metadata

### DIFF
--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -472,6 +472,12 @@ function onChanOpenTry(
   SetInterchainAccountAddress(counterpartyPortIdentifier, connectionId, address)
 
   cpMetadata = UnmarshalJSON(counterpartyVersion)
+  // it's not mandatory for the controller to fill in the host connection ID, since
+  // it could not be possible for it to know it. ibc-go's implementation of the
+  // controller does fill it in, but an CosmWasm controller implementation would
+  // not be able. For that reason, the host fills in here its own connection ID.
+  cpMetadata.HostConnectionId = connectionId
+
   abortTransactionUnless(cpMetadata.Version === "ics27-1")
   // If encoding or txType requested by initializing chain is not supported by host chain then
   // fail handshake and abort transaction


### PR DESCRIPTION
Update ICS 27 spec for [this change in ibc-go](https://github.com/cosmos/ibc-go/pull/5533/files#diff-0af39e5e94b598423a42ea2db6d5611a6c3ab78d653d048bf0a89e9cb2aa7bf1).