### PR TITLE
[E2E harness 2/4] Add runtime

### DIFF
--- a/link/harness/AGENTS.md
+++ b/link/harness/AGENTS.md
@@ -1,0 +1,21 @@
+# E2E Harness Development Guide for AI Agents
+
+This module is the black-box e2e harness for IBC Link. It observes the `ibc` binary only through
+its public wire surface — CLI commands with JSON output, config YAML, and the status API — and
+corroborates outcomes by reading chain state with its own clients.
+
+- **The wall:** this module never imports `link/internal/...` or the stub's guts. Its go.mod has no
+  requirement on the link module; keep it that way. The single declaration of the wire contract is
+  `ibclink/wire`.
+- **Two wait primitives only.** `onchain.Await` for effect waits (budget-bounded, retries through
+  transient probe errors); `internal/poll.Until` for launch-side readiness (aborts on the first
+  probe error). Never hand-roll a ticker loop; never sleep. Every wait budget derives from the
+  chain's `topology.TimingProfile`, never a literal tuned to instant Anvil. The one deliberate
+  exception is `wait.go`'s `waitPacketStable`, a stability assertion — the condition must hold at
+  every sample across the settle window, so it is not a wait-until and fits neither primitive.
+- **Docker discipline.** Containers/networks carry the `ibc-link-e2e=true` and
+  `ibc-link-run=<runid>` labels and the `ibc-link-e2e-` name prefix, with pinned images. Anvil runs
+  with `--entrypoint anvil` (PID 1, so `docker stop`'s SIGTERM reaches it and it dumps its
+  `--state` file — what makes StopNode/StartNode fault injection survive restarts). Don't
+  reintroduce a shell-wrapped entrypoint.
+- Lint with `make lint-e2e` from `link/`; both e2e modules use the root `.golangci.yml`.

--- a/link/harness/assert_test.go
+++ b/link/harness/assert_test.go
@@ -1,0 +1,68 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+func twoChainTopology() topology.Topology {
+	return topology.Topology{
+		Name: "test",
+		Chains: []topology.ChainSpec{
+			{Chain: wire.Chain{ID: "chain-a"}},
+			{Chain: wire.Chain{ID: "chain-b"}},
+		},
+	}
+}
+
+func TestAssertChainsConnected(t *testing.T) {
+	topo := twoChainTopology()
+
+	ready := wire.Readiness{ChainsConnected: []string{"chain-a", "chain-b"}}
+	require.NoError(t, assertChainsConnected(ready, topo))
+
+	partial := wire.Readiness{ChainsConnected: []string{"chain-a"}}
+	err := assertChainsConnected(partial, topo)
+	require.ErrorContains(t, err, "did not connect to chain chain-b")
+}
+
+func TestAssertDeploymentMatchesTopology(t *testing.T) {
+	topo := twoChainTopology()
+
+	full := &wire.Deployment{Chains: map[string]wire.ChainDeployment{"chain-a": {}, "chain-b": {}}}
+	require.NoError(t, assertDeploymentMatchesTopology(full, topo))
+
+	partial := &wire.Deployment{Chains: map[string]wire.ChainDeployment{"chain-a": {}}}
+	err := assertDeploymentMatchesTopology(partial, topo)
+	require.ErrorContains(t, err, "must report chain chain-b")
+}
+
+func TestTopologySummaryNamesExternalLogGap(t *testing.T) {
+	topo := topology.Topology{
+		Name: "mixed",
+		Chains: []topology.ChainSpec{
+			{
+				Chain:     wire.Chain{ID: "chain-a", ChainID: 31337},
+				Provision: topology.Provision{Mode: topology.ProvisionManaged, Launcher: topology.LauncherAnvil},
+			},
+			{
+				Chain:     wire.Chain{ID: "chain-b", ChainID: 1},
+				Provision: topology.Provision{Mode: topology.ProvisionExternal, RPCURL: "http://10.0.0.1:8545"},
+			},
+		},
+		Config: wire.ConfigYAML{Relayer: wire.Relayer{Routes: []wire.Route{
+			{ID: "r", Source: "chain-a", Destination: "chain-b", Type: wire.RouteEVMToEVMAttested},
+		}}},
+	}
+	// The doctrine under test (AGENTS.md: named gaps, never silent omissions): an external chain's
+	// uncollectable logs are called out in the summary — and only there, so the managed chain's line
+	// carries no such marker. Wording beyond the marker is not contract.
+	summary := topologySummary(topo)
+	require.Equal(t, 1, strings.Count(summary, "(logs unavailable)"),
+		"exactly the external chain is gap-marked")
+}

