### PR TITLE
ICS20v2 path forwarding: simplify revert in-flight changes

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -526,6 +526,14 @@ function onRecvPacket(packet: Packet) {
 function onAcknowledgePacket(
   packet: Packet,
   acknowledgement: bytes) {
+  // if the transfer failed, refund the tokens
+  // to the sender account. In case of a packet sent for a
+  // forwarded packet, the sender is the forwarding
+  // address for the destination channel of the forwarded packet.
+  if !(acknowledgement.success) {
+    refundTokens(packet)
+  }
+
   // check if the packet that was sent is from a previously forwarded packet
   prevPacket = privateStore.get(packetForwardPath(packet.sourcePort, packet.sourceChannel, packet.sequence))
 
@@ -548,11 +556,6 @@ function onAcknowledgePacket(
         ack,
       )
     }
-  } else {
-    // if the transfer failed, refund the tokens
-    if !(acknowledgement.success) {
-      refundTokens(packet)
-    }
   }
 }
 ```
@@ -561,6 +564,12 @@ function onAcknowledgePacket(
 
 ```typescript
 function onTimeoutPacket(packet: Packet) {
+  // the packet timed-out, so refund the tokens
+  // to the sender account. In case of a packet sent for a
+  // forwarded packet, the sender is the forwarding
+  // address for the destination channel of the forwarded packet.
+  refundTokens(packet)
+
   // check if the packet sent is from a previously forwarded packet
   prevPacket = privateStore.get(packetForwardPath(packet.sourcePort, packet.sourceChannel, packet.sequence))
 
@@ -575,9 +584,6 @@ function onTimeoutPacket(packet: Packet) {
       prevPacket,
       ack,
     )
-  } else {
-    // the packet timed-out, so refund the tokens
-    refundTokens(packet)
   }
 }
 ```
@@ -635,39 +641,26 @@ function refundTokens(packet: Packet) {
 ```
 
 ```typescript
-// revertInFlightChanges reverts the receive packet and send packet
+// revertInFlightChanges reverts the receive packet
 // that occurs in the middle chains during a packet forwarding
 // If an error occurs further down the line, the state changes
 // on this chain must be reverted before sending back the error acknowledgement
 // to ensure atomic packet forwarding
 function revertInFlightChanges(sentPacket: Packet, receivedPacket: Packet) {
-  forwardEscrow = channelEscrowAddresses[sentPacket.sourceChannel]
+  forwardingAddress = channelForwardingAddress[receivedPacket.destinationChannel]
   reverseEscrow = channelEscrowAddresses[receivedPacket.destChannel]
+
   // the token on our chain is the token in the sentPacket
   for token in sentPacket.tokens {
-    // check if the packet we sent out was sending as source or not
-    // in this case we escrowed the outgoing tokens
-    if isSource(sentPacket.sourcePort, sentPacket.sourceChannel, token) {
-      // check if the packet we received was a source token for our chain
-      if isSource(receivedPacket.destinationPort, receivedPacket.desinationChannel, token) {
-        // receive sent tokens from the received escrow to the forward escrow account
-        // so we must send the tokens back from the forward escrow to the original received escrow account
-        bank.TransferCoins(forwardEscrow, reverseEscrow, token.denom, token.amount)
-      } else {
-        // receive minted vouchers and sent to the forward escrow account
-        // so we must remove the vouchers from the forward escrow account and burn them
-        bank.BurnCoins(forwardEscrow, token.denom, token.amount)
-      }
+    // check if the packet we received was a source token for our chain
+    if isSource(receivedPacket.destinationPort, receivedPacket.desinationChannel, token) {
+      // receive sent tokens from the received escrow account to the forwarding account
+      // so we must send the tokens back from the forwarding account to the received escrow account
+      bank.TransferCoins(forwardingAddress, reverseEscrow, token.denom, token.amount)
     } else {
-      // in this case we burned the vouchers of the outgoing packets
-      // check if the packet we received was a source token for our chain
-      // in this case, the tokens were unescrowed from the reverse escrow account
-      if isSource(receivedPacket.destinationPort, receivedPacket.desinationChannel, token) {
-        // in this case we must mint the burned vouchers and send them back to the escrow account
-        bank.MintCoins(reverseEscrow, token.denom, token.amount)
-      }
-      // if it wasn't a source token on receive, then we simply had minted vouchers and burned them in the receive.
-      // So no state changes were made, and thus no reversion is necessary
+      // receive minted vouchers and sent to the forwarding account
+      // so we must burn the vouchers from the forwarding account
+      bank.BurnCoins(forwardingAddress, token.denom, token.amount)
     }
   }
 }

--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -647,7 +647,7 @@ function refundTokens(packet: Packet) {
 // on this chain must be reverted before sending back the error acknowledgement
 // to ensure atomic packet forwarding
 function revertInFlightChanges(sentPacket: Packet, receivedPacket: Packet) {
-  forwardingAddress = channelForwardingAddress[receivedPacket.destinationChannel]
+  forwardingAddress = channelForwardingAddress[receivedPacket.destChannel]
   reverseEscrow = channelEscrowAddresses[receivedPacket.destChannel]
 
   // the token on our chain is the token in the sentPacket


### PR DESCRIPTION
Following up on the discussion from the walkthrough, it does seem like we can simplify the logic of `revertInflightChanges` ([I actually had also hinted that to Aditya when I first reviewed the spec...](https://github.com/cosmos/ibc/pull/1090#discussion_r1552390936))

To make it easier for everyone to reason about this (although please double check that I haven't made any mistake), the following outlines what happens with the escrow accounts and forwarding account assuming that there is a timeout or error ack and changes on the middle hop need to be reverted. The `receivedPacket` is the received packet on the middle hop and the `sentPacket` is the packet sent from the middle hop as a result of forwarding.

### Scenario 1 (source when receiving, source when sending)

- receive packet as source of tokens:
transfer tokens `escrow[receivedPacket.destinationChannel]` -> `forwarding[receivedPacket.destinationChannel]`
- send packet as source of tokens:
transfer tokens `forwarding[receivedPacket.destinationChannel]` -> `escrow[sentPacket.sourceChannel]`
- refund packet tokens:
transfer tokens `escrow[sentPacket.sourceChannel]` -> `forwarding[receivedPacket.destinationChannel]`
- revert in-flight changes:
transfer tokens `forwarding[receivedPacket.destinationChannel]` -> `escrow[receivedPacket.destinationChannel]`

### Scenario 2 (source when receiving, not source when sending)

- receive packet as source of tokens:
transfer tokens `escrow[receivedPacket.destinationChannel]` -> `forwarding[receivedPacket.destinationChannel]`
- send packet as not source of tokens:
burn tokens `forwarding[receivedPacket.destinationChannel]`
- refund packet tokens;
mint tokens `forwarding[receivedPacket.destinationChannel]`
- revert in-flight changes;
transfer tokens `forwarding[receivedPacket.destinationChannel]` -> `escrow[receivedPacket.destinationChannel]`

### Scenario 3 (not source when receiving, source when sending)

- receive packet as not source of tokens:
mint vouchers `forwarding[receivedPacket.destinationChannel]`
- send packet as source of tokens:
transfer vouchers `forwarding[receivedPacket.destinationChannel]` -> `escrow[sentPacket.sourceChannel]`
- refund packet tokens:
transfer vouchers `escrow[sentPacket.sourceChannel]` -> `forwarding[receivedPacket.destinationChannel]`
- revert in-flight changes:
burn vouchers `forwarding[receivedpacket.destinationChannel]`

### Scenario 4 (not source when receiving, not source when sending)

- receive packet as not source of tokens:
mint vouchers `forwarding[receivedPacket.destinationChannel]`
- send packet as not source of tokens:
burn vouchers `forwarding[receivedPacket.destinationChannel]`
- refund packet tokens:
mint vouchers `forwarding[receivedPacket.destinationChannel]`
- revert in-flight changes:
burn vouchers `forwarding[receivedpacket.destinationChannel]`