### PR TITLE
docs: fix undefined `header` in `updateState`

### DIFF
--- a/spec/client/ics-009-loopback-cilent/README.md
+++ b/spec/client/ics-009-loopback-cilent/README.md
@@ -127,7 +127,7 @@ function updateState(clientMsg: clientMessage) {
 
   // retrieve the latest height from the local ledger
   height = getSelfHeight()
-  clientState.latestHeight = header.height
+  clientState.latestHeight = height
 
   // save the client state
   provableStore.set("clients/{clientMsg.identifier}/clientState", clientState)


### PR DESCRIPTION
While reviewing the `updateState` function in the Loopback Client spec, I noticed that `header.height` is used, but `header` is never defined. However, just above, `height = getSelfHeight()` correctly retrieves the height of the local ledger.  

This change replaces `header.height` with `height`, ensuring that the function uses the properly initialized variable.