--- a/link/harness/chains.go
+++ b/link/harness/chains.go
@@ -1,0 +1,83 @@
+package harness
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cosmos/ibc/link/harness/chain"
+	"github.com/cosmos/ibc/link/harness/chain/evm"
+	"github.com/cosmos/ibc/link/harness/provision"
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+// Chains is the registry of one run's provisioned chains, keyed by logical chain id. Each entry carries
+// the chain handle, its resolved timing profile, and its lifecycle hooks — the per-chain runtime state,
+// as opposed to the run-wide state (driver, bundle, workspace) the Harness holds.
+type Chains struct {
+	list []provision.Provisioned // start order; teardown stops in reverse
+	byID map[string]provision.Provisioned
+}
+
+// newChains indexes the provisioned list by chain id. Uniqueness is guaranteed upstream
+// (provision.Start rejects duplicate ids before launching anything).
+func newChains(list []provision.Provisioned) *Chains {
+	byID := make(map[string]provision.Provisioned, len(list))
+	for _, p := range list {
+		byID[p.Chain.ID()] = p
+	}
+	return &Chains{list: list, byID: byID}
+}
+
+// Get returns the chain with id, or a clear error when id names no chain in the run — never a nil
+// interface a caller could deref.
+func (c *Chains) Get(id string) (chain.Chain, error) {
+	p, ok := c.byID[id]
+	if !ok {
+		return nil, fmt.Errorf("harness: no chain %q", id)
+	}
+	return p.Chain, nil
+}
+
+// EVM returns chain id's concrete EVM client (the evm.ClientProvider capability), or an error if the
+// chain is missing or not EVM-family.
+func (c *Chains) EVM(id string) (*evm.EVMClient, error) {
+	ch, err := c.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	ec, ok := evm.FromChain(ch)
+	if !ok {
+		return nil, fmt.Errorf("harness: chain %q is not an EVM chain", id)
+	}
+	return ec, nil
+}
+
+// Profile returns the resolved timing profile for id — the budget source for every wait observing that
+// chain. An unknown id is a programmer error (every path here resolves the id through Get, the
+// deployment, or the topology first), so it panics rather than substituting a default: a silently
+// wrong profile is worse than a loud failure, since a too-short settle window can green a stability
+// check the observed chain's real cadence would fail.
+func (c *Chains) Profile(id string) topology.TimingProfile {
+	p, ok := c.byID[id]
+	if !ok {
+		panic(
+			fmt.Sprintf(
+				"harness: Profile(%q): no such chain — every wait budget must derive from a provisioned chain's resolved profile",
+				id,
+			),
+		)
+	}
+	return p.Profile
+}
+
+// stopAll stops every chain in reverse start order, joining any stop errors.
+func (c *Chains) stopAll() error {
+	var errs []error
+	for i := len(c.list) - 1; i >= 0; i-- {
+		p := c.list[i]
+		if err := p.Stop(); err != nil {
+			errs = append(errs, fmt.Errorf("stop chain %s: %w", p.Chain.ID(), err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/link/harness/config.go
+++ b/link/harness/config.go
@@ -1,0 +1,30 @@
+package harness
+
+import (
+	"errors"
+
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+// StartConfig configures the harness startup.
+type StartConfig struct {
+	// Topology is the harness environment to start (required).
+	Topology topology.Topology
+
+	// KeepOnClose, if true, leaves the whole world running after Shutdown so a failure can be inspected:
+	// the chains, the workdir (sqlite, compiled config, logs), and the relayer daemon (its pid file in the
+	// workdir names the process to sweep). Diagnostics are still captured and artifacts still written.
+	KeepOnClose bool
+
+	// ArtifactDir is the directory where failure diagnostics are written.
+	// If empty, no artifact file is written.
+	ArtifactDir string
+}
+
+// Validate reports whether the required fields are present.
+func (c StartConfig) Validate() error {
+	if c.Topology.Name == "" {
+		return errors.New("harness: StartConfig.Topology is required")
+	}
+	return nil
+}

--- a/link/harness/diag/bundle.go
+++ b/link/harness/diag/bundle.go
@@ -1,0 +1,152 @@
+// Package diag collects failure diagnostics for a run.
+package diag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+)
+
+// Bundle is the failure-diagnostics collector for one run.
+type Bundle struct {
+	chainLogs  map[string]string // chainID -> captured log text
+	heights    map[string]uint64 // chainID -> last observed height
+	sutLogs    map[string]string // SUT process name -> captured stderr/combined log text
+	statusJSON map[string]string // SUT process name -> captured status API output
+
+	versions   map[string]string // tool/binary -> version string
+	configYAML string            // resolved IBC Link config
+	topology   string            // topology summary
+	deployment string            // rendered deployment metadata (addresses, routes, tx hashes)
+}
+
+// NewBundle creates an empty bundle.
+func NewBundle() *Bundle {
+	return &Bundle{
+		chainLogs:  map[string]string{},
+		heights:    map[string]uint64{},
+		sutLogs:    map[string]string{},
+		statusJSON: map[string]string{},
+		versions:   map[string]string{},
+	}
+}
+
+// AddChainLog records log output for a chain.
+func (b *Bundle) AddChainLog(chainID, log string) {
+	b.chainLogs[chainID] = log
+}
+
+// AddSUTLog records output captured from a SUT invocation (the ibc-link Runner's per-run log, or a
+// daemon instance's combined output — whichever binary the swap ledger routed to), keyed by process
+// name. This is the harness↔SUT boundary's side of the diagnostics: what the black box said on its
+// way to a failure.
+func (b *Bundle) AddSUTLog(name, log string) {
+	b.sutLogs[name] = log
+}
+
+// AddStatus records the status-API output captured from a daemon on failure — the better signal for
+// pending packets, alongside the on-chain heights. Keyed by daemon name so a restart's second
+// instance does not overwrite the first.
+func (b *Bundle) AddStatus(name, status string) {
+	b.statusJSON[name] = status
+}
+
+// SetHeight records the last observed height of a chain.
+func (b *Bundle) SetHeight(chainID string, h uint64) {
+	b.heights[chainID] = h
+}
+
+// SetVersion records a binary/image version (e.g. "anvil", "go-ethereum", "ibc-link").
+func (b *Bundle) SetVersion(tool, version string) {
+	b.versions[tool] = version
+}
+
+// SetConfig records the resolved IBC Link config the harness compiled — it pins exactly what the stub
+// consumed.
+func (b *Bundle) SetConfig(yaml string) { b.configYAML = yaml }
+
+// SetTopology records a short summary of the topology under test.
+func (b *Bundle) SetTopology(summary string) { b.topology = summary }
+
+// SetDeployment records the stub's reported deployment metadata — per-chain fixture addresses and deploy
+// tx hashes — rendered into a stable block. These are the packet-trace anchors a failure report needs
+// (tx hashes; packet ids/sequences come from the status output and stub logs).
+func (b *Bundle) SetDeployment(d *wire.Deployment) {
+	var sb strings.Builder
+	for _, id := range sortedKeys(d.Chains) {
+		cd := d.Chains[id]
+		fmt.Fprintf(&sb, "  chain %s:", id)
+		for _, name := range sortedKeys(cd.Fixtures) {
+			fmt.Fprintf(&sb, " %s=%s", name, cd.Fixtures[name])
+		}
+		fmt.Fprintf(&sb, " clientId=%s\n", cd.ClientID)
+	}
+	if len(d.TxHashes) > 0 {
+		fmt.Fprintf(&sb, "  txHashes: %s\n", strings.Join(d.TxHashes, ", "))
+	}
+	b.deployment = sb.String()
+}
+
+// String renders the bundle as a single stably-ordered report.
+func (b *Bundle) String() string {
+	var sb strings.Builder
+	sb.WriteString("=== diagnostics bundle ===\n")
+
+	if len(b.versions) > 0 {
+		sb.WriteString("versions:\n")
+		for _, t := range sortedKeys(b.versions) {
+			fmt.Fprintf(&sb, "  %s: %s\n", t, b.versions[t])
+		}
+	}
+
+	if b.topology != "" {
+		fmt.Fprintf(&sb, "topology:\n%s\n", indent(b.topology))
+	}
+
+	if b.deployment != "" {
+		fmt.Fprintf(&sb, "deployment:\n%s", b.deployment)
+	}
+
+	sb.WriteString("heights:\n")
+	for _, id := range sortedKeys(b.heights) {
+		fmt.Fprintf(&sb, "  %s: %d\n", id, b.heights[id])
+	}
+
+	if b.configYAML != "" {
+		fmt.Fprintf(&sb, "--- resolved config ---\n%s\n", b.configYAML)
+	}
+
+	for _, id := range sortedKeys(b.chainLogs) {
+		fmt.Fprintf(&sb, "--- chain %s log ---\n%s\n", id, b.chainLogs[id])
+	}
+
+	for _, name := range sortedKeys(b.sutLogs) {
+		fmt.Fprintf(&sb, "--- sut %s log ---\n%s\n", name, b.sutLogs[name])
+	}
+
+	for _, name := range sortedKeys(b.statusJSON) {
+		fmt.Fprintf(&sb, "--- sut %s status ---\n%s\n", name, b.statusJSON[name])
+	}
+
+	return sb.String()
+}
+
+// indent prefixes each non-empty line with two spaces for a nested section.
+func indent(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, l := range lines {
+		lines[i] = "  " + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/link/harness/diag/bundle_test.go
+++ b/link/harness/diag/bundle_test.go
@@ -1,0 +1,52 @@
+package diag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/ibc/link/harness/fixturekeys"
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+)
+
+// TestBundleRendersAllSections pins the full failure bundle: every section renders. Pure-Go so the
+// every-PR lane guards the rendering without the e2e tag.
+func TestBundleRendersAllSections(t *testing.T) {
+	b := NewBundle()
+
+	b.SetVersion("anvil", "anvil Version: 1.7.1")
+	b.SetVersion("go-ethereum", "v1.16.9")
+	b.SetVersion("ibc-link", "/repo/bin/ibc")
+	b.SetTopology("name=evm-evm-anvil db=sqlite\nroute route-a-to-b: chain-a -> chain-b")
+	b.SetConfig("relayer:\n  routes:\n    - id: route-a-to-b\n")
+	b.SetDeployment(&wire.Deployment{
+		Chains: map[string]wire.ChainDeployment{
+			"chain-a": {Fixtures: map[string]string{
+				fixturekeys.MockIFT: "0xIFT",
+				fixturekeys.MockGMP: "0xGMP",
+				fixturekeys.Counter: "0xCNT",
+			}, ClientID: "client-a-b"},
+		},
+		TxHashes: []string{"0xdeadbeef"},
+	})
+	b.SetHeight("chain-a", 7)
+	b.AddChainLog("chain-a", "anvil log line")
+	b.AddSUTLog("ibc-link-daemon-1", "relayer log line")
+	b.AddStatus("ibc-link-daemon-1", `{"packets":[{"packetId":"p1","sequence":1,"state":"complete"}]}`)
+
+	out := b.String()
+
+	// Every section is present.
+	for _, want := range []string{
+		"versions:", "anvil Version: 1.7.1", "v1.16.9", "/repo/bin/ibc",
+		"topology:", "name=evm-evm-anvil",
+		"deployment:", "0xIFT", "route-a-to-b", "0xdeadbeef",
+		"heights:", "chain-a: 7",
+		"resolved config",
+		"chain chain-a log", "anvil log line",
+		"sut ibc-link-daemon-1 log", "relayer log line",
+		"sut ibc-link-daemon-1 status", `"packetId":"p1"`,
+	} {
+		require.Containsf(t, out, want, "bundle must render %q", want)
+	}
+}

--- a/link/harness/diag/versions.go
+++ b/link/harness/diag/versions.go
@@ -1,0 +1,29 @@
+package diag
+
+import "runtime/debug"
+
+// goEthereumModule is the EVM client dependency whose version the bundle records, so a failure report
+// names which go-ethereum the harness was built against without shelling out.
+const goEthereumModule = "github.com/ethereum/go-ethereum"
+
+// GoEthereumVersion reads the go-ethereum dependency version from the binary's build info (no exec). A
+// replace directive is reported as the replacement's version. Returns "unknown" when build info is
+// unavailable (e.g. a binary built without module info).
+func GoEthereumVersion() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, d := range bi.Deps {
+		if d.Path != goEthereumModule {
+			continue
+		}
+		if d.Replace != nil && d.Replace.Version != "" {
+			return d.Replace.Version
+		}
+		if d.Version != "" {
+			return d.Version
+		}
+	}
+	return "unknown"
+}

--- a/link/harness/gmp.go
+++ b/link/harness/gmp.go
@@ -1,0 +1,211 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/cosmos/ibc/link/harness/chain"
+	"github.com/cosmos/ibc/link/harness/fixturekeys"
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/onchain"
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+// GMP describes one general-message call.
+//
+// Target is a string so the harness surface stays chain-family-agnostic: Prepare canonicalizes it
+// through the destination chain's Reader, and that canonical form is what the source submission carries.
+// Empty keeps the default behavior — the deployed Counter fixture (the canonical GMP target) on the
+// destination chain.
+type GMP struct {
+	Route   string
+	Target  string
+	Payload []byte
+}
+
+// GMPPlan captures the frozen input and pre-submit baseline. Use when submission must happen after setup
+// steps — the GMP analog of IFTPlan.
+type GMPPlan struct {
+	run    *Session
+	in     GMP
+	route  wire.Route
+	before *big.Int
+}
+
+// GMPOutcome is a submitted GMP action plus verification context: the harness-native action the submitter
+// produced, the typed on-chain tracker, and the plan whose frozen input/baseline the Verify methods assert
+// against.
+type GMPOutcome struct {
+	action *onchain.GMPAction
+
+	tracker *onchain.GMPTracker
+	plan    *GMPPlan
+}
+
+// PrepareGMP resolves the route and target/payload defaults and snapshots the counter baseline before
+// submit.
+func (r *Session) PrepareGMP(ctx context.Context, in GMP) (*GMPPlan, error) {
+	route, err := requireRoute(r.h, in.Route)
+	if err != nil {
+		return nil, err
+	}
+	rdr, err := r.reader(route.Destination)
+	if err != nil {
+		return nil, err
+	}
+	// Resolve the target. Empty defaults to the deployed Counter fixture on the destination — sourced from
+	// the deployment metadata by its family-agnostic fixture name. Either way it is canonicalized through
+	// the destination Reader (the family's string->address choke point), so the frozen string — what the
+	// submission carries and the terminal floor exact-compares against the destination event — is the
+	// family's canonical form, and a malformed target fails here rather than mid-verification.
+	if in.Target == "" {
+		target, fixtureErr := r.fixture(route.Destination, fixturekeys.Counter)
+		if fixtureErr != nil {
+			return nil, fixtureErr
+		}
+		in.Target = target
+	}
+	in.Target, err = rdr.CanonicalAddr(in.Target)
+	if err != nil {
+		return nil, fmt.Errorf("harness: GMP target: %w", err)
+	}
+	// Default payload is inherently family-specific, so it comes from the destination's Reader rather than
+	// a package-level EVM call here (EVM: Counter.increment() calldata).
+	if len(in.Payload) == 0 {
+		in.Payload = rdr.GMPDefaultPayload()
+	}
+	in.Payload = append([]byte(nil), in.Payload...)
+	before, err := r.gmp.Count(ctx, route.Destination, in.Target)
+	if err != nil {
+		return nil, err
+	}
+	return &GMPPlan{run: r, in: in, route: route, before: before}, nil
+}
+
+// Submit sends the call using the frozen plan input.
+func (p *GMPPlan) Submit(ctx context.Context) (*GMPOutcome, error) {
+	action, tracker, err := p.run.submitGMP(ctx, p.in, p.route)
+	if err != nil {
+		return nil, err
+	}
+	return &GMPOutcome{action: action, tracker: tracker, plan: p}, nil
+}
+
+// GMP is PrepareGMP + Submit in one call.
+func (r *Session) GMP(ctx context.Context, in GMP) (*GMPOutcome, error) {
+	plan, err := r.PrepareGMP(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return plan.Submit(ctx)
+}
+
+// submitGMP sends the message through the source chain's submitter (see chain.AppSubmitter) and builds
+// the harness-native action the tracker correlates — constructed from the harness's own submission, like
+// submitIFT.
+func (r *Session) submitGMP(
+	ctx context.Context,
+	in GMP,
+	route wire.Route,
+) (*onchain.GMPAction, *onchain.GMPTracker, error) {
+	submitter, err := r.submitter(route.Source)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := submitter.SubmitGMP(ctx, chain.GMPSubmission{
+		RouteID: route.ID,
+		Target:  in.Target,
+		Payload: in.Payload,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("harness: submit GMP on route %s: %w", route.ID, err)
+	}
+	action := &onchain.GMPAction{
+		PacketAction: onchain.PacketAction{
+			RouteID:      route.ID,
+			Source:       route.Source,
+			Destination:  route.Destination,
+			SourceTxHash: res.SourceTxHash,
+			Sequence:     res.Sequence,
+		},
+		Target: in.Target,
+	}
+	return action, r.packets.TrackGMP(action), nil
+}
+
+// fixture resolves a named deployment fixture's address on chainID, wrapping the lookup to name the chain
+// (the wire accessor names the fixture) so a missing fixture is a clear error, not an empty target.
+func (r *Session) fixture(chainID, name string) (string, error) {
+	cd, ok := r.deployment.Chain(chainID)
+	if !ok {
+		return "", fmt.Errorf("harness: deployment has no chain %q", chainID)
+	}
+	addr, err := cd.Fixture(name)
+	if err != nil {
+		return "", fmt.Errorf("harness: chain %s: %w", chainID, err)
+	}
+	return addr, nil
+}
+
+// destProfile is the timing profile of the submitted packet's destination.
+func (o *GMPOutcome) destProfile() topology.TimingProfile {
+	return o.plan.run.h.chains.Profile(o.action.Destination)
+}
+
+// status is the status source answering for this outcome.
+func (o *GMPOutcome) status() onchain.StatusSource { return o.plan.run.h.relayer }
+
+// VerifyComplete checks tracker terminal floor, status cross-check, and counter delta.
+func (o *GMPOutcome) VerifyComplete(ctx context.Context) error {
+	if err := o.tracker.VerifyComplete(ctx); err != nil {
+		return err
+	}
+	if err := o.tracker.StatusCrossCheck(ctx, o.status()); err != nil {
+		return err
+	}
+	return o.plan.run.gmp.VerifyTargetChangedOnce(ctx, o.action.Destination, o.action.Target, o.plan.before)
+}
+
+// VerifyPending asserts status is pending and the target counter has not changed.
+func (o *GMPOutcome) VerifyPending(ctx context.Context) error {
+	if err := o.VerifyPendingStatus(ctx); err != nil {
+		return err
+	}
+	return o.VerifyTargetUnchanged(ctx)
+}
+
+// VerifyPendingStatus asserts only the daemon status.
+func (o *GMPOutcome) VerifyPendingStatus(ctx context.Context) error {
+	_, err := waitPacketState(ctx, o.status(), o.action.ID(), wire.PacketPending, o.destProfile())
+	return err
+}
+
+// VerifyPendingStable asserts the daemon status remains pending across the destination's settle window.
+func (o *GMPOutcome) VerifyPendingStable(ctx context.Context) error {
+	return waitPacketStable(ctx, o.status(), o.action.ID(), wire.PacketPending, o.destProfile())
+}
+
+// VerifyErrorAck asserts the destination rejected the call and the target stayed unchanged.
+func (o *GMPOutcome) VerifyErrorAck(ctx context.Context) error {
+	errAck, err := waitPacketState(ctx, o.status(), o.action.ID(), wire.PacketErrorAck, o.destProfile())
+	if err != nil {
+		return err
+	}
+	if errAck.Reason == "" {
+		return errors.New("harness: error_ack packet must carry a reason")
+	}
+	if errAck.EffectTxHash == "" {
+		return errors.New("harness: error_ack packet must carry an effect tx hash")
+	}
+	if err := o.tracker.VerifyErrorAck(ctx); err != nil {
+		return err
+	}
+	return o.VerifyTargetUnchanged(ctx)
+}
+
+// VerifyTargetUnchanged asserts the GMP target stayed at its prepared baseline.
+func (o *GMPOutcome) VerifyTargetUnchanged(ctx context.Context) error {
+	return o.plan.run.gmp.VerifyTargetUnchanged(ctx, o.action.Destination, o.action.Target, o.plan.before)
+}

--- a/link/harness/harness.go
+++ b/link/harness/harness.go
@@ -1,0 +1,319 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cosmos/ibc/link/harness/chain"
+	"github.com/cosmos/ibc/link/harness/chain/evm"
+	"github.com/cosmos/ibc/link/harness/diag"
+	"github.com/cosmos/ibc/link/harness/ibclink"
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/onchain"
+	"github.com/cosmos/ibc/link/harness/topology"
+
+	evmreader "github.com/cosmos/ibc/link/harness/chain/evm/reader"
+	evmsubmit "github.com/cosmos/ibc/link/harness/chain/evm/submit"
+)
+
+const (
+	// daemonStopTimeout bounds the graceful daemon stop during teardown so a wedged daemon cannot hang
+	// cleanup (it is escalated to SIGKILL past this).
+	daemonStopTimeout = 15 * time.Second
+
+	// diagRPCTimeout bounds each diagnostic RPC. A wedged node is the usual reason a test failed, so an
+	// unbounded Height call here would hang teardown forever — diagnostics must never block cleanup.
+	diagRPCTimeout = 10 * time.Second
+)
+
+// Harness is one run's world: the provisioned chains, the ibc link driver bound to this run's compiled
+// config, and the run's workspace + diagnostics bundle. It is the result of Start; everything in it is
+// passive until StartRelayer brings the relayer up and wraps it in a Session.
+//
+// The Harness also owns every long-lived SUT process started during the run (the procs ledger), so
+// Shutdown is the single teardown-and-capture path: a daemon that came up and failed later — even during
+// StartRelayer itself — still has its log and final status folded into the failure bundle, on every exit
+// path, without per-path capture calls.
+type Harness struct {
+	topo   topology.Topology
+	chains *Chains
+
+	link    ibclink.Runner // ibc link driver over this run's compiled config
+	linkLog string         // file the driver appends every one-shot invocation's stderr to
+
+	// procs is the ledger of every long-lived SUT process started during this run, in start order —
+	// today relayer daemon instances (a restart appends a second entry), tomorrow attestors alike.
+	// Entries are never removed: a stopped instance stays capturable (Logs is an in-memory snapshot,
+	// FinalStatus a pre-stop one). relayer is the current instance, nil until StartRelayer. Both are
+	// single-threaded by test convention, like the rest of the harness surface.
+	procs   []ibclink.Daemon
+	relayer ibclink.Daemon
+
+	bundle *diag.Bundle
+	ws     workspace
+}
+
+// trackDaemon ledgers a newly started daemon and makes it the current relayer instance.
+func (h *Harness) trackDaemon(d ibclink.Daemon) {
+	h.procs = append(h.procs, d)
+	h.relayer = d
+}
+
+// Chains returns the run's chain registry (per-chain handles, profiles, capability lookups).
+func (h *Harness) Chains() *Chains { return h.chains }
+
+// IBCLink returns the ibc link driver bound to this run's compiled config.
+func (h *Harness) IBCLink() ibclink.Runner { return h.link }
+
+// WorkDir returns the run's workspace directory (compiled config, relayer DB, chain and daemon
+// files). Under KeepOnClose it is the kept world's root, so callers can surface where to inspect.
+func (h *Harness) WorkDir() string { return h.ws.dir }
+
+// workspace is the run's on-disk scratch area and artifact policy: where chain logs, the compiled
+// config, and the relayer DB live, plus what happens to all of it at teardown. The run id doubles as
+// the Docker label value provisioning tags every container with. The harness always creates the dir
+// and always owns its removal: teardown deletes it unless keepOnClose preserves the world.
+type workspace struct {
+	dir         string
+	runID       string
+	artifactDir string
+	keepOnClose bool
+}
+
+func newWorkspace(cfg StartConfig) (workspace, error) {
+	dir, err := os.MkdirTemp("", "harness-")
+	if err != nil {
+		return workspace{}, fmt.Errorf("create work dir: %w", err)
+	}
+	return workspace{
+		dir:         dir,
+		runID:       fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano()),
+		artifactDir: cfg.ArtifactDir,
+		keepOnClose: cfg.KeepOnClose,
+	}, nil
+}
+
+// remove deletes the workdir. Callers gate on keepOnClose.
+func (ws workspace) remove() error {
+	return os.RemoveAll(ws.dir)
+}
+
+// buildReaders constructs one onchain.Reader per chain (keyed by Chain.ID), dispatching on the chain's
+// family. Each reader is bound to its chain client and that chain's deployed fixtures, so the correlator and
+// app asserters read every on-chain effect through the family-agnostic Reader seam.
+func (h *Harness) buildReaders(dep *wire.Deployment) (map[string]onchain.Reader, error) {
+	out := make(map[string]onchain.Reader, len(h.chains.list))
+	for _, p := range h.chains.list {
+		id := p.Chain.ID()
+		cd, ok := dep.Chain(id)
+		if !ok {
+			return nil, fmt.Errorf(
+				"harness: deployment has no chain %q; deploy/topology mismatch should have been caught earlier",
+				id,
+			)
+		}
+		budget := h.readerBudget(id)
+		switch p.Chain.Family() {
+		case chain.FamilyEVM:
+			ec, ok := evm.FromChain(p.Chain)
+			if !ok {
+				return nil, fmt.Errorf("harness: chain %q reports EVM family but exposes no EVM client", id)
+			}
+			out[id] = evmreader.New(ec, id, cd, budget)
+		default:
+			return nil, fmt.Errorf("harness: chain %q family %q has no on-chain reader", id, p.Chain.Family())
+		}
+	}
+	return out, nil
+}
+
+// buildSubmitters constructs one chain.AppSubmitter per chain (keyed by Chain.ID), dispatching on the
+// chain's family — the write-side twin of buildReaders, bound the same way: each submitter gets its
+// chain's client, its deployed fixtures, and its timing budget at construction (see chain.AppSubmitter
+// for why this seam exists). A submitter borrows its chain's client (closed by the chain's Stop), so
+// there is nothing to tear down here.
+func (h *Harness) buildSubmitters(dep *wire.Deployment) (map[string]chain.AppSubmitter, error) {
+	out := make(map[string]chain.AppSubmitter, len(h.chains.list))
+	for _, p := range h.chains.list {
+		id := p.Chain.ID()
+		cd, ok := dep.Chain(id)
+		if !ok {
+			return nil, fmt.Errorf(
+				"harness: deployment has no chain %q; deploy/topology mismatch should have been caught earlier",
+				id,
+			)
+		}
+		switch p.Chain.Family() {
+		case chain.FamilyEVM:
+			ec, ok := evm.FromChain(p.Chain)
+			if !ok {
+				return nil, fmt.Errorf("harness: chain %q reports EVM family but exposes no EVM client", id)
+			}
+			s, err := evmsubmit.New(ec, cd)
+			if err != nil {
+				return nil, err
+			}
+			out[id] = s
+		default:
+			return nil, fmt.Errorf("harness: chain %q family %q has no app submitter", id, p.Chain.Family())
+		}
+	}
+	return out, nil
+}
+
+// readerBudget translates a chain's resolved timing profile into the onchain package's Budget — the
+// completion/poll bounds effect waits use and the status-row bound the destination reader lends to
+// StatusCrossCheck. This is the one place topology.TimingProfile crosses into onchain, keeping onchain free
+// of the topology package.
+func (h *Harness) readerBudget(chainID string) onchain.Budget {
+	p := h.chains.Profile(chainID)
+	return onchain.Budget{
+		Completion: p.CompletionBudget,
+		Poll:       p.PollInterval,
+		StatusRow:  p.StatusRowBudget(),
+	}
+}
+
+// Shutdown is the run's single teardown path: it stops the current relayer daemon first (completing its
+// log and snapshotting its final status), captures diagnostics from the chains and every ledgered SUT
+// process, writes artifacts when failed is true, then tears the world down. Under KeepOnClose everything
+// stays up for inspection — chains, workdir, and the daemon alike (its pid file names the process to
+// sweep) — but diagnostics are still captured and artifacts still written.
+func (h *Harness) Shutdown(ctx context.Context, failed bool) error {
+	var errs []error
+	if h.relayer != nil && !h.ws.keepOnClose {
+		stopCtx, cancel := context.WithTimeout(ctx, daemonStopTimeout)
+		if err := h.relayer.Stop(stopCtx); err != nil {
+			errs = append(errs, fmt.Errorf("stop relayer daemon: %w", err))
+		}
+		cancel()
+	}
+	h.CaptureDiagnostics(ctx)
+	if failed && h.ws.artifactDir != "" {
+		_, _ = h.WriteArtifacts(h.ws.artifactDir)
+	}
+	errs = append(errs, h.closeWorld())
+	return errors.Join(errs...)
+}
+
+// CaptureDiagnostics pulls chain logs, current heights, the ibc-link one-shot command log, and every
+// ledgered SUT process's log + status into the bundle. It is best-effort: each diagnostic RPC is
+// independently time-bounded, and a stopped process contributes its captured log and pre-stop status
+// snapshot instead of a live query.
+func (h *Harness) CaptureDiagnostics(ctx context.Context) {
+	for _, p := range h.chains.list {
+		for id, log := range p.CollectLogs(ctx) {
+			if log != "" {
+				h.bundle.AddChainLog(id, log)
+			}
+		}
+		hctx, cancel := context.WithTimeout(ctx, diagRPCTimeout)
+		height, err := p.Chain.Height(hctx)
+		cancel()
+		if err == nil {
+			h.bundle.SetHeight(p.Chain.ID(), height)
+		}
+	}
+	if h.linkLog != "" {
+		if data, err := os.ReadFile(h.linkLog); err == nil && len(data) > 0 {
+			h.bundle.AddSUTLog("ibc-link", string(data))
+		}
+	}
+	for _, d := range h.procs {
+		captureDaemonLog(h.bundle, d, d.LogLabel())
+		captureDaemonStatus(h.bundle, d, d.LogLabel())
+	}
+}
+
+// WriteArtifacts writes the bundle to a subdirectory of dir named by the run id.
+func (h *Harness) WriteArtifacts(dir string) (string, error) {
+	if dir == "" {
+		return "", errors.New("harness: WriteArtifacts called with empty dir")
+	}
+	if !filepath.IsAbs(dir) {
+		wd, err := os.Getwd()
+		if err != nil {
+			wd = "."
+		}
+		dir = filepath.Join(wd, dir)
+	}
+	outDir := filepath.Join(dir, h.ws.runID)
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(outDir, "diagnostics.txt")
+	return path, os.WriteFile(path, []byte(h.bundle.String()), 0o644)
+}
+
+// closeWorld stops the chains (reverse start order) and cleans up the temp workdir if the harness
+// created it. It is Shutdown's final step, not a public teardown: Shutdown is the only teardown path, so
+// there is no way to tear the world down without the daemon stop and diagnostics capture that precede this.
+func (h *Harness) closeWorld() error {
+	if h.ws.keepOnClose {
+		return nil
+	}
+	errs := []error{h.chains.stopAll()}
+	if err := h.ws.remove(); err != nil {
+		errs = append(errs, fmt.Errorf("remove workdir %s: %w", h.ws.dir, err))
+	}
+	return errors.Join(errs...)
+}
+
+// captureDaemonStatus folds the daemon's status JSON into the bundle: the live status API when the
+// process still answers, else the final snapshot its Stop captured (see Daemon.FinalStatus). A stopped
+// endpoint refuses the connection immediately, so the live attempt costs nothing on a dead instance.
+func captureDaemonStatus(b *diag.Bundle, d ibclink.Daemon, key string) {
+	ctx, cancel := context.WithTimeout(context.Background(), diagRPCTimeout)
+	defer cancel()
+	status, err := d.Status(ctx, wire.StatusQuery{})
+	if err != nil {
+		var ok bool
+		if status, ok = d.FinalStatus(); !ok {
+			return
+		}
+	}
+	data, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return
+	}
+	b.AddStatus(key, string(data))
+}
+
+// captureDaemonLog reads the daemon's captured stderr into the bundle.
+func captureDaemonLog(b *diag.Bundle, d ibclink.Daemon, key string) {
+	if data, err := io.ReadAll(d.Logs()); err == nil && len(data) > 0 {
+		b.AddSUTLog(key, string(data))
+	}
+}
+
+func topologySummary(t topology.Topology) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "name=%s db=sqlite(runtime path)\n", t.Name)
+	for _, spec := range t.Chains {
+		c := spec.Chain
+		if spec.Provision.Mode == topology.ProvisionExternal {
+			// Name the gap rather than silently omit it: the harness does not own this node, so it never
+			// captures its logs. The summary makes that explicit in any failure bundle.
+			fmt.Fprintf(
+				&b,
+				"chain %s: external rpc=%s chainID=%d (logs unavailable)\n",
+				c.ID,
+				spec.Provision.RPCURL,
+				c.ChainID,
+			)
+			continue
+		}
+		fmt.Fprintf(&b, "chain %s: launcher=%s chainID=%d\n", c.ID, spec.Provision.Launcher, c.ChainID)
+	}
+	for _, r := range t.Config.Relayer.Routes {
+		fmt.Fprintf(&b, "route %s: %s -> %s (%s)\n", r.ID, r.Source, r.Destination, r.Type)
+	}
+	return b.String()
+}

--- a/link/harness/ibclink/daemon.go
+++ b/link/harness/ibclink/daemon.go
@@ -1,0 +1,458 @@
+package ibclink
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/internal/proc"
+)
+
+const (
+	// defaultStartupTimeout bounds how long Run waits for the daemon's readiness line. The daemon dials
+	// every configured chain (each up to its own startup-dial budget) and binds the status server before
+	// it can announce readiness, so the bound is generous; readiness is a semantic signal (the parsed
+	// readiness JSON), never a sleep.
+	defaultStartupTimeout = 60 * time.Second
+	// stopGrace is how long Stop waits after SIGTERM for the daemon's graceful HTTP drain before it
+	// escalates to SIGKILL. The relay drains within a few seconds; this leaves margin.
+	stopGrace = 10 * time.Second
+	// statusHTTPTimeout is the hard ceiling on a single status GET. The status endpoint is a local,
+	// in-memory query that answers in well under a second, so this is only a backstop: without it a status
+	// endpoint that accepts the connection but never responds would hang a caller that passed an unbounded
+	// context forever.
+	statusHTTPTimeout = 30 * time.Second
+	// finalStatusTimeout bounds the last status snapshot Stop takes before signaling the process. It is
+	// deliberately tight: the snapshot is best-effort diagnostics, and a wedged daemon (the usual reason
+	// Stop is being called on a failed run) must not delay its own teardown.
+	finalStatusTimeout = 2 * time.Second
+)
+
+// daemonSeq assigns each started daemon a process-unique instance number. A Restart spawns a fresh
+// process against the same runner (so the same log-path base), so the on-disk daemon log is namespaced
+// per instance — otherwise the second instance's os.Create would truncate the first instance's log and
+// lose it (the restart-mid-packet path).
+var daemonSeq atomic.Int64
+
+// Daemon drives a running `ibc relayer run` instance as a black box: it never reaches into the
+// relayer's internals, only reads the readiness line it printed, hits its status HTTP API, execs the
+// one-shot app-action command against the same shared config/DB, and signals the process to stop. The
+// concrete *daemon is returned by Runner.Run.
+type Daemon interface {
+	// Ready returns the readiness JSON the daemon printed as its first stdout line (captured at Run).
+	Ready() wire.Readiness
+	// Status GETs the daemon's status HTTP endpoint (advertised in the readiness line), optionally
+	// filtered. It is the harness's cross-check surface — the better signal for pending packets.
+	Status(ctx context.Context, q wire.StatusQuery) (*wire.Status, error)
+	// Relay POSTs a manual relay request to the daemon's relay HTTP endpoint.
+	Relay(ctx context.Context, req wire.RelayRequest) (*wire.RelayResult, error)
+	// Stop takes a final bounded status snapshot (see FinalStatus), then sends SIGTERM and waits for a
+	// graceful exit (escalating to SIGKILL past the grace window).
+	Stop(ctx context.Context) error
+	// Restart stops this daemon and starts a fresh one against the same config, returning the new
+	// Daemon. The stub resumes any pending packets from sqlite, so in-flight work completes after.
+	Restart(ctx context.Context) (Daemon, error)
+	// Logs returns a snapshot reader over the daemon's captured combined output, for
+	// diagnostics.
+	Logs() io.Reader
+	// FinalStatus returns the status snapshot Stop captured just before signaling the process, if one was
+	// obtained. It makes diagnostics capture time-independent: a bundle assembled after the process is
+	// gone still carries the daemon's last self-report, so no caller has to race a capture against Stop.
+	FinalStatus() (*wire.Status, bool)
+	// LogLabel is the per-instance key a diagnostics bundle should file this daemon's log under. It
+	// shares its instance number with the on-disk daemon log path, so a captured bundle entry and the
+	// preserved KEEP_AFTER_TEST file always carry the same number (a Restart spawns a new instance with
+	// a new number, so the two never overwrite each other in a name-keyed bundle).
+	LogLabel() string
+}
+
+// daemon is the concrete Daemon: the supervised relayer subprocess plus the captured readiness/status
+// wiring. It holds the runner it was started from so Restart can spawn a fresh instance against the
+// same config.
+type daemon struct {
+	runner    *runner
+	readiness wire.Readiness
+	httpAddr  string // status HTTP host:port from the readiness line
+	http      *http.Client
+
+	logSeq int // process-unique instance number; shared by the on-disk log path and LogLabel
+
+	out *safeWriter  // captured combined output, for Logs() + the daemon run log
+	h   *proc.Handle // owns cmd.Wait() and the stop/reap state machine
+
+	mu          sync.Mutex
+	finalStatus *wire.Status // written under mu by snapshotFinalStatus (successful probes only); read via FinalStatus
+}
+
+var _ Daemon = (*daemon)(nil)
+
+// Run starts the relayer daemon and blocks on its semantic readiness.
+func (r *runner) Run(ctx context.Context) (Daemon, error) {
+	return startDaemon(ctx, r)
+}
+
+// readyResult carries the outcome of reading the first stdout line: either the parsed readiness or the
+// reason it could not be obtained (bad line, or the process produced no stdout before exiting).
+type readyResult struct {
+	readiness wire.Readiness
+	err       error
+}
+
+// startDaemon launches `ibc relayer run` as a long-lived child (not via exec.CommandContext with
+// the one-shot timeout — its lifetime is owned by Stop/kill), reads + parses the first stdout line as
+// the readiness signal, and keeps draining both streams into a capture buffer + log file.
+func startDaemon(ctx context.Context, r *runner) (*daemon, error) {
+	const label = "relayer run"
+	args := append([]string{"relayer", "run"}, r.configArgs()...)
+	bin, err := r.binFor(label)
+	if err != nil {
+		return nil, err
+	}
+	// Deliberately exec.Command, not exec.CommandContext: a per-command deadline must never apply to the
+	// long-lived daemon. Setpgid lets Stop/kill signal the whole subtree.
+	cmd := exec.Command(bin, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// Keep stdout and stderr separate: the readiness JSON is the first stdout line, while human logs go
+	// to stderr. Merging them would make "first line" non-deterministic across the two streams.
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("ibc relayer run: stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("ibc relayer run: stderr pipe: %w", err)
+	}
+
+	// Assign the instance number once, up front, so it is stable whether or not a log file is configured
+	// and both the on-disk path and LogLabel derive from the same value.
+	seq := int(daemonSeq.Add(1))
+	out := &safeWriter{}
+	if r.logPath != "" {
+		// Best-effort: a dedicated daemon log next to the one-shot run log, so KEEP_AFTER_TEST preserves
+		// the daemon's output without interleaving it with the per-command appends to logPath.
+		if f, ferr := os.Create(daemonLogPath(r.logPath, seq)); ferr == nil {
+			out.f = f
+		}
+	}
+
+	d := &daemon{
+		runner: r,
+		logSeq: seq,
+		http:   &http.Client{Timeout: statusHTTPTimeout},
+		out:    out,
+	}
+
+	if startErr := cmd.Start(); startErr != nil {
+		out.close()
+		return nil, fmt.Errorf("start ibc relayer run (%s): %w", bin, startErr)
+	}
+	if r.logPath != "" {
+		// Best-effort pid file beside the daemon log. The daemon is its own process group (Setpgid), so a
+		// KeepOnClose run that outlives the test binary leaves it running; the pid file is what lets reset
+		// tooling sweep host daemons the way labels let it sweep containers.
+		pid := strconv.Itoa(cmd.Process.Pid)
+		_ = os.WriteFile(daemonPidPath(r.logPath, seq), []byte(pid+"\n"), 0o644)
+	}
+
+	// Drain both streams to EOF (which arrives when the process exits). cmd.Wait must not run until both
+	// drains finish, so the WaitGroup's Wait is the handle's preWait barrier. The stdout drainer also
+	// extracts the readiness line, and the log sink closes once the process is reaped.
+	readyCh := make(chan readyResult, 1)
+	var drained sync.WaitGroup
+	drained.Add(2)
+	go func() { defer drained.Done(); d.drainStdout(stdout, readyCh) }()
+	go func() { defer drained.Done(); d.drainStderr(stderr) }()
+	d.h = proc.Reap(cmd, drained.Wait)
+	go func() {
+		<-d.h.Done()
+		out.close()
+	}()
+
+	readiness, err := d.awaitReady(ctx, readyCh)
+	if err != nil {
+		// Tear down the half-started daemon so a failed Run never leaks a relayer process.
+		_ = d.kill()
+		return nil, err
+	}
+	d.readiness = readiness
+	d.httpAddr = readiness.Status.HTTP
+	if err := d.probeHealth(ctx); err != nil {
+		_ = d.kill()
+		return nil, err
+	}
+	return d, nil
+}
+
+// drainStdout reads the daemon's stdout line by line. The first line is parsed as the readiness JSON
+// and signaled on readyCh; every line is captured verbatim (stdout is machine JSON we must not
+// mangle). It runs to EOF so cmd.Wait stays safe.
+func (d *daemon) drainStdout(rc io.Reader, readyCh chan<- readyResult) {
+	br := bufio.NewReader(rc)
+	first := true
+	for {
+		line, err := br.ReadString('\n')
+		if len(line) > 0 {
+			d.out.writeLine(line)
+			if first {
+				first = false
+				readyCh <- parseReadiness(line)
+			}
+		}
+		if err != nil {
+			if first {
+				// No stdout line at all before the stream closed — the daemon almost certainly exited
+				// before announcing readiness.
+				readyCh <- readyResult{err: fmt.Errorf("no readiness line on stdout: %w", err)}
+			}
+			return
+		}
+	}
+}
+
+// parseReadiness decodes a stdout line as the readiness event, validating the discriminant field.
+func parseReadiness(line string) readyResult {
+	var r wire.Readiness
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &r); err != nil {
+		return readyResult{
+			err: fmt.Errorf("first stdout line is not readiness JSON (%q): %w", strings.TrimSpace(line), err),
+		}
+	}
+	if err := r.Validate(); err != nil {
+		return readyResult{err: fmt.Errorf("invalid readiness: %w", err)}
+	}
+	return readyResult{readiness: r}
+}
+
+// drainStderr captures the daemon's stderr to EOF.
+func (d *daemon) drainStderr(rc io.Reader) {
+	br := bufio.NewReader(rc)
+	for {
+		line, err := br.ReadString('\n')
+		if len(line) > 0 {
+			d.out.writeLine(line)
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// awaitReady blocks until the readiness line arrives, the startup budget elapses, or ctx is canceled.
+func (d *daemon) awaitReady(ctx context.Context, readyCh <-chan readyResult) (wire.Readiness, error) {
+	timer := time.NewTimer(defaultStartupTimeout)
+	defer timer.Stop()
+	select {
+	case res := <-readyCh:
+		if res.err != nil {
+			return wire.Readiness{}, fmt.Errorf("ibc relayer run: %w", res.err)
+		}
+		return res.readiness, nil
+	case <-timer.C:
+		return wire.Readiness{}, fmt.Errorf("ibc relayer run: not ready within %s", defaultStartupTimeout)
+	case <-ctx.Done():
+		return wire.Readiness{}, fmt.Errorf("ibc relayer run: startup canceled: %w", ctx.Err())
+	}
+}
+
+func (d *daemon) Ready() wire.Readiness { return d.readiness }
+
+func (d *daemon) Logs() io.Reader { return bytes.NewReader(d.out.snapshot()) }
+
+func (d *daemon) LogLabel() string { return fmt.Sprintf("ibc-daemon-%d", d.logSeq) }
+
+// Status GETs the daemon's status HTTP endpoint.
+func (d *daemon) Status(ctx context.Context, q wire.StatusQuery) (*wire.Status, error) {
+	u := d.apiURL(wire.StatusPath)
+	vals := url.Values{}
+	if q.RouteID != "" {
+		vals.Set(wire.StatusQueryRoute, q.RouteID)
+	}
+	if q.PacketID != "" {
+		vals.Set(wire.StatusQueryPacket, q.PacketID)
+	}
+	u.RawQuery = vals.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("ibc status: build request: %w", err)
+	}
+	var status wire.Status
+	if err := d.doJSON(req, "ibc status", &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+// Relay POSTs a manual relay request to the daemon.
+func (d *daemon) Relay(ctx context.Context, in wire.RelayRequest) (*wire.RelayResult, error) {
+	u := d.apiURL(wire.RelayPath)
+	body, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("ibc relay: encode request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("ibc relay: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	var result wire.RelayResult
+	if err := d.doJSON(req, "ibc relay", &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// probeHealth pins the /health wire contract at startup. Readiness already implies the API is
+// serving, so this is not a liveness wait: it fails a start whose daemon does not serve the health
+// endpoint, keeping /health a tested contract in every lane.
+func (d *daemon) probeHealth(ctx context.Context) error {
+	u := d.apiURL(wire.HealthPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("ibc relayer run: health: build request: %w", err)
+	}
+	return d.doJSON(req, "ibc relayer run: health", nil)
+}
+
+// apiURL addresses one daemon API endpoint: a plain-HTTP URL on the daemon's local status listener.
+func (d *daemon) apiURL(path string) url.URL {
+	return url.URL{Scheme: "http", Host: d.httpAddr, Path: path}
+}
+
+// doJSON is the shared tail of every daemon API call: execute the request, treat any non-200 as an
+// error carrying the first 512 bytes of the response body, and decode the JSON response into out
+// (skipped when out is nil). label prefixes every error so failures stay attributable per verb.
+func (d *daemon) doJSON(req *http.Request, label string, out any) error {
+	resp, err := d.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s: %s %s: %w", label, req.Method, req.URL.String(), err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf(
+			"%s: %s %s -> %s: %s",
+			label,
+			req.Method,
+			req.URL.String(),
+			resp.Status,
+			strings.TrimSpace(string(body)),
+		)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("%s: decode response: %w", label, err)
+	}
+	return nil
+}
+
+// Stop takes the final status snapshot, then signals SIGTERM and waits for the daemon's graceful exit,
+// escalating to SIGKILL past the grace (the stop/reap state machine lives in proc.Handle).
+func (d *daemon) Stop(ctx context.Context) error {
+	d.snapshotFinalStatus(ctx)
+	return d.h.SignalAndWait(ctx, syscall.SIGTERM, stopGrace)
+}
+
+// snapshotFinalStatus captures the daemon's status-API view before the process is signaled, so
+// FinalStatus can serve it after the process is gone. Best-effort and tightly bounded; it stores only
+// successful probes, so a repeat Stop against the dead endpoint (e.g. via Restart) fails its probe
+// fast and leaves the earlier snapshot intact.
+func (d *daemon) snapshotFinalStatus(ctx context.Context) {
+	if d.httpAddr == "" {
+		return // never became ready; there is no status endpoint to snapshot
+	}
+	sctx, cancel := context.WithTimeout(ctx, finalStatusTimeout)
+	defer cancel()
+	s, err := d.Status(sctx, wire.StatusQuery{})
+	if err != nil {
+		return
+	}
+	d.mu.Lock()
+	d.finalStatus = s
+	d.mu.Unlock()
+}
+
+func (d *daemon) FinalStatus() (*wire.Status, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.finalStatus, d.finalStatus != nil
+}
+
+// kill signals SIGKILL and waits for the process to be reaped.
+func (d *daemon) kill() error {
+	return d.h.SignalAndWait(context.Background(), syscall.SIGKILL, 0)
+}
+
+// Restart stops this daemon and starts a fresh one against the same config. The stub resumes pending
+// packets from sqlite on start, so work in flight at stop time completes on the new instance.
+func (d *daemon) Restart(ctx context.Context) (Daemon, error) {
+	if err := d.Stop(ctx); err != nil {
+		return nil, fmt.Errorf("restart: stop current daemon: %w", err)
+	}
+	nd, err := startDaemon(ctx, d.runner)
+	if err != nil {
+		return nil, fmt.Errorf("restart: start new daemon: %w", err)
+	}
+	return nd, nil
+}
+
+// daemonLogPath derives a per-instance daemon log path from the runner's one-shot run-log path, suffixing
+// the instance number (see daemonSeq).
+func daemonLogPath(runnerLog string, instance int) string {
+	return fmt.Sprintf("%s-daemon-%d.log", strings.TrimSuffix(runnerLog, ".log"), instance)
+}
+
+// daemonPidPath is daemonLogPath's sibling pid file for the same instance.
+func daemonPidPath(runnerLog string, instance int) string {
+	return fmt.Sprintf("%s-daemon-%d.pid", strings.TrimSuffix(runnerLog, ".log"), instance)
+}
+
+// safeWriter captures the daemon's combined output for both Logs() (an in-memory buffer) and an
+// optional on-disk log, serialized so the two drain goroutines (stdout + stderr) can write
+// concurrently.
+type safeWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+	f   *os.File // nil if no log file was configured
+}
+
+func (w *safeWriter) writeLine(s string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf.WriteString(s)
+	if w.f != nil {
+		_, _ = w.f.WriteString(s)
+	}
+}
+
+func (w *safeWriter) snapshot() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]byte(nil), w.buf.Bytes()...)
+}
+
+func (w *safeWriter) close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f != nil {
+		_ = w.f.Close()
+		w.f = nil
+	}
+}

--- a/link/harness/ibclink/daemon_test.go
+++ b/link/harness/ibclink/daemon_test.go
@@ -1,0 +1,37 @@
+package ibclink
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseReadiness(t *testing.T) {
+	valid := `{"event":"ready","configLoaded":true,"dbReady":true,` +
+		`"chainsConnected":["chain-a"],"relayerSubscribed":true,"status":{"http":"127.0.0.1:4242"}}` + "\n"
+	res := parseReadiness(valid)
+	require.NoError(t, res.err)
+	require.Equal(t, "127.0.0.1:4242", res.readiness.Status.HTTP)
+	require.Equal(t, []string{"chain-a"}, res.readiness.ChainsConnected)
+
+	res = parseReadiness("plain log line, not json\n")
+	require.Error(t, res.err)
+	require.ErrorContains(t, res.err, "not readiness JSON")
+
+	wrongEvent := `{"event":"started","configLoaded":true,"dbReady":true,"relayerSubscribed":true,` +
+		`"status":{"http":"127.0.0.1:4242"}}`
+	res = parseReadiness(wrongEvent)
+	require.Error(t, res.err)
+	require.ErrorContains(t, res.err, "invalid readiness")
+
+	notReady := `{"event":"ready","configLoaded":true,"dbReady":false,"relayerSubscribed":true,` +
+		`"status":{"http":"127.0.0.1:4242"}}`
+	res = parseReadiness(notReady)
+	require.Error(t, res.err)
+	require.ErrorContains(t, res.err, "dbReady")
+}
+
+func TestDaemonInstancePaths(t *testing.T) {
+	require.Equal(t, "/w/ibc-link-daemon-2.log", daemonLogPath("/w/ibc-link.log", 2))
+	require.Equal(t, "/w/ibc-link-daemon-2.pid", daemonPidPath("/w/ibc-link.log", 2))
+}

--- a/link/harness/ibclink/process.go
+++ b/link/harness/ibclink/process.go
@@ -1,0 +1,165 @@
+package ibclink
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+)
+
+const (
+	// realBinEnv overrides the real ibc link binary. IBC_BIN keeps its original meaning: the
+	// real binary seam. During the progressive migration IBC_STUB_BIN overrides the temporary stub;
+	// when the routing table is all-real the stub seam disappears and IBC_BIN is the only override again.
+	realBinEnv = "IBC_BIN"
+	// stubBinEnv overrides the temporary stub binary while commands are still routed to it.
+	stubBinEnv = "IBC_STUB_BIN"
+)
+
+// maxStderrSnippet caps how much stderr an ExitError carries, so a failing command's error stays
+// readable while still pointing at the cause. The full stream is in the log file.
+const maxStderrSnippet = 600
+
+// defaultCommandTimeout bounds a single one-shot SUT invocation (validate/migrate/deploy/app actions).
+// It is generous — larger than the stub's own per-chain probe/deploy timeouts — and exists so a hung
+// binary fails this command at a deadline rather than blocking until the whole test times out. It
+// deliberately does not apply to the long-lived daemon path (`relayer run`), which needs its own
+// unbounded, streaming exec.
+const defaultCommandTimeout = 120 * time.Second
+
+// result is one SUT invocation's captured output and exit status. A non-zero Code is data (part of
+// the CLI contract), not a Go-level error — exec returns it without an error so the caller can map it.
+type result struct {
+	stdout []byte
+	stderr string // captured stderr tail
+	code   int
+}
+
+// exec runs the routed SUT with args, capturing stdout (the machine-readable JSON) and stderr (human logs)
+// into buffers. label is a short human name for the command used in the log header and error messages.
+//
+// It returns a Go error only when the process could not be run at all (the binary is missing, or the
+// context was canceled). A clean exit and any coded non-zero exit both return (result, nil); the
+// caller inspects result.code and maps it to a typed error.
+func (r *runner) exec(ctx context.Context, label string, args ...string) (*result, error) {
+	// Bound this one-shot invocation so a hung stub (or real binary) fails this command at its own
+	// deadline instead of blocking until the whole test times out. One-shot path only — the long-lived
+	// daemon must not route through exec, which buffers all output and waits for exit.
+	ctx, cancel := context.WithTimeout(ctx, defaultCommandTimeout)
+	defer cancel()
+
+	bin, err := r.binFor(label)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	stderrText := stderr.String()
+	r.writeLog(label, args, stderrText)
+	res := &result{stdout: stdout.Bytes(), stderr: stderrText}
+
+	var exitErr *exec.ExitError
+	switch {
+	case runErr == nil:
+		res.code = wire.ExitOK
+	case errors.As(runErr, &exitErr):
+		// A coded non-zero exit is the CLI contract talking; hand it back as data.
+		res.code = exitErr.ExitCode()
+	default:
+		// Could not start the process (e.g. the routed binary was never built).
+		return res, fmt.Errorf("exec ibc %s (%s): %w", label, bin, runErr)
+	}
+	// CommandContext kills the child on cancellation, surfacing as a signal exit; distinguish that
+	// real setup failure from a stub-chosen exit code by checking the context explicitly.
+	if err := ctx.Err(); err != nil {
+		return res, fmt.Errorf("ibc %s canceled: %w", label, err)
+	}
+	return res, nil
+}
+
+// writeLog appends this invocation's header and its stderr to the run's log file for the diag bundle.
+// Best-effort: a log-file problem must never fail the command, so a missing logPath or a failed open is
+// silently skipped (the stderr still reaches the error snippet and the bundle).
+func (r *runner) writeLog(label string, args []string, stderrText string) {
+	if r.logPath == "" {
+		return
+	}
+	f, err := os.OpenFile(r.logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close() //nolint:errcheck
+	_, _ = fmt.Fprintf(f, "\n=== ibc %s | args: %s ===\n%s", label, strings.Join(args, " "), stderrText)
+}
+
+// classify maps a stub exit code to its sentinel error so callers can errors.Is on the failure class
+// without parsing stderr. An unknown non-zero code is treated as an internal fault by definition.
+func classify(code int) error {
+	switch code {
+	case wire.ExitConfigInvalid:
+		return ErrConfigInvalid
+	case wire.ExitRPCUnreachable:
+		return ErrRPCUnreachable
+	case wire.ExitDeployFailure:
+		return ErrDeployFailed
+	case wire.ExitNotReady:
+		return ErrNotReady
+	default:
+		return ErrInternal
+	}
+}
+
+// snippet trims and tail-truncates stderr for inclusion in an ExitError.
+func snippet(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > maxStderrSnippet {
+		s = "..." + s[len(s)-maxStderrSnippet:]
+	}
+	return s
+}
+
+// ResolvedRealBin reports the real ibc link binary: IBC_BIN if set, else bin/ibc.
+func ResolvedRealBin() string {
+	if v := os.Getenv(realBinEnv); v != "" {
+		return v
+	}
+	return defaultBinPath("ibc")
+}
+
+// ResolvedStubBin reports the temporary stub binary: IBC_STUB_BIN if set, else bin/ibc-stub.
+func ResolvedStubBin() string {
+	if v := os.Getenv(stubBinEnv); v != "" {
+		return v
+	}
+	return defaultBinPath("ibc-stub")
+}
+
+// defaultBinPath locates a link/bin binary relative to this source file (via runtime.Caller) rather
+// than the process working directory, so it resolves the same whether a test runs from
+// harness/ibclink, e2e/setup, or a module root.
+func defaultBinPath(name string) string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		// skip=0 cannot fail in practice; fail loudly rather than silently resolving a wrong
+		// cwd-relative "bin/<name>" that would then produce a confusing "binary not built" error.
+		panic("ibclink: runtime.Caller(0) failed; cannot locate the link bin/ directory")
+	}
+	// file = <link>/harness/ibclink/process.go -> three parents up is the link repo root, whose
+	// bin/ holds both the real binary (bin/ibc, `make build`) and the stub (bin/ibc-stub).
+	root := filepath.Dir(filepath.Dir(filepath.Dir(file)))
+	return filepath.Join(root, "bin", name)
+}

