### PR TITLE
fix(e2e): derive relayer attestors from environment

### DIFF
--- a/e2e/e2etest/traffic_setup.go
+++ b/e2e/e2etest/traffic_setup.go
@@ -115,7 +115,7 @@ func Deploy(
 }
 
 // DeployWithRelayerConfig is Deploy with a hook that adjusts the resolved
-// relayer configuration before it is written.
+// relayer configuration after environment Attestors are assigned.
 func DeployWithRelayerConfig(
 	t testing.TB,
 	env *environment.Environment,
@@ -433,6 +433,25 @@ func buildConfig(
 			ICS26Router: apps.ICS26Router.Hex(),
 		})
 	}
+	attestorIDs := env.Attestors()
+	attestorSets := make(map[string]*ibclink.RelayerAttestorSet, len(attestorIDs))
+	for _, id := range attestorIDs {
+		attestor, err := env.Attestor(id)
+		if err != nil {
+			t.Fatalf("e2etest: resolve Attestor %q: %v", id, err)
+		}
+		client := attestor.IBCClient()
+		chainID := options.ChainIDs[string(client.IBCInstance().Chain().ID())]
+		key := chainID + "/" + string(client.Locator())
+		set := attestorSets[key]
+		if set == nil {
+			set = &ibclink.RelayerAttestorSet{Threshold: int(client.MinRequiredSignatures())}
+			attestorSets[key] = set
+		}
+		set.Attestors = append(set.Attestors, ibclink.RelayerAttestor{
+			Name: string(attestor.ID()), Type: ibclink.RelayerAttestorRemote, GRPC: attestor.Endpoint(),
+		})
+	}
 
 	connections := map[string]bool{}
 	for _, route := range routes {
@@ -456,6 +475,8 @@ func buildConfig(
 		key := connection.ChainA + "/" + connection.ClientA
 		if !connections[key] {
 			connections[key] = true
+			connection.AttestorSetA = attestorSets[key]
+			connection.AttestorSetB = attestorSets[connection.ChainB+"/"+connection.ClientB]
 			config.Connections = append(config.Connections, connection)
 		}
 

--- a/e2e/internal/harness/environment/environment.go
+++ b/e2e/internal/harness/environment/environment.go
@@ -107,6 +107,17 @@ func (e *Environment) Attestor(id AttestorID) (*Attestor, error) {
 	return attestor, nil
 }
 
+// Attestors returns the resolved Attestor identities in stable order. The
+// returned slice is owned by the caller.
+func (e *Environment) Attestors() []AttestorID {
+	ids := make([]AttestorID, 0, len(e.attestors))
+	for id := range e.attestors {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
 // Close releases acquired effects in reverse acquisition order, then removes
 // the private workspace. Successful effects are never repeated. If cleanup
 // fails or ctx expires, a later call retries only unfinished effects.

--- a/e2e/internal/harness/environment/environment_test.go
+++ b/e2e/internal/harness/environment/environment_test.go
@@ -19,3 +19,17 @@ func TestEnvironmentChainsReturnsStableCallerOwnedIDs(t *testing.T) {
 	ids[0] = "changed-by-caller"
 	require.Equal(t, []ChainID{"alpha", "bravo", "charlie"}, env.Chains())
 }
+
+func TestEnvironmentAttestorsReturnsStableCallerOwnedIDs(t *testing.T) {
+	env := &Environment{attestors: map[AttestorID]*Attestor{
+		"charlie": {},
+		"alpha":   {},
+		"bravo":   {},
+	}}
+
+	ids := env.Attestors()
+	require.Equal(t, []AttestorID{"alpha", "bravo", "charlie"}, ids)
+
+	ids[0] = "changed-by-caller"
+	require.Equal(t, []AttestorID{"alpha", "bravo", "charlie"}, env.Attestors())
+}


### PR DESCRIPTION
## Summary

Fix relayer configuration for environments with declared attestors. The harness previously ignored those declarations and fell back to local attestors whose keys were not registered on-chain.

Remote sets are now derived from the resolved environment, matched by chain and client locator, and use the client's resolved quorum.

## Testing

- `make lint-e2e`
- environment and e2etest package tests
- complete Anvil E2E suite