### PR TITLE
fix: add missing annotations to Wasm client spec

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -6,4 +6,3 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
-

--- a/spec/client/ics-008-wasm-client/README.md
+++ b/spec/client/ics-008-wasm-client/README.md
@@ -513,7 +513,9 @@ pub struct UpdateStateMsg {
 
 #[cw_serde]
 pub struct CheckSubstituteAndUpdateStateMsg {
-  substitute_client_msg: Vec<u8>,
+  #[schemars(with = "String")]
+  #[serde(with = "Base64", default)]
+  pub substitute_client_msg: Vec<u8>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Description

Fixed formatting inconsistencies in the Wasm client specification:

1. Added missing annotations to `CheckSubstituteAndUpdateStateMsg` struct in `spec/client/ics-008-wasm-client/README.md`:
   - Added `#[schemars(with = "String")]` annotation
   - Added `#[serde(with = "Base64", default)]` annotation
   - Added `pub` modifier to the field

2. Removed trailing empty lines in `.github/workflows/link-check.yml`

## Type of change

- [x] Bug fix (non-breaking change which fixes formatting issues)

## Testing

No testing required as these are documentation-only changes.