--- a/link/harness/ibclink/process_test.go
+++ b/link/harness/ibclink/process_test.go
@@ -1,0 +1,35 @@
+package ibclink
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+)
+
+func TestClassifyMapsSysexitsToSentinels(t *testing.T) {
+	require.ErrorIs(t, classify(wire.ExitConfigInvalid), ErrConfigInvalid)
+	require.ErrorIs(t, classify(wire.ExitRPCUnreachable), ErrRPCUnreachable)
+	require.ErrorIs(t, classify(wire.ExitDeployFailure), ErrDeployFailed)
+	require.ErrorIs(t, classify(wire.ExitNotReady), ErrNotReady)
+	require.ErrorIs(t, classify(wire.ExitInternal), ErrInternal)
+	require.ErrorIs(t, classify(1), ErrInternal, "unknown non-zero codes classify as internal")
+}
+
+func TestSnippetTailTruncates(t *testing.T) {
+	require.Equal(t, "short", snippet("  short \n"))
+
+	long := strings.Repeat("x", maxStderrSnippet) + "TAIL"
+	got := snippet(long)
+	require.True(t, strings.HasPrefix(got, "..."))
+	require.True(t, strings.HasSuffix(got, "TAIL"), "the tail (where the cause usually is) survives")
+	require.Len(t, got, maxStderrSnippet+3)
+}
+
+func TestExitErrorUnwrapsToClass(t *testing.T) {
+	err := &ExitError{Code: wire.ExitConfigInvalid, Class: ErrConfigInvalid, Stderr: "bad yaml"}
+	require.ErrorIs(t, err, ErrConfigInvalid)
+	require.ErrorContains(t, err, "bad yaml")
+}

