### PR TITLE
Fix typos

### DIFF
--- a/spec/app/ics-100-atomic-swap/README.md
+++ b/spec/app/ics-100-atomic-swap/README.md
@@ -235,7 +235,7 @@ function makeSwap(request: MakeSwapMsg, packet: channelTypes.Packet) {
   // locks the sellToken to the escrow account
   const err = bank.sendCoins(request.makerAddress, escrowAddr, request.sellToken.amount, request.sellToken.denom)
   abortTransactionUnless(err === null)
-  // contructs the IBC data packet
+  // constructs the IBC data packet
   const packet = {
     type: SwapMessageType.TYPE_MSG_MAKE_SWAP,
     data: protobuf.encode(request), // encode the request message to protobuf bytes
@@ -451,7 +451,7 @@ function onRecvPacket(packet channeltypes.Packet) {
   
   switch swapPacket.type {
     case TYPE_MSG_MAKE_SWAP:
-      const makeMsg = protobuf.decode(swapPaket.data)
+      const makeMsg = protobuf.decode(swapPacket.data)
         
       // check if buyToken is a valid token on the taker chain, could be either native or ibc token
       const supply = bank.getSupply(makeMsg.buyToken.denom)
@@ -470,7 +470,7 @@ function onRecvPacket(packet channeltypes.Packet) {
       }
       break;
     case TYPE_MSG_TAKE_SWAP:
-      const takeMsg = protobuf.decode(swapPaket.data)
+      const takeMsg = protobuf.decode(swapPacket.data)
       const order = privateStore.get(takeMsg.orderId)
       abortTransactionUnless(order !== null)
       abortTransactionUnless(order.status === Status.SYNC) 
@@ -495,7 +495,7 @@ function onRecvPacket(packet channeltypes.Packet) {
       privateStore.set(takeMsg.orderId, order)
       break;
     case TYPE_MSG_CANCEL_SWAP:
-      const cancelMsg = protobuf.decode(swapPaket.data)
+      const cancelMsg = protobuf.decode(swapPacket.data)
       const order = privateStore.get(cancelMsg.orderId)
       abortTransactionUnless(order !== null)
       abortTransactionUnless(order.status === Status.SYNC || order.status == Status.INITIAL)
@@ -528,12 +528,12 @@ function onAcknowledgePacket(
     refundTokens(packet) 
   } else {
     
-    const swapPaket: AtomicSwapPacketData = protobuf.decode(packet.data)
+    const swapPacket: AtomicSwapPacketData = protobuf.decode(packet.data)
     const escrowAddr = escrowAddress(packet.sourcePort, packet.sourceChannel)
     
-    switch swapPaket.type {
+    switch swapPacket.type {
       case TYPE_MSG_MAKE_SWAP:
-        const makeMsg = protobuf.decode(swapPaket.data)
+        const makeMsg = protobuf.decode(swapPacket.data)
         
         // update order status on the maker chain.
         const order = privateStore.get(generateOrderId(packet))
@@ -542,7 +542,7 @@ function onAcknowledgePacket(
         privateStore.set(order.id, order)
         break;
       case TYPE_MSG_TAKE_SWAP:
-        const takeMsg = protobuf.decode(swapPaket.data)
+        const takeMsg = protobuf.decode(swapPacket.data)
         
         // update order status on the taker chain.
         const order = privateStore.get(takeMsg.orderId)
@@ -557,7 +557,7 @@ function onAcknowledgePacket(
         
         break;
       case TYPE_MSG_CANCEL_SWAP:
-        const cancelMsg = protobuf.decode(swapPaket.data)
+        const cancelMsg = protobuf.decode(swapPacket.data)
         
         // update order status on the maker chain.
         const order = privateStore.get( cancelMsg.orderId )
@@ -595,7 +595,7 @@ function refundTokens(packet: Packet) {
   const escrowAddr = escrowAddress(packet.sourcePort, packet.sourceChannel)
   
   // send tokens from module to message sender
-  switch swapPaket.type {
+  switch swapPacket.type {
     case TYPE_MSG_MAKE_SWAP:
       const msg = protobuf.decode(swapPacket.data)
       bank.sendCoins(escrowAddr, msg.makerAddress, msg.sellToken.amount, msg.sellToken.denom)


### PR DESCRIPTION
In the README.md of ibc/blob/main/spec/app/ics-100-atomic-swap/README.md, 'constructs' misspelt as 'contructs', 'Packet' misspelt as 'Paket'.