### PR TITLE
imp: clarify that 23-commitments must be lexographically ordered to maintain soundness

### DIFF
--- a/spec/core/ics-023-vector-commitments/README.md
+++ b/spec/core/ics-023-vector-commitments/README.md
@@ -249,6 +249,8 @@ For any prefix `prefix` and any path `path` not set in the commitment `acc`, for
 Probability(verifyMembership(root, proof, applyPrefix(prefix, path), value) === true) negligible in k
 ```
 
+To ensure the commitment proofs are *sound*, the commitment must be lexographically ordered to ensure that non-existence proofs of the key `b` may be proven by showing the existence of key `a` and key `c` in addition to proving that these two keys are neightbors in the commitment. 
+
 #### Position binding
 
 Commitment proofs MUST be *position binding*: a given commitment path can only map to one value, and a commitment proof cannot prove that the same path opens to a different value except with probability negligible in k.


### PR DESCRIPTION
As per audit