--- a/link/harness/ibclink/runner.go
+++ b/link/harness/ibclink/runner.go
@@ -1,0 +1,197 @@
+// Package ibclink drives the ibc link SUT as a black box. It routes each command to either the real
+// binary or the temporary stub, execs it with the harness-compiled config, and parses stdout JSON /
+// exit codes into harness-side wire types. It never reaches into the SUT's guts: the only thing
+// crossing the wall is the binary's public CLI surface, config YAML, and JSON output.
+package ibclink
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+)
+
+// Sentinel errors classify a non-zero SUT exit. Stub-served commands use sysexits codes; real-served
+// commands that fail with other codes map to ErrInternal unless a command-specific contract says more.
+// A failing command returns an *ExitError wrapping one of these, so a test asserts the failure class
+// with errors.Is(err, ErrConfigInvalid) instead of string-matching stderr.
+var (
+	ErrConfigInvalid  = errors.New("ibc: config invalid (exit 64)")
+	ErrRPCUnreachable = errors.New("ibc: rpc unreachable (exit 65)")
+	ErrDeployFailed   = errors.New("ibc: deploy failed (exit 66)")
+	ErrNotReady       = errors.New("ibc: not ready (exit 69)")
+	ErrInternal       = errors.New("ibc: internal error (exit 70)")
+)
+
+type sutBin uint8
+
+const (
+	sutReal sutBin = iota
+	sutStub
+)
+
+// commandRoutes is the swap ledger for the progressive stub-to-real migration: flip an entry when
+// the real binary implements the command, delete the stub code it replaces; all-real means the stub
+// is gone.
+var commandRoutes = map[string]sutBin{
+	"config validate": sutStub,
+	"migrate up":      sutReal,
+	"deploy":          sutStub,
+	"relayer run":     sutStub,
+}
+
+// ExitError reports a SUT command that exited non-zero. Class is the sentinel for the exit code
+// (matchable via errors.Is); Stderr is a tail of the command's human logs for debugging.
+type ExitError struct {
+	Code   int
+	Class  error
+	Stderr string
+}
+
+func (e *ExitError) Error() string {
+	if e.Stderr != "" {
+		return fmt.Sprintf("%v: %s", e.Class, e.Stderr)
+	}
+	return e.Class.Error()
+}
+
+// Unwrap exposes the sentinel class so errors.Is(err, ErrConfigInvalid) matches.
+func (e *ExitError) Unwrap() error { return e.Class }
+
+// Runner is the public harness handle for the ibc link binary.
+type Runner interface {
+	// ValidateConfig runs `config validate [--live]`. It returns the parsed result whenever the stub
+	// emitted one (it does for ok, structural-invalid and live-unreachable), and an *ExitError for any
+	// non-zero exit: ErrConfigInvalid (64) for structural failure, ErrRPCUnreachable (65) when --live
+	// could not reach a chain. So a caller reads the result for detail and errors.Is for the class.
+	ValidateConfig(ctx context.Context, live bool) (*wire.ValidateResult, error)
+	// MigrateUp runs `migrate up`, applying the DB schema expected by later commands.
+	MigrateUp(ctx context.Context) error
+	// Deploy runs `deploy`, returning the per-chain fixture metadata (or ErrDeployFailed on exit 66).
+	Deploy(ctx context.Context) (*wire.Deployment, error)
+	// Run starts `ibc relayer run` as a long-lived daemon and blocks until it reports readiness.
+	Run(ctx context.Context) (Daemon, error)
+}
+
+// Options configure a Runner. Only ConfigPath is required.
+type Options struct {
+	// ConfigPath is the compiled config; the runner passes its directory as --home and basename as --config.
+	ConfigPath string
+	// LogPath, if set, receives every invocation's stderr (appended) for the diagnostics bundle.
+	LogPath string
+}
+
+// runner is the concrete Runner: both SUT binaries + the config they drive, plus capture wiring.
+type runner struct {
+	realBin    string
+	stubBin    string
+	configPath string
+	configHome string
+	configName string
+	logPath    string
+}
+
+var _ Runner = (*runner)(nil)
+
+// NewRunner builds a Runner for the given compiled config. It resolves both binary paths without
+// requiring either file to exist until a routed command actually runs, so constructing one is cheap and
+// side-effect free.
+func NewRunner(o Options) (Runner, error) {
+	if o.ConfigPath == "" {
+		return nil, errors.New("ibclink: NewRunner requires a ConfigPath")
+	}
+	return &runner{
+		realBin:    ResolvedRealBin(),
+		stubBin:    ResolvedStubBin(),
+		configPath: o.ConfigPath,
+		configHome: filepath.Dir(o.ConfigPath),
+		configName: filepath.Base(o.ConfigPath),
+		logPath:    o.LogPath,
+	}, nil
+}
+
+func (r *runner) binFor(label string) (string, error) {
+	target, ok := commandRoutes[label]
+	if !ok {
+		return "", fmt.Errorf("ibclink: no SUT route for command label %q", label)
+	}
+	switch target {
+	case sutReal:
+		return r.realBin, nil
+	case sutStub:
+		return r.stubBin, nil
+	default:
+		return "", fmt.Errorf("ibclink: invalid SUT route for command label %q", label)
+	}
+}
+
+func (r *runner) ValidateConfig(ctx context.Context, live bool) (*wire.ValidateResult, error) {
+	args := append([]string{"config", "validate"}, r.configArgs()...)
+	if live {
+		args = append(args, "--live")
+	}
+	res, err := r.exec(ctx, "config validate", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	// The stub emits a ValidateResult on stdout for ok (0), structural-invalid (64) and
+	// live-unreachable (65), so decode it whenever it parses; a miss on a non-zero exit just means
+	// that failure had no structured body.
+	var out wire.ValidateResult
+	decoded := json.Unmarshal(res.stdout, &out) == nil
+
+	if res.code == wire.ExitOK {
+		if !decoded {
+			return nil, fmt.Errorf(
+				"ibc config validate: exit 0 but stdout is not a ValidateResult: %q",
+				string(res.stdout),
+			)
+		}
+		return &out, nil
+	}
+	var parsed *wire.ValidateResult
+	if decoded {
+		parsed = &out
+	}
+	return parsed, &ExitError{Code: res.code, Class: classify(res.code), Stderr: snippet(res.stderr)}
+}
+
+func (r *runner) MigrateUp(ctx context.Context) error {
+	args := append([]string{"migrate", "up"}, r.configArgs()...)
+	_, err := runJSON[wire.MigrationUpResult](ctx, r, "migrate up", args...)
+	return err
+}
+
+func (r *runner) Deploy(ctx context.Context) (*wire.Deployment, error) {
+	args := append([]string{"deploy"}, r.configArgs()...)
+	return runJSON[wire.Deployment](ctx, r, "deploy", args...)
+}
+
+func (r *runner) configArgs() []string {
+	return []string{"--home", r.configHome, "--config", r.configName}
+}
+
+// runJSON execs a one-shot SUT command and decodes its stdout JSON into *T. It is the shared tail of
+// every command whose contract is "exit 0 with a JSON body, else a non-zero sysexits code": a non-zero
+// exit becomes an *ExitError classed by the code, and a stdout that will not decode is a hard error
+// naming the command. Real-served commands may use non-sysexits failure codes; unknown codes classify as
+// ErrInternal. ValidateConfig deliberately does not use it — that verb also decodes a body on the 64/65
+// exits, so it keeps its own dual-path decode.
+func runJSON[T any](ctx context.Context, r *runner, label string, args ...string) (*T, error) {
+	res, err := r.exec(ctx, label, args...)
+	if err != nil {
+		return nil, err
+	}
+	if res.code != wire.ExitOK {
+		return nil, &ExitError{Code: res.code, Class: classify(res.code), Stderr: snippet(res.stderr)}
+	}
+	var out T
+	if err := json.Unmarshal(res.stdout, &out); err != nil {
+		return nil, fmt.Errorf("ibc %s: decode stdout: %w (%q)", label, err, string(res.stdout))
+	}
+	return &out, nil
+}

--- a/link/harness/ift.go
+++ b/link/harness/ift.go
@@ -1,0 +1,307 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/cosmos/ibc/link/harness/chain"
+	"github.com/cosmos/ibc/link/harness/fixturekeys"
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/onchain"
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+// IFT describes one fungible-token transfer. The fixture has a single token, so there is no token field.
+//
+// Receiver is a string so the harness surface stays chain-family-agnostic: Prepare canonicalizes it
+// through the destination chain's Reader, and that canonical form is what the source action carries.
+// Empty keeps the default behavior — a fresh auto-funded account on the destination chain.
+type IFT struct {
+	Route    string
+	Amount   *big.Int
+	Receiver string
+	Timeout  time.Duration
+}
+
+// IFTPlan captures pre-submit baselines. Use when submission must happen after setup steps.
+type IFTPlan struct {
+	run       *Session
+	in        IFT
+	route     wire.Route
+	srcHolder string
+	srcBefore *big.Int
+	dstBefore *big.Int
+}
+
+// IFTOutcome is a submitted IFT action plus verification context: the harness-native action the submitter
+// produced, the typed on-chain tracker, and the plan whose frozen input/baselines the Verify methods
+// assert against.
+type IFTOutcome struct {
+	action *onchain.IFTAction
+
+	tracker *onchain.IFTTracker
+	plan    *IFTPlan
+}
+
+// PrepareIFT resolves the route and snapshots balances before submit.
+func (r *Session) PrepareIFT(ctx context.Context, in IFT) (*IFTPlan, error) {
+	// Validate and own the amount once before dispatching to a chain family.
+	if in.Amount == nil {
+		return nil, errors.New("harness: IFT amount is required")
+	}
+	in.Amount = new(big.Int).Set(in.Amount)
+	if in.Amount.Sign() <= 0 {
+		return nil, fmt.Errorf("harness: IFT amount must be positive, got %s", in.Amount)
+	}
+	if in.Amount.BitLen() > 256 {
+		return nil, fmt.Errorf("harness: IFT amount %s exceeds uint256", in.Amount)
+	}
+	route, err := requireRoute(r.h, in.Route)
+	if err != nil {
+		return nil, err
+	}
+	// Resolve the receiver. Empty defaults to a fresh auto-funded account on the destination; anything
+	// else is caller input. Either way it is canonicalized through the destination Reader (the family's
+	// string->address choke point), so the frozen string — what the submission carries and the terminal
+	// floor exact-compares against the destination event — is the family's canonical form regardless of
+	// the caller's casing, and a malformed receiver fails here rather than mid-verification.
+	if in.Receiver == "" {
+		recv, receiverErr := r.defaultIFTReceiver(ctx, route.Destination)
+		if receiverErr != nil {
+			return nil, receiverErr
+		}
+		in.Receiver = recv
+	}
+	rdr, err := r.reader(route.Destination)
+	if err != nil {
+		return nil, err
+	}
+	in.Receiver, err = rdr.CanonicalAddr(in.Receiver)
+	if err != nil {
+		return nil, fmt.Errorf("harness: IFT receiver: %w", err)
+	}
+
+	// Resolve the IFT source holder — the account the source transfer debits — from that chain's deployment
+	// fixture. The harness reads the same holder's balance to baseline and assert the source debit.
+	srcHolder, err := r.iftSourceHolder(route.Source)
+	if err != nil {
+		return nil, err
+	}
+
+	ift := r.ift
+	srcBefore, err := ift.Balance(ctx, route.Source, srcHolder)
+	if err != nil {
+		return nil, err
+	}
+	dstBefore, err := ift.Balance(ctx, route.Destination, in.Receiver)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IFTPlan{
+		run:       r,
+		in:        in,
+		route:     route,
+		srcHolder: srcHolder,
+		srcBefore: srcBefore,
+		dstBefore: dstBefore,
+	}, nil
+}
+
+// Submit sends the transfer using the frozen plan input.
+func (p *IFTPlan) Submit(ctx context.Context) (*IFTOutcome, error) {
+	action, tracker, err := p.run.submitIFT(ctx, p.in, p.route)
+	if err != nil {
+		return nil, err
+	}
+	return &IFTOutcome{action: action, tracker: tracker, plan: p}, nil
+}
+
+// IFT is PrepareIFT + Submit in one call, so its balance baselines snapshot immediately before
+// submission. A test that mutates the world first (pause mining, stop a node) and needs baselines from
+// BEFORE the mutation must use the split form — the one-shot would silently baseline after it.
+func (r *Session) IFT(ctx context.Context, in IFT) (*IFTOutcome, error) {
+	plan, err := r.PrepareIFT(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return plan.Submit(ctx)
+}
+
+// submitIFT starts the transfer through the source chain's submitter (see chain.AppSubmitter) and builds
+// the harness-native action the tracker correlates — constructed from the harness's own submission, so it
+// is correct by construction rather than something the SUT reports back to be verified.
+func (r *Session) submitIFT(
+	ctx context.Context,
+	in IFT,
+	route wire.Route,
+) (*onchain.IFTAction, *onchain.IFTTracker, error) {
+	submitter, err := r.submitter(route.Source)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Resolve the timeout against the destination chain's clock (IBC v2 receive-time semantics).
+	timeoutTs, err := r.resolveTimeout(ctx, route, in.Timeout)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := submitter.SubmitIFT(ctx, chain.IFTSubmission{
+		RouteID:          route.ID,
+		Receiver:         in.Receiver,
+		Amount:           in.Amount,
+		TimeoutTimestamp: timeoutTs,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("harness: submit IFT on route %s: %w", route.ID, err)
+	}
+	action := &onchain.IFTAction{
+		PacketAction: onchain.PacketAction{
+			RouteID:      route.ID,
+			Source:       route.Source,
+			Destination:  route.Destination,
+			SourceTxHash: res.SourceTxHash,
+			Sequence:     res.Sequence,
+		},
+		Receiver: in.Receiver,
+		Amount:   new(big.Int).Set(in.Amount),
+	}
+	return action, r.packets.TrackIFT(action), nil
+}
+
+// submitter resolves the app submitter for a source chain, or a clear error if the run bound none.
+func (r *Session) submitter(chainID string) (chain.AppSubmitter, error) {
+	s, ok := r.submitters[chainID]
+	if !ok {
+		return nil, fmt.Errorf("harness: no app submitter for chain %q", chainID)
+	}
+	return s, nil
+}
+
+// resolveTimeout turns a caller's relative IFT timeout into an absolute unix-second deadline read from the
+// destination chain's clock, matching IBC v2 receive-time semantics. 0 (the happy path) stays 0. The
+// destination chain must expose an EVM client so the harness can read its clock.
+func (r *Session) resolveTimeout(ctx context.Context, route wire.Route, timeout time.Duration) (uint64, error) {
+	if timeout <= 0 {
+		return 0, nil
+	}
+	ec, err := r.h.chains.EVM(route.Destination)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"harness: route %q IFT timeout requires an EVM destination (the timeout/refund leg is out of scope for non-EVM chains): %w",
+			route.ID,
+			err,
+		)
+	}
+	hdr, err := ec.Client().HeaderByNumber(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("harness: read destination %s head for timeout: %w", route.Destination, err)
+	}
+	// Round a sub-second duration up to the next whole second so a small timeout is never truncated to 0
+	// (which would silently disable the leg the caller asked for).
+	secs := uint64((timeout + time.Second - 1) / time.Second)
+	return hdr.Time + secs, nil
+}
+
+// defaultIFTReceiver mints a fresh default IFT receiver on the destination chain by resolving its
+// ReceiverProvider capability. A destination that advertises no ReceiverProvider fails with
+// ErrCapabilityMissing.
+func (r *Session) defaultIFTReceiver(ctx context.Context, destChainID string) (string, error) {
+	rp, err := chainCapability[chain.ReceiverProvider](r.h.chains, destChainID, "ReceiverProvider")
+	if err != nil {
+		return "", err
+	}
+	return rp.NewReceiver(ctx)
+}
+
+// iftSourceHolder resolves the IFT source holder — the account the source transfer debits on chainID — from
+// that chain's deployment fixture (fixturekeys.IFTFaucet).
+func (r *Session) iftSourceHolder(chainID string) (string, error) {
+	return r.fixture(chainID, fixturekeys.IFTFaucet)
+}
+
+func (o *IFTOutcome) iftAsserter() *onchain.IFT { return o.plan.run.ift }
+
+// status is the status source answering for this outcome.
+func (o *IFTOutcome) status() onchain.StatusSource { return o.plan.run.h.relayer }
+
+// destProfile / srcProfile are the timing profiles of the submitted packet's route ends.
+func (o *IFTOutcome) destProfile() topology.TimingProfile {
+	return o.plan.run.h.chains.Profile(o.action.Destination)
+}
+
+func (o *IFTOutcome) srcProfile() topology.TimingProfile {
+	return o.plan.run.h.chains.Profile(o.action.Source)
+}
+
+// VerifyComplete checks tracker terminal floor, status cross-check, and balance deltas.
+func (o *IFTOutcome) VerifyComplete(ctx context.Context) error {
+	if err := o.tracker.VerifyComplete(ctx); err != nil {
+		return err
+	}
+	if err := o.tracker.StatusCrossCheck(ctx, o.status()); err != nil {
+		return err
+	}
+	if err := o.iftAsserter().
+		VerifyReceived(ctx, o.action.Destination, o.action.Receiver, o.action.Amount, o.plan.dstBefore); err != nil {
+		return err
+	}
+	return o.iftAsserter().VerifyEscrow(ctx, o.action.Source, o.plan.srcHolder, o.action.Amount, o.plan.srcBefore)
+}
+
+// VerifyEscrowed asserts only the source-chain escrow effect.
+func (o *IFTOutcome) VerifyEscrowed(ctx context.Context) error {
+	return o.iftAsserter().VerifyEscrow(ctx, o.action.Source, o.plan.srcHolder, o.action.Amount, o.plan.srcBefore)
+}
+
+// VerifyPending asserts status is pending and the destination balance has not changed.
+func (o *IFTOutcome) VerifyPending(ctx context.Context) error {
+	if err := o.VerifyPendingStatus(ctx); err != nil {
+		return err
+	}
+	return o.VerifyNoMint(ctx)
+}
+
+// VerifyPendingStatus asserts only the daemon status.
+func (o *IFTOutcome) VerifyPendingStatus(ctx context.Context) error {
+	_, err := waitPacketState(ctx, o.status(), o.action.ID(), wire.PacketPending, o.destProfile())
+	return err
+}
+
+// VerifyPendingStable asserts the daemon status remains pending across the destination's settle window.
+func (o *IFTOutcome) VerifyPendingStable(ctx context.Context) error {
+	return waitPacketStable(ctx, o.status(), o.action.ID(), wire.PacketPending, o.destProfile())
+}
+
+// VerifyTimedOut asserts the source escrow was refunded and the receiver was never minted.
+func (o *IFTOutcome) VerifyTimedOut(ctx context.Context) error {
+	timedOut, err := waitPacketState(ctx, o.status(), o.action.ID(), wire.PacketTimedOut, o.srcProfile())
+	if err != nil {
+		return err
+	}
+	if timedOut.Reason == "" {
+		return errors.New("harness: timed_out packet must carry a reason")
+	}
+	if timedOut.EffectTxHash == "" {
+		return errors.New("harness: timed_out packet must carry an effect tx hash")
+	}
+	if err := o.tracker.VerifyTimedOut(ctx); err != nil {
+		return err
+	}
+	if err := o.verifyRefunded(ctx); err != nil {
+		return err
+	}
+	return o.VerifyNoMint(ctx)
+}
+
+// VerifyNoMint asserts the destination receiver balance has not changed from the prepared baseline.
+func (o *IFTOutcome) VerifyNoMint(ctx context.Context) error {
+	return o.iftAsserter().VerifyBalance(ctx, o.action.Destination, o.action.Receiver, o.plan.dstBefore)
+}
+
+// verifyRefunded asserts the source faucet balance returned to its prepared baseline.
+func (o *IFTOutcome) verifyRefunded(ctx context.Context) error {
+	return o.iftAsserter().VerifyBalance(ctx, o.action.Source, o.plan.srcHolder, o.plan.srcBefore)
+}

--- a/link/harness/prepared_input_test.go
+++ b/link/harness/prepared_input_test.go
@@ -1,0 +1,105 @@
+package harness
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/ibc/link/harness/fixturekeys"
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/onchain"
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+type preparedInputReader struct {
+	onchain.Reader
+	defaultPayload []byte
+}
+
+func (preparedInputReader) IFTBalance(context.Context, string) (*big.Int, error) {
+	return new(big.Int), nil
+}
+
+func (preparedInputReader) GMPCount(context.Context, string) (*big.Int, error) {
+	return new(big.Int), nil
+}
+
+func (r preparedInputReader) GMPDefaultPayload() []byte { return r.defaultPayload }
+
+func (preparedInputReader) CanonicalAddr(addr string) (string, error) { return addr, nil }
+
+func (preparedInputReader) Budget() onchain.Budget { return onchain.Budget{} }
+
+func newPreparedInputSession(defaultPayload []byte) *Session {
+	route := wire.Route{ID: "route", Source: "source", Destination: "destination"}
+	rdr := preparedInputReader{defaultPayload: defaultPayload}
+	readers := map[string]onchain.Reader{
+		"source":      rdr,
+		"destination": rdr,
+	}
+	return &Session{
+		h: &Harness{topo: topology.Topology{Config: wire.ConfigYAML{
+			Relayer: wire.Relayer{Routes: []wire.Route{route}},
+		}}},
+		deployment: &wire.Deployment{Chains: map[string]wire.ChainDeployment{
+			"source": {Fixtures: map[string]string{fixturekeys.IFTFaucet: "holder"}},
+		}},
+		readers: readers,
+		ift:     onchain.NewIFT(readers),
+		gmp:     onchain.NewGMP(readers),
+	}
+}
+
+func TestPrepareIFTOwnsAmount(t *testing.T) {
+	session := newPreparedInputSession(nil)
+	amount := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+	want := new(big.Int).Set(amount)
+
+	plan, err := session.PrepareIFT(t.Context(), IFT{
+		Route:    "route",
+		Amount:   amount,
+		Receiver: "receiver",
+	})
+	require.NoError(t, err)
+
+	amount.SetInt64(99)
+	require.Equal(t, want, plan.in.Amount)
+}
+
+func TestPrepareIFTRejectsInvalidAmounts(t *testing.T) {
+	session := newPreparedInputSession(nil)
+	tooLarge := new(big.Int).Lsh(big.NewInt(1), 256)
+
+	for _, amount := range []*big.Int{nil, new(big.Int), big.NewInt(-1), tooLarge} {
+		_, err := session.PrepareIFT(t.Context(), IFT{Route: "route", Amount: amount, Receiver: "receiver"})
+		require.Error(t, err)
+	}
+}
+
+func TestPrepareGMPOwnsPayload(t *testing.T) {
+	session := newPreparedInputSession(nil)
+	payload := []byte{1, 2, 3}
+
+	plan, err := session.PrepareGMP(t.Context(), GMP{
+		Route:   "route",
+		Target:  "target",
+		Payload: payload,
+	})
+	require.NoError(t, err)
+
+	payload[0] = 9
+	require.Equal(t, []byte{1, 2, 3}, plan.in.Payload)
+}
+
+func TestPrepareGMPOwnsDefaultPayload(t *testing.T) {
+	payload := []byte{1, 2, 3}
+	session := newPreparedInputSession(payload)
+
+	plan, err := session.PrepareGMP(t.Context(), GMP{Route: "route", Target: "target"})
+	require.NoError(t, err)
+
+	payload[0] = 9
+	require.Equal(t, []byte{1, 2, 3}, plan.in.Payload)
+}

--- a/link/harness/provision/provision.go
+++ b/link/harness/provision/provision.go
@@ -1,0 +1,191 @@
+// Package provision brings a topology's chains up. It is the single component that maps a chain's
+// harness-only Provision (managed vs external, which launcher) onto the concrete chain packages, so the
+// root harness package composes phases without importing any node launcher. The launch decision keys off
+// Provision.Mode/Launcher only — never wire.Chain.Provider, which is relayer-facing metadata the harness
+// must not read.
+//
+// Provisioning returns plain data (Provisioned records); it never touches the chain registry or the
+// diagnostics bundle — both belong to the caller.
+package provision
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cosmos/ibc/link/harness/chain"
+	"github.com/cosmos/ibc/link/harness/chain/evm/anvil"
+	"github.com/cosmos/ibc/link/harness/chain/evm/besu"
+	"github.com/cosmos/ibc/link/harness/chain/evm/external"
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+// Provisioned is one running (or dialed) chain: the handle the rest of the harness drives, the resolved
+// timing profile every wait observing it budgets from, and the lifecycle hooks the owner calls at
+// teardown.
+type Provisioned struct {
+	Chain chain.Chain
+
+	// Profile is the chain's resolved timing profile (ChainSpec.ResolvedTiming) — the same value the
+	// launcher derived the node's block cadence from, so cadence and wait budgets cannot drift.
+	Profile topology.TimingProfile
+
+	// Stop tears the chain down (or, for an external chain, only closes the harness's client).
+	Stop func() error
+
+	// CollectLogs snapshots the chain's logs keyed by chain id, or nil when the harness owns none (an
+	// external node's logs are a named gap, surfaced in the diagnostics topology summary).
+	CollectLogs func(context.Context) map[string]string
+}
+
+// Start brings up the topology's chains concurrently and returns one Provisioned record per started
+// chain, in declaration order. On failure it returns the records of the chains that DID start alongside the error —
+// teardown policy (stop them, or keep them up for inspection) belongs to the caller, so provisioning
+// never second-guesses it. ctx governs startup only; a started chain lives until its Stop is called.
+func Start(ctx context.Context, topo topology.Topology, workDir, runID string) ([]Provisioned, error) {
+	seen := make(map[string]bool, len(topo.Chains))
+	for _, spec := range topo.Chains {
+		if seen[spec.Chain.ID] {
+			return nil, fmt.Errorf("provision: duplicate chain id %q in topology %s", spec.Chain.ID, topo.Name)
+		}
+		seen[spec.Chain.ID] = true
+	}
+
+	// Chains launch concurrently: launchers allocate per-chain ports/containers/networks/workdirs and
+	// share no mutable state, so a 2-chain bring-up costs ~one launch budget instead of two. Each
+	// goroutine writes its own result slot (indexed by declaration order), so the returned records stay
+	// deterministic without a lock. On any failure the errgroup ctx cancels the rest, but we still wait
+	// for every goroutine and return the records of the chains that DID come up — so the caller can tear
+	// them down and nothing leaks when chain 2 of N fails.
+	results := make([]Provisioned, len(topo.Chains))
+	ok := make([]bool, len(topo.Chains))
+	g, gctx := errgroup.WithContext(ctx)
+	for i, spec := range topo.Chains {
+		g.Go(func() error {
+			p, err := startChain(gctx, spec, workDir, runID)
+			if err != nil {
+				return fmt.Errorf("provision: start chain %s: %w", spec.Chain.ID, err)
+			}
+			results[i] = p
+			ok[i] = true
+			return nil
+		})
+	}
+	err := g.Wait()
+
+	started := make([]Provisioned, 0, len(topo.Chains))
+	for i := range results {
+		if ok[i] {
+			started = append(started, results[i])
+		}
+	}
+	return started, err
+}
+
+// startChain brings up one chain per its Provision. The resolved timing profile is passed down so a
+// managed node mines at the profile's BlockInterval.
+func startChain(ctx context.Context, spec topology.ChainSpec, workDir, runID string) (Provisioned, error) {
+	c := spec.Chain
+	prof := spec.ResolvedTiming()
+	switch spec.Provision.Mode {
+	case topology.ProvisionManaged:
+		return startManagedChain(ctx, c, spec.Provision.Launcher, prof, workDir, runID)
+	case topology.ProvisionExternal:
+		ext, err := external.Connect(ctx, external.Spec{
+			ID:      c.ID,
+			ChainID: c.ChainID,
+			RPCURL:  spec.Provision.RPCURL,
+		})
+		if err != nil {
+			return Provisioned{}, err
+		}
+		return Provisioned{
+			Chain:   ext,
+			Profile: prof,
+			// The harness does not own this node: stop only closes the client, it never signals the node,
+			// and there are no logs to collect. The "external (logs unavailable)" gap is surfaced in the
+			// diagnostics topology summary rather than silently omitted.
+			Stop:        func() error { ext.Close(); return nil },
+			CollectLogs: func(context.Context) map[string]string { return nil },
+		}, nil
+	default:
+		return Provisioned{}, fmt.Errorf("chain %s has unknown provision mode %q", c.ID, spec.Provision.Mode)
+	}
+}
+
+// startManagedChain launches a node the harness owns, dispatching on the configured managed launcher. The
+// resolved profile's BlockInterval sets a managed anvil's --block-time (0 = instant/automine, the default)
+// and a managed besu's QBFT block period, so the node seals at exactly the cadence the harness's waits are
+// budgeted for.
+func startManagedChain(
+	ctx context.Context,
+	c wire.Chain,
+	launcher string,
+	prof topology.TimingProfile,
+	workDir, runID string,
+) (Provisioned, error) {
+	switch launcher {
+	case topology.LauncherAnvil:
+		ac, err := anvil.Start(ctx, anvil.Spec{
+			ID:        c.ID,
+			ChainID:   c.ChainID,
+			LogPath:   filepath.Join(workDir, "anvil-"+c.ID+".log"),
+			RunID:     runID,
+			BlockTime: prof.BlockInterval,
+		})
+		if err != nil {
+			return Provisioned{}, err
+		}
+		return Provisioned{
+			Chain:       ac,
+			Profile:     prof,
+			Stop:        ac.Stop,
+			CollectLogs: ac.CollectLogs,
+		}, nil
+	case topology.LauncherBesu:
+		bc, err := besu.StartQBFT(ctx, besu.Spec{
+			ID:            c.ID,
+			ChainID:       c.ChainID,
+			WorkDir:       filepath.Join(workDir, "besu-"+c.ID),
+			RunID:         runID,
+			BlockPeriod:   prof.BlockInterval,
+			RelayerKeyHex: c.EVMSignerKey,
+		})
+		if err != nil {
+			return Provisioned{}, err
+		}
+		return Provisioned{
+			Chain:       bc,
+			Profile:     prof,
+			Stop:        bc.Stop,
+			CollectLogs: bc.CollectLogs,
+		}, nil
+	default:
+		return Provisioned{}, fmt.Errorf("managed launcher %q is unsupported", launcher)
+	}
+}
+
+// Versions reports the versions/images of the launchers the topology's managed chains use, keyed the way
+// the diagnostics bundle names tools. Only launchers in use are probed.
+func Versions(topo topology.Topology) map[string]string {
+	out := map[string]string{}
+	if usesLauncher(topo, topology.LauncherAnvil) {
+		out["anvil-image"] = anvil.DockerImage()
+	}
+	if usesLauncher(topo, topology.LauncherBesu) {
+		out["besu-image"] = besu.DockerImage()
+	}
+	return out
+}
+
+func usesLauncher(t topology.Topology, launcher string) bool {
+	for _, spec := range t.Chains {
+		if spec.Provision.Mode == topology.ProvisionManaged && spec.Provision.Launcher == launcher {
+			return true
+		}
+	}
+	return false
+}

--- a/link/harness/relay.go
+++ b/link/harness/relay.go
@@ -1,0 +1,50 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+)
+
+// Relay identifies one source transaction to submit to the relayer's manual relay endpoint. Field
+// names mirror wire.RelayRequest, the request this becomes.
+type Relay struct {
+	SourceChainID string
+	SourceTxHash  string
+}
+
+// Relay submits a manual relay request for one source transaction.
+func (r *Session) Relay(ctx context.Context, in Relay) error {
+	_, err := r.relay(ctx, in)
+	return err
+}
+
+func (r *Session) relay(ctx context.Context, in Relay) (*wire.RelayResult, error) {
+	req := wire.RelayRequest{SourceChainID: in.SourceChainID, SourceTxHash: in.SourceTxHash}
+	return r.h.relayer.Relay(ctx, req)
+}
+
+// relayOutcome submits the manual relay request for one submitted action's source tx and cross-checks
+// that the daemon matched the action's packet — a miss is a wire-contract violation.
+func (r *Session) relayOutcome(ctx context.Context, sourceChain, packetID, sourceTxHash string) error {
+	res, err := r.relay(ctx, Relay{SourceChainID: sourceChain, SourceTxHash: sourceTxHash})
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(res.PacketIDs, packetID) {
+		return fmt.Errorf("harness: relay result for packet %s did not include it: %v", packetID, res.PacketIDs)
+	}
+	return nil
+}
+
+// Relay requests manual relay for this IFT outcome and verifies the daemon matched this packet.
+func (o *IFTOutcome) Relay(ctx context.Context) error {
+	return o.plan.run.relayOutcome(ctx, o.action.Source, o.action.ID(), o.action.SourceTxHash)
+}
+
+// Relay requests manual relay for this GMP outcome and verifies the daemon matched this packet.
+func (o *GMPOutcome) Relay(ctx context.Context) error {
+	return o.plan.run.relayOutcome(ctx, o.action.Source, o.action.ID(), o.action.SourceTxHash)
+}

--- a/link/harness/route.go
+++ b/link/harness/route.go
@@ -1,0 +1,19 @@
+package harness
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+)
+
+func requireRoute(h *Harness, id string) (wire.Route, error) {
+	if id == "" {
+		return wire.Route{}, errors.New("harness: route is required")
+	}
+	r, ok := h.topo.Config.Route(id)
+	if !ok {
+		return wire.Route{}, fmt.Errorf("harness: unknown route %q", id)
+	}
+	return r, nil
+}

--- a/link/harness/session.go
+++ b/link/harness/session.go
@@ -1,0 +1,48 @@
+package harness
+
+import (
+	"fmt"
+
+	"github.com/cosmos/ibc/link/harness/chain"
+	"github.com/cosmos/ibc/link/harness/ibclink"
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/onchain"
+)
+
+// Session is a Harness plus a successful deployment and running daemon — the test surface for a live
+// relayer flow (session.IFT, session.GMP, session.Chain handles; verification happens through the typed
+// outcomes those return). It is a driver over the harness's world, not a resource owner: the daemon
+// lives on the Harness's process ledger, and teardown is Harness.Shutdown. Like the rest of the harness
+// surface, a Session is single-threaded by test convention.
+type Session struct {
+	h          *Harness
+	deployment *wire.Deployment
+
+	// readers is one on-chain Reader per chain (keyed by Chain.ID), built once from the deployment
+	// the stub reported. The correlator (packets), the ift/gmp asserters, and the prepare/verify paths
+	// all read through these, so the harness surface never touches a chain client for its independent reads.
+	readers map[string]onchain.Reader
+
+	// packets (the on-chain correlator) and the ift/gmp asserters are built once over the immutable
+	// readers map at construction, since every IFT/GMP verify call reuses them. All three are consumed by
+	// the typed outcomes, never exposed to tests.
+	packets onchain.Packets
+	ift     *onchain.IFT
+	gmp     *onchain.GMP
+
+	// submitters is one chain.AppSubmitter per chain (keyed by Chain.ID) — the write-side twin of
+	// readers; see chain.AppSubmitter for the seam's contract.
+	submitters map[string]chain.AppSubmitter
+}
+
+// IBCLink returns the ibc link driver bound to this run's compiled config.
+func (r *Session) IBCLink() ibclink.Runner { return r.h.IBCLink() }
+
+// reader returns the on-chain Reader for chainID, or a clear error if the run bound none.
+func (r *Session) reader(chainID string) (onchain.Reader, error) {
+	rdr, ok := r.readers[chainID]
+	if !ok {
+		return nil, fmt.Errorf("harness: no on-chain reader for chain %q", chainID)
+	}
+	return rdr, nil
+}

--- a/link/harness/session_actions.go
+++ b/link/harness/session_actions.go
@@ -1,0 +1,150 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cosmos/ibc/link/harness/chain"
+	"github.com/cosmos/ibc/link/harness/chain/evm"
+)
+
+// StopRelayer stops the current relayer daemon. The instance stays on the Harness's ledger (a stopped
+// daemon remains fully capturable), and RestartRelayer brings a fresh one up in its place.
+func (r *Session) StopRelayer(ctx context.Context) error {
+	d := r.h.relayer
+	if d == nil {
+		return errors.New("harness: no daemon to stop")
+	}
+	stopCtx, cancel := context.WithTimeout(ctx, daemonStopTimeout)
+	defer cancel()
+	return d.Stop(stopCtx)
+}
+
+// RestartRelayer restarts the current relayer daemon. Both instances end up on the Harness's ledger, so
+// Shutdown captures each under its own LogLabel — no eager capture is needed here (the outgoing
+// instance's Stop snapshots its final status, and its log is an in-memory snapshot).
+func (r *Session) RestartRelayer(ctx context.Context) error {
+	old := r.h.relayer
+	if old == nil {
+		return errors.New("harness: no daemon to restart")
+	}
+	nd, err := old.Restart(ctx)
+	if err != nil {
+		return err
+	}
+	r.h.trackDaemon(nd)
+	return nil
+}
+
+// ChainHandle is a per-chain control surface bound to one chain id in the run's registry. It carries
+// the block-production and fault-injection operations (and a typed EVM view) without repeating the chain
+// id at every call. Capability negotiation is lazy: an operation a chain does not advertise — or a
+// handle for an unknown chain id — fails on use, naming the missing capability, rather than at Chain().
+type ChainHandle struct {
+	chains *Chains
+	id     string
+}
+
+// Chain returns a control handle for the chain with id. The handle is always non-nil; if id names no
+// chain in the run, its operations report the "no chain" error when invoked.
+func (r *Session) Chain(id string) *ChainHandle {
+	return &ChainHandle{chains: r.h.chains, id: id}
+}
+
+// EVM returns the handle's chain's concrete EVM client, or an error if the chain is missing or not EVM.
+func (h *ChainHandle) EVM() (*evm.EVMClient, error) {
+	return h.chains.EVM(h.id)
+}
+
+// PauseMining holds new transactions in the chain mempool until Mine is called.
+func (h *ChainHandle) PauseMining(ctx context.Context) error {
+	ctrl, err := h.blockController()
+	if err != nil {
+		return err
+	}
+	return ctrl.PauseMining(ctx)
+}
+
+// ResumeMining restores normal automining on a paused chain.
+func (h *ChainHandle) ResumeMining(ctx context.Context) error {
+	ctrl, err := h.blockController()
+	if err != nil {
+		return err
+	}
+	return ctrl.ResumeMining(ctx)
+}
+
+// WithPausedMining pauses mining for fn and resumes it even if fn returns an error.
+func (h *ChainHandle) WithPausedMining(ctx context.Context, fn func() error) (err error) {
+	if pauseErr := h.PauseMining(ctx); pauseErr != nil {
+		return pauseErr
+	}
+	defer func() {
+		err = errors.Join(err, h.ResumeMining(ctx))
+	}()
+	return fn()
+}
+
+// Mine produces blocks on a chain whose mining is paused.
+func (h *ChainHandle) Mine(ctx context.Context, blocks int) error {
+	ctrl, err := h.blockController()
+	if err != nil {
+		return err
+	}
+	return ctrl.MineBlocks(ctx, blocks)
+}
+
+// AdvanceTime fast-forwards a chain clock and mines one block to make the new time visible.
+func (h *ChainHandle) AdvanceTime(ctx context.Context, d time.Duration) error {
+	ctrl, err := h.blockController()
+	if err != nil {
+		return err
+	}
+	return ctrl.AdvanceTime(ctx, d)
+}
+
+// StopNode takes a chain's local node down, preserving its state for StartNode.
+func (h *ChainHandle) StopNode(ctx context.Context) error {
+	fi, err := h.faultInjector()
+	if err != nil {
+		return err
+	}
+	return fi.StopNode(ctx)
+}
+
+// StartNode restarts a previously stopped local node on the same RPC address.
+func (h *ChainHandle) StartNode(ctx context.Context) error {
+	fi, err := h.faultInjector()
+	if err != nil {
+		return err
+	}
+	return fi.StartNode(ctx)
+}
+
+func (h *ChainHandle) blockController() (chain.BlockController, error) {
+	return chainCapability[chain.BlockController](h.chains, h.id, "BlockController")
+}
+
+func (h *ChainHandle) faultInjector() (chain.FaultInjector, error) {
+	return chainCapability[chain.FaultInjector](h.chains, h.id, "FaultInjector")
+}
+
+// ErrCapabilityMissing classifies a failed optional-capability negotiation: the action needed a chain
+// capability (chain.As) the chain does not advertise. Wrapped errors name the chain and capability; tests
+// assert the class with errors.Is instead of matching message text.
+var ErrCapabilityMissing = errors.New("harness: missing chain capability")
+
+func chainCapability[T any](chains *Chains, chainID, capability string) (T, error) {
+	var zero T
+	c, err := chains.Get(chainID)
+	if err != nil {
+		return zero, err
+	}
+	capValue, ok := chain.As[T](c)
+	if !ok {
+		return zero, fmt.Errorf("%w: chain %q does not support %s", ErrCapabilityMissing, chainID, capability)
+	}
+	return capValue, nil
+}

--- a/link/harness/start.go
+++ b/link/harness/start.go
@@ -1,0 +1,230 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cosmos/ibc/link/harness/diag"
+	"github.com/cosmos/ibc/link/harness/ibclink"
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/onchain"
+	"github.com/cosmos/ibc/link/harness/provision"
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+// Start brings up the harness's world for one run, in four explicit steps: the workspace (dirs + run
+// id), the provisioned chains, the compiled ibc link config, and the driver over that config. Each step
+// takes the previous step's output — nothing is assembled half-built. Nothing of ibc link runs yet
+// (constructing the driver execs nothing), so a Harness is passive until StartRelayer.
+func Start(ctx context.Context, cfg StartConfig) (*Harness, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	topo := cfg.Topology
+	if err := topo.Validate(); err != nil {
+		return nil, fmt.Errorf("harness.Start: %w", err)
+	}
+
+	ws, err := newWorkspace(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("harness.Start: %w", err)
+	}
+
+	// provision.Start returns whatever chains did start even on failure; keep them up under KeepOnClose
+	// (the whole point is inspecting a failed run), tear them down otherwise.
+	provisioned, err := provision.Start(ctx, topo, ws.dir, ws.runID)
+	chains := newChains(provisioned)
+	abort := func() {
+		if cfg.KeepOnClose {
+			return
+		}
+		_ = chains.stopAll()
+		_ = ws.remove()
+	}
+	if err != nil {
+		abort()
+		return nil, fmt.Errorf("harness.Start: %w", err)
+	}
+
+	link, err := newIBCLink(topo, chains, ws.dir)
+	if err != nil {
+		abort()
+		return nil, fmt.Errorf("harness.Start: %w", err)
+	}
+
+	return &Harness{
+		topo:    topo,
+		chains:  chains,
+		link:    link.runner,
+		linkLog: link.logPath,
+		bundle:  newBundle(topo, link.config),
+		ws:      ws,
+	}, nil
+}
+
+// StartRelayer brings the relayer up against this Harness and returns the Session: it applies the DB
+// migration, validates the compiled config live, deploys the per-chain fixtures, starts the relayer
+// daemon (blocking on its semantic readiness), and binds one on-chain Reader per chain from the
+// reported deployment. Callers that register Harness teardown before calling this (e.g. e2etest) get
+// diagnostics even when a step here fails: the daemon is ledgered the moment it starts, so Shutdown
+// captures its log and status on every exit path below.
+func (h *Harness) StartRelayer(ctx context.Context) (*Session, error) {
+	if h.relayer != nil {
+		// One live session per harness: a second relayer instance is a topology-level decision (route
+		// assignment, shared vs separate DB), never an implicit second StartRelayer.
+		return nil, errors.New("harness.StartRelayer: a relayer session is already live for this harness")
+	}
+	link := h.link
+
+	if err := link.MigrateUp(ctx); err != nil {
+		return nil, fmt.Errorf("harness.StartRelayer: migrate: %w", err)
+	}
+
+	vr, err := link.ValidateConfig(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("harness.StartRelayer: validate config: %w", err)
+	}
+	if !vr.Valid || len(vr.Errors) > 0 {
+		return nil, fmt.Errorf("harness.StartRelayer: invalid config: %v", vr.Errors)
+	}
+
+	dep, err := link.Deploy(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("harness.StartRelayer: deploy: %w", err)
+	}
+	if deploymentErr := assertDeploymentMatchesTopology(dep, h.topo); deploymentErr != nil {
+		return nil, deploymentErr
+	}
+	h.bundle.SetDeployment(dep)
+
+	daemon, err := link.Run(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("harness.StartRelayer: relayer run: %w", err)
+	}
+	// Ledger the daemon before any assertion can fail, so a bring-up that dies past this point still has
+	// the daemon's log and final status captured by Shutdown. The failure paths stop the process but keep
+	// the handle: Logs() is an in-memory snapshot and Stop takes the status snapshot, so a stopped
+	// instance stays fully capturable.
+	h.trackDaemon(daemon)
+	// The daemon already validated its readiness line before link.Run returned (startDaemon -> parseReadiness),
+	// so only the topology-level connectivity assertion is left to make here.
+	ready := daemon.Ready()
+	if connectedErr := assertChainsConnected(ready, h.topo); connectedErr != nil {
+		_ = daemon.Stop(context.Background())
+		return nil, connectedErr
+	}
+
+	// Build one on-chain Reader per chain from the reported deployment, so every subsequent independent
+	// read (correlator, app asserters, prepare baselines) goes through the family-agnostic Reader seam.
+	readers, err := h.buildReaders(dep)
+	if err != nil {
+		_ = daemon.Stop(context.Background())
+		return nil, fmt.Errorf("harness.StartRelayer: build readers: %w", err)
+	}
+
+	// Build one app submitter per chain — the write-side twin of the readers (see chain.AppSubmitter).
+	submitters, err := h.buildSubmitters(dep)
+	if err != nil {
+		_ = daemon.Stop(context.Background())
+		return nil, fmt.Errorf("harness.StartRelayer: build submitters: %w", err)
+	}
+
+	return &Session{
+		h:          h,
+		deployment: dep,
+		readers:    readers,
+		packets:    onchain.NewPackets(readers),
+		ift:        onchain.NewIFT(readers),
+		gmp:        onchain.NewGMP(readers),
+		submitters: submitters,
+	}, nil
+}
+
+// linkDriver is newIBCLink's result: the driver, the log file its one-shot invocations append stderr
+// to, and the compiled config bytes for the diagnostics bundle.
+type linkDriver struct {
+	runner  ibclink.Runner
+	logPath string
+	config  []byte
+}
+
+// newIBCLink compiles the topology into the ibc link config against the chains' runtime endpoints,
+// writes it into the workspace, and constructs the driver over it. Everything here is passive: the
+// ibc link binary is not exec'd until a command runs.
+func newIBCLink(topo topology.Topology, chains *Chains, dir string) (linkDriver, error) {
+	rb := topology.RuntimeBindings{
+		ChainRPC: make(map[string]string, len(topo.Chains)),
+		DBPath:   filepath.Join(dir, "relayer.db"),
+	}
+	// Every chain reports its host-reachable RPC — managed nodes their dynamic 127.0.0.1 port, external
+	// nodes their static URL — so the compiled config points ibc link at the same endpoints the
+	// harness drives. Compile ignores the binding for an external chain and keeps its Provision.RPCURL.
+	for _, p := range chains.list {
+		id := p.Chain.ID()
+		rb.ChainRPC[id] = p.Chain.RPCURL()
+	}
+
+	compiled, err := topology.Compile(topo, rb)
+	if err != nil {
+		return linkDriver{}, fmt.Errorf("compile config: %w", err)
+	}
+	data, err := compiled.Marshal()
+	if err != nil {
+		return linkDriver{}, fmt.Errorf("marshal config: %w", err)
+	}
+	configPath := filepath.Join(dir, "ibc-link.config.yaml")
+	if writeErr := os.WriteFile(configPath, data, 0o600); writeErr != nil {
+		return linkDriver{}, fmt.Errorf("write config %q: %w", configPath, writeErr)
+	}
+
+	logPath := filepath.Join(dir, "ibc-link.log")
+	runner, err := ibclink.NewRunner(ibclink.Options{
+		ConfigPath: configPath,
+		LogPath:    logPath,
+	})
+	if err != nil {
+		return linkDriver{}, fmt.Errorf("build ibc relayer runner: %w", err)
+	}
+	return linkDriver{runner: runner, logPath: logPath, config: data}, nil
+}
+
+// newBundle seeds the diagnostics bundle with everything known statically at startup: the topology
+// summary, tool/image versions (probed via provision for the providers in use), and the compiled config
+// ibc link consumes.
+func newBundle(topo topology.Topology, configYAML []byte) *diag.Bundle {
+	b := diag.NewBundle()
+	b.SetTopology(topologySummary(topo))
+	b.SetVersion("go-ethereum", diag.GoEthereumVersion())
+	b.SetVersion("ibc-link-bin", ibclink.ResolvedRealBin())
+	b.SetVersion("ibc-link-stub-bin", ibclink.ResolvedStubBin())
+	for tool, version := range provision.Versions(topo) {
+		b.SetVersion(tool, version)
+	}
+	b.SetConfig(string(configYAML))
+	return b
+}
+
+func assertDeploymentMatchesTopology(dep *wire.Deployment, topo topology.Topology) error {
+	for _, spec := range topo.Chains {
+		if _, ok := dep.Chain(spec.Chain.ID); !ok {
+			return fmt.Errorf("harness.StartRelayer: deploy must report chain %s", spec.Chain.ID)
+		}
+	}
+	return nil
+}
+
+func assertChainsConnected(ready wire.Readiness, topo topology.Topology) error {
+	connected := make(map[string]bool, len(ready.ChainsConnected))
+	for _, id := range ready.ChainsConnected {
+		connected[id] = true
+	}
+	for _, spec := range topo.Chains {
+		if !connected[spec.Chain.ID] {
+			return fmt.Errorf("harness.StartRelayer: relayer did not connect to chain %s", spec.Chain.ID)
+		}
+	}
+	return nil
+}

--- a/link/harness/wait.go
+++ b/link/harness/wait.go
@@ -1,0 +1,94 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/onchain"
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+// waitPacketState polls the status API until the packet reports want, returning the matched
+// PacketStatus. A status wait is an effect wait seen through the daemon (see wire.PacketStatus), so it
+// runs on onchain.Await with the observed route end's profile. A packet seen in a different state is
+// retained as the last probe error so a timeout names the state the row was stuck in.
+//
+// It takes the narrow onchain.StatusSource (which ibclink.Daemon satisfies) rather than the daemon
+// handle: the wait needs nothing but status queries, and the seam keeps it independent of how many
+// relayer processes serve them — and testable against a scripted source.
+func waitPacketState(
+	ctx context.Context,
+	src onchain.StatusSource,
+	packetID string,
+	want wire.PacketState,
+	prof topology.TimingProfile,
+) (wire.PacketStatus, error) {
+	desc := fmt.Sprintf("packet %s to report status %q", packetID, want)
+	return onchain.Await(
+		ctx,
+		prof.CompletionBudget,
+		prof.PollInterval,
+		desc,
+		func(ctx context.Context) (wire.PacketStatus, bool, error) {
+			s, err := src.Status(ctx, wire.StatusQuery{PacketID: packetID})
+			if err != nil {
+				return wire.PacketStatus{}, false, err // transient; retried within the budget
+			}
+			ps, ok := s.Packet(packetID)
+			if !ok {
+				return wire.PacketStatus{}, false, fmt.Errorf("packet %s not present in daemon status", packetID)
+			}
+			if ps.State != want {
+				// Not-yet progress, retained so a timeout names the state the row was stuck in.
+				return wire.PacketStatus{}, false, fmt.Errorf("packet %s in state %q", packetID, ps.State)
+			}
+			return ps, true, nil
+		},
+	)
+}
+
+// waitPacketStable asserts the packet remains in want across prof's settle window — SettleObservations
+// samples at prof.PollInterval, so the window is a property of the observed chain (it must outlast a block
+// before a state is trusted stable), not a fixed observation count.
+//
+// This is the repo's one stability assertion — the condition must hold at EVERY sample, there is no
+// "done early" — so it is not a wait-until and fits neither wait primitive (onchain.Await and poll.Until
+// both stop at first success). It keeps its own bounded ticker loop by design; see AGENTS.md.
+func waitPacketStable(
+	ctx context.Context,
+	src onchain.StatusSource,
+	packetID string,
+	want wire.PacketState,
+	prof topology.TimingProfile,
+) error {
+	// Bound the whole assertion by the completion budget so a status endpoint that accepts but never
+	// answers can't wedge it forever (unlike waitPacketState, this loop has no onchain.Await budget of its
+	// own). Each Status call runs on this ctx, so a hung request also trips the deadline; the daemon's
+	// http.Client carries its own ceiling too.
+	ctx, cancel := context.WithTimeout(ctx, prof.CompletionBudget)
+	defer cancel()
+
+	ticker := time.NewTicker(prof.PollInterval)
+	defer ticker.Stop()
+	for i := 0; i < prof.SettleObservations(); i++ {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context canceled while watching packet %s stay %q: %w", packetID, want, ctx.Err())
+		case <-ticker.C:
+		}
+		s, err := src.Status(ctx, wire.StatusQuery{PacketID: packetID})
+		if err != nil {
+			return err
+		}
+		ps, ok := s.Packet(packetID)
+		if !ok {
+			return fmt.Errorf("packet %s must stay present in the ledger", packetID)
+		}
+		if ps.State != want {
+			return fmt.Errorf("packet %s must remain %q, got %q", packetID, want, ps.State)
+		}
+	}
+	return nil
+}

--- a/link/harness/wait_test.go
+++ b/link/harness/wait_test.go
@@ -1,0 +1,114 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/ibc/link/harness/ibclink/wire"
+	"github.com/cosmos/ibc/link/harness/topology"
+)
+
+// statusFunc adapts a func to onchain.StatusSource so wait tests script the status API per call.
+type statusFunc func(ctx context.Context, q wire.StatusQuery) (*wire.Status, error)
+
+func (f statusFunc) Status(ctx context.Context, q wire.StatusQuery) (*wire.Status, error) {
+	return f(ctx, q)
+}
+
+// scriptStatus returns a StatusSource that serves each step once (the last repeats forever). A nil
+// *wire.Status step serves an error instead, exercising the transient-retry path.
+func scriptStatus(steps ...*wire.Status) statusFunc {
+	var mu sync.Mutex
+	i := 0
+	return func(_ context.Context, _ wire.StatusQuery) (*wire.Status, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		s := steps[i]
+		if i < len(steps)-1 {
+			i++
+		}
+		if s == nil {
+			return nil, errors.New("scripted transient error")
+		}
+		return s, nil
+	}
+}
+
+func packetIn(state wire.PacketState) *wire.Status {
+	return &wire.Status{Packets: []wire.PacketStatus{{
+		PacketID: "p-1",
+		RouteID:  "r-1",
+		Sequence: 7,
+		State:    state,
+	}}}
+}
+
+// fastProfile keeps the wait tests sub-second: 24 settle observations at 5ms inside a 500ms budget.
+func fastProfile() topology.TimingProfile {
+	return topology.TimingProfile{
+		CompletionBudget: 500 * time.Millisecond,
+		SettleWindow:     120 * time.Millisecond,
+		PollInterval:     5 * time.Millisecond,
+	}
+}
+
+func TestWaitPacketStateReturnsMatch(t *testing.T) {
+	src := scriptStatus(packetIn(wire.PacketPending), packetIn(wire.PacketPending), packetIn(wire.PacketComplete))
+	ps, err := waitPacketState(t.Context(), src, "p-1", wire.PacketComplete, fastProfile())
+	require.NoError(t, err)
+	require.Equal(t, wire.PacketComplete, ps.State)
+	require.Equal(t, uint64(7), ps.Sequence)
+}
+
+func TestWaitPacketStateRetriesTransientErrors(t *testing.T) {
+	src := scriptStatus(nil, nil, packetIn(wire.PacketComplete))
+	_, err := waitPacketState(t.Context(), src, "p-1", wire.PacketComplete, fastProfile())
+	require.NoError(t, err)
+}
+
+func TestWaitPacketStateTimeoutNamesStuckState(t *testing.T) {
+	prof := fastProfile()
+	prof.CompletionBudget = 50 * time.Millisecond
+	_, err := waitPacketState(t.Context(), scriptStatus(packetIn(wire.PacketPending)), "p-1", wire.PacketComplete, prof)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `packet p-1 in state "pending"`)
+}
+
+func TestWaitPacketStateTimeoutNamesMissingPacket(t *testing.T) {
+	prof := fastProfile()
+	prof.CompletionBudget = 50 * time.Millisecond
+	empty := &wire.Status{}
+	_, err := waitPacketState(t.Context(), scriptStatus(empty), "p-1", wire.PacketComplete, prof)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not present in daemon status")
+}
+
+func TestWaitPacketStableHolds(t *testing.T) {
+	err := waitPacketStable(t.Context(), scriptStatus(packetIn(wire.PacketPending)), "p-1", wire.PacketPending, fastProfile())
+	require.NoError(t, err)
+}
+
+func TestWaitPacketStableRejectsFlap(t *testing.T) {
+	// The packet flips to complete partway through the settle window; the assertion must fail, not
+	// "recover" — a stability check holds at every sample.
+	src := scriptStatus(
+		packetIn(wire.PacketPending),
+		packetIn(wire.PacketPending),
+		packetIn(wire.PacketComplete),
+	)
+	err := waitPacketStable(t.Context(), src, "p-1", wire.PacketPending, fastProfile())
+	require.Error(t, err)
+	require.ErrorContains(t, err, `must remain "pending"`)
+}
+
+func TestWaitPacketStableRejectsDisappearance(t *testing.T) {
+	src := scriptStatus(packetIn(wire.PacketPending), &wire.Status{})
+	err := waitPacketStable(t.Context(), src, "p-1", wire.PacketPending, fastProfile())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "must stay present")
+}


### PR DESCRIPTION
Builds the harness runtime and public API on top of the foundations layer, including diagnostics, provisioning, sessions, routes, and relay orchestration.

Stack: 2/4.