### PR TITLE
test(e2e): add attested IFT auto-relay coverage

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -2,7 +2,8 @@
 
 This module contains one root repository-level acceptance package: linear Go tests over the
 `internal/harness` surface. Tests relay real IBC packets through the real Link relayer and
-Solidity IBC stack (ICS26Router, ICS20Transfer, ICS27GMP) with a permissive dummy light client.
+Solidity IBC stack (ICS26Router, ICS20Transfer, ICS27GMP), usually with a permissive dummy light
+client; `TestAttestedIFTTransfer_AutoRelay` uses attestation clients and managed attestors.
 
 - Run everything from the repository root: `make test-e2e` for the complete acceptance package, or
   `make test-e2e E2E_FLAGS='-run TestTransfer_AutoRelay -count=1'` for one focused loop. Lanes:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,12 +1,12 @@
 # Repository E2E Test Surface
 
-This repository-level surface hosts one black-box acceptance package. Its tests drive IBC Link through its public CLI, config, readiness, relay, and status contracts, and relay real IBC packets: each Chain runs the real Solidity IBC stack (ICS26Router, ICS20Transfer, ICS27GMP) behind a permissive dummy light client that accepts every packet without proof verification, so the transport is real while attestation stays out of scope.
+This repository-level surface hosts one black-box acceptance package. Its tests drive IBC Link through its public CLI, config, readiness, relay, and status contracts, and relay real IBC packets. Most use a permissive dummy light client that accepts packets without proof verification; `TestAttestedIFTTransfer_AutoRelay` instead uses attestation clients and managed attestors.
 
 `internal/harness/environment` realizes Chains and protocol resources, including the IBC contract stack and dummy light clients. `e2etest` deploys a test ERC20, a Counter target, and an IFT token per Chain and binds ICS20 transfers, ICS27 GMP calls, and IFT transfers to routes. Tests deploy the applications and start the relayer explicitly, so process restarts, manual relay, fault injection, and teardown remain visible in the behavior under test.
 
 ## Acceptance coverage
 
-The root package covers ICS20 transfer, ICS27 GMP, and IFT (burn/mint on top of GMP) relay behavior, timeout refunds, error acknowledgements, pending-packet status, Relayer and node recovery, cross-route handling, and relaying through an attached RPC that `Environment` does not own. These are all acceptance criteria and run together by default.
+The root package covers ICS20 transfer, ICS27 GMP, IFT (burn/mint on top of GMP) relay behavior, an attested IFT relay, timeout refunds, error acknowledgements, pending-packet status, Relayer and node recovery, cross-route handling, and relaying through an attached RPC that `Environment` does not own. These are all acceptance criteria and run together by default.
 
 ## Running the acceptance tests
 
@@ -18,7 +18,7 @@ make build-link
 make test-e2e
 ```
 
-`make build-link` produces `link/bin/ibc`; `IBC_BIN` overrides that path. The real Link Relayer submits recv, ack, and timeout transactions with empty proofs, which the dummy light client accepts.
+`make build-link` produces `link/bin/ibc`; `IBC_BIN` overrides that path. In dummy-client tests, the real Link Relayer submits recv, ack, and timeout transactions with empty proofs, which the dummy light client accepts.
 
 The same tests can select different Chain declarations:
 
@@ -51,7 +51,7 @@ func TestTransfer_AutoRelay(t *testing.T) {
     require.NoError(t, err)
     destination, err := env.Chain(route.Destination)
     require.NoError(t, err)
-    err = e2etest.AwaitState(t.Context(), relayer, transfer.Packet(),
+    _, err = e2etest.AwaitState(t.Context(), relayer, transfer.Packet(),
         relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
     require.NoError(t, err)
     require.NoError(t, transfer.VerifyDelivered(t.Context()))

--- a/e2e/attached_chain_test.go
+++ b/e2e/attached_chain_test.go
@@ -78,7 +78,7 @@ func TestAttachedChainRemainsCallerOwned(t *testing.T) {
 
 		attached, chainErr := env.Chain(e2etest.ChainB)
 		require.NoError(t, chainErr)
-		awaitErr := e2etest.AwaitState(rctx, relayer, transfer.Packet(),
+		_, awaitErr := e2etest.AwaitState(rctx, relayer, transfer.Packet(),
 			relayerv2.PacketState_PACKET_STATE_SUCCEEDED, attached.Timing())
 		require.NoError(t, awaitErr)
 		require.NoError(t, transfer.VerifyDelivered(rctx))

--- a/e2e/attestation_helpers_test.go
+++ b/e2e/attestation_helpers_test.go
@@ -1,0 +1,48 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/solidity-ibc-eureka/packages/go-abigen/attestation"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+)
+
+type attestationClientState struct {
+	AttestorAddresses []common.Address
+	MinRequiredSigs   uint8
+	LatestHeight      uint64
+	IsFrozen          bool
+}
+
+func attestedClientState(
+	t testing.TB,
+	evm *environment.EVM,
+	address environment.EVMAddress,
+) attestationClientState {
+	t.Helper()
+	var encoded []byte
+	err := evm.UseContractCaller(func(caller bind.ContractCaller) error {
+		client, err := attestation.NewContractCaller(common.HexToAddress(string(address)), caller)
+		if err != nil {
+			return err
+		}
+		encoded, err = client.GetClientState(&bind.CallOpts{Context: t.Context()})
+		return err
+	})
+	require.NoError(t, err)
+	tuple, err := abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "attestorAddresses", Type: "address[]"},
+		{Name: "minRequiredSigs", Type: "uint8"},
+		{Name: "latestHeight", Type: "uint64"},
+		{Name: "isFrozen", Type: "bool"},
+	})
+	require.NoError(t, err)
+	values, err := (abi.Arguments{{Type: tuple}}).Unpack(encoded)
+	require.NoError(t, err)
+	return *abi.ConvertType(values[0], new(attestationClientState)).(*attestationClientState)
+}

--- a/e2e/cross_route_test.go
+++ b/e2e/cross_route_test.go
@@ -52,10 +52,10 @@ func TestCrossRoutePacketsDoNotCollideBySequence(t *testing.T) {
 
 	destination, err := env.Chain("chain-a")
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, bToA.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, bToA.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, cToA.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, cToA.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
 	require.NoError(t, bToA.VerifyDelivered(ctx))

--- a/e2e/e2etest/traffic_relayer.go
+++ b/e2e/e2etest/traffic_relayer.go
@@ -12,20 +12,22 @@ import (
 	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
+// AwaitState waits for the packet to reach want. If want is pending and the
+// relayer has not indexed the source transaction, it returns (nil, nil).
 func AwaitState(
 	ctx context.Context,
 	relayer *ibclink.Relayer,
 	packet Packet,
 	want relayerv2.PacketState,
 	timing environment.Timing,
-) error {
+) (*relayerv2.PacketStatus, error) {
 	if relayer == nil {
-		return errors.New("e2etest: relayer is required")
+		return nil, errors.New("e2etest: relayer is required")
 	}
 	packetID := packetID(packet)
 
 	description := fmt.Sprintf("packet %s to report status %q", packetID, want)
-	_, err := await(
+	return await(
 		ctx,
 		timing.CompletionBudget,
 		timing.PollInterval,
@@ -55,7 +57,6 @@ func AwaitState(
 			return observed, true, nil
 		},
 	)
-	return err
 }
 
 // AwaitStable requires the packet to remain in one state across the Chain's
@@ -69,7 +70,7 @@ func AwaitStable(
 ) error {
 	ctx, cancel := context.WithTimeout(ctx, timing.CompletionBudget)
 	defer cancel()
-	if err := AwaitState(ctx, relayer, packet, want, timing); err != nil {
+	if _, err := AwaitState(ctx, relayer, packet, want, timing); err != nil {
 		return err
 	}
 

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -27,7 +27,7 @@ func TestGMPCall_AutoRelay(t *testing.T) {
 	require.NoError(t, err)
 	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, call.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, call.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
 	require.NoError(t, call.VerifyExecuted(ctx))
@@ -52,7 +52,7 @@ func TestGMPCall_ErrorAcknowledgement(t *testing.T) {
 	require.NoError(t, err)
 	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, call.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, call.Packet(),
 		relayerv2.PacketState_PACKET_STATE_REJECTED, destination.Timing())
 	require.NoError(t, err)
 	require.NoError(t, call.VerifyRejected(ctx))

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -110,7 +110,6 @@ func TestAttestedIFTTransfer_AutoRelay(t *testing.T) {
 	require.GreaterOrEqual(t, sourceState.LatestHeight, receiveReceipt.BlockNumber.Uint64())
 }
 
-//nolint:dupl // acceptance tests keep their setup sequences deliberately explicit
 func TestIFTTransfer_AutoRelay(t *testing.T) {
 	t.Parallel()
 	spec := dummyClientMeshSpec(e2etest.ChainSpecsForConfiguredLane(t))

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -17,6 +17,100 @@ import (
 // destination mint reverts on it, forcing an error acknowledgement.
 var zeroAddressReceiver = (common.Address{}).Hex()
 
+const (
+	attestedClientAID  environment.ClientID    = "attested-client-a"
+	attestedClientBID  environment.ClientID    = "attested-client-b"
+	attestorAID        environment.AttestorID  = "attestor-a"
+	attestorBID        environment.AttestorID  = "attestor-b"
+	attestorAAuthority environment.AuthorityID = "attestor-a-authority"
+	attestorBAuthority environment.AuthorityID = "attestor-b-authority"
+)
+
+func TestAttestedIFTTransfer_AutoRelay(t *testing.T) {
+	t.Parallel()
+	spec := environment.Spec{
+		Chains: e2etest.ChainSpecsForConfiguredLane(t),
+		IBCInstances: []environment.IBCInstanceSpec{
+			environment.NewIBCInstance{
+				ID:        "attested-ibc-a",
+				Chain:     e2etest.ChainA,
+				Authority: e2etest.ProtocolAuthorityID,
+			},
+			environment.NewIBCInstance{
+				ID:        "attested-ibc-b",
+				Chain:     e2etest.ChainB,
+				Authority: e2etest.ProtocolAuthorityID,
+			},
+		},
+		Connections: []environment.ConnectionSpec{{
+			ID: "attested-connection",
+			A: environment.NewClient{
+				ID:                    attestedClientAID,
+				IBCInstance:           "attested-ibc-a",
+				Authority:             e2etest.ProtocolAuthorityID,
+				MinRequiredSignatures: 1,
+			},
+			B: environment.NewClient{
+				ID:                    attestedClientBID,
+				IBCInstance:           "attested-ibc-b",
+				Authority:             e2etest.ProtocolAuthorityID,
+				MinRequiredSignatures: 1,
+			},
+		}},
+		Attestors: []environment.AttestorSpec{
+			{ID: attestorAID, Client: attestedClientAID, Authority: attestorAAuthority},
+			{ID: attestorBID, Client: attestedClientBID, Authority: attestorBAuthority},
+		},
+	}
+	runtime := e2etest.RuntimeWithProtocolDeployer(
+		environment.Runtime{Authorities: map[environment.AuthorityID]environment.EVMAuthority{
+			attestorAAuthority: {PrivateKeyHex: "0000000000000000000000000000000000000000000000000000000000000006"},
+			attestorBAuthority: {PrivateKeyHex: "0000000000000000000000000000000000000000000000000000000000000007"},
+		}},
+	)
+	env := e2etest.Start(t, spec, runtime)
+	signers := e2etest.NewSigners(t)
+	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
+	attestorA, err := env.Attestor(attestorAID)
+	require.NoError(t, err)
+	attestorB, err := env.Attestor(attestorBID)
+	require.NoError(t, err)
+	driver, deployment := e2etest.Deploy(t, env, signers, route)
+	iftApp := e2etest.BindIFT(t, env, deployment, signers, route)
+	relayer := e2etest.StartRelayer(t, driver, env)
+	ctx := t.Context()
+
+	transfer, err := iftApp.Send(ctx, e2etest.IFTRequest{Amount: big.NewInt(1_234_000)})
+	require.NoError(t, err)
+	require.NoError(t, transfer.VerifyBurned(ctx))
+
+	destination, err := env.Chain(route.Destination)
+	require.NoError(t, err)
+	status, err := e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
+	require.NoError(t, err)
+	require.NoError(t, transfer.VerifyDelivered(ctx))
+
+	source, err := env.Chain(route.Source)
+	require.NoError(t, err)
+	sourceEVM, err := source.EVM()
+	require.NoError(t, err)
+	sendReceipt, err := sourceEVM.TransactionReceipt(ctx, common.HexToHash(transfer.Packet().SourceTxHash))
+	require.NoError(t, err)
+	destinationEVM, err := destination.EVM()
+	require.NoError(t, err)
+	receiveReceipt, err := destinationEVM.TransactionReceipt(ctx, common.HexToHash(status.GetRecvTx().GetTxHash()))
+	require.NoError(t, err)
+
+	destinationState := attestedClientState(t, destinationEVM, attestorB.IBCClient().LightClientAddress())
+	sourceState := attestedClientState(t, sourceEVM, attestorA.IBCClient().LightClientAddress())
+	// The receive proof advanced the destination client through the send block.
+	require.GreaterOrEqual(t, destinationState.LatestHeight, sendReceipt.BlockNumber.Uint64())
+	// The acknowledgement proof advanced the source client through the receive block.
+	require.GreaterOrEqual(t, sourceState.LatestHeight, receiveReceipt.BlockNumber.Uint64())
+}
+
+//nolint:dupl // acceptance tests keep their setup sequences deliberately explicit
 func TestIFTTransfer_AutoRelay(t *testing.T) {
 	t.Parallel()
 	spec := dummyClientMeshSpec(e2etest.ChainSpecsForConfiguredLane(t))
@@ -36,7 +130,7 @@ func TestIFTTransfer_AutoRelay(t *testing.T) {
 
 	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyDelivered(ctx))
@@ -75,7 +169,7 @@ func TestIFTTimeout_Refund(t *testing.T) {
 
 	source, err := env.Chain(route.Source)
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_TIMED_OUT, source.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyRefunded(ctx))
@@ -107,7 +201,7 @@ func TestIFTTransfer_ErrorAck_Refund(t *testing.T) {
 
 	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_REJECTED, destination.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyNotMinted(ctx))
@@ -137,7 +231,7 @@ func TestIFTTransfer_ErrorAck_UnregisteredBridge(t *testing.T) {
 
 	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_REJECTED, destination.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyNotMinted(ctx))
@@ -175,7 +269,7 @@ func TestIFTTransfer_MultiPacketPending(t *testing.T) {
 	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
 	for _, transfer := range transfers {
-		err := e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+		_, err := e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 			relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 		require.NoError(t, err)
 		require.NoError(t, transfer.VerifyDelivered(ctx))
@@ -221,7 +315,7 @@ func TestIFTTransfer_MultiPacketSingleTx(t *testing.T) {
 	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
 	for _, packet := range packets {
-		err = e2etest.AwaitState(ctx, relayer, packet,
+		_, err = e2etest.AwaitState(ctx, relayer, packet,
 			relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 		require.NoError(t, err)
 	}

--- a/e2e/internal/harness/environment/chain.go
+++ b/e2e/internal/harness/environment/chain.go
@@ -118,6 +118,16 @@ func (e *EVM) BroadcastTx(
 	return receipt, err
 }
 
+func (e *EVM) TransactionReceipt(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+	var receipt *types.Receipt
+	err := e.use(func(client *chainevm.EVMClient) error {
+		var err error
+		receipt, err = client.Client().TransactionReceipt(ctx, hash)
+		return err
+	})
+	return receipt, err
+}
+
 func (e *EVM) transactionWait() chainevm.TransactionWait {
 	return chainevm.TransactionWait{
 		Timeout:      e.chain.timing.CompletionBudget,

--- a/e2e/internal/harness/ibclink/attestor.go
+++ b/e2e/internal/harness/ibclink/attestor.go
@@ -1,9 +1,4 @@
 // Package ibclink manages IBC Link processes as black boxes.
-//
-// Readiness means that the process loaded its private configuration and serves
-// LatestHeight for the configured attestor. The current Link
-// implementation returns a synthetic timestamp from that RPC; this package
-// therefore does not claim that the process can produce or submit attestations.
 package ibclink
 
 import (

--- a/e2e/node_recovery_test.go
+++ b/e2e/node_recovery_test.go
@@ -50,7 +50,7 @@ func TestRelayerRecoversAfterNodeRestart(t *testing.T) {
 	_, err = chainB.Height(ctx)
 	require.NoError(t, err, "after node restart the destination must be reachable again")
 
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, chainB.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyDelivered(ctx))

--- a/e2e/pending_packet_test.go
+++ b/e2e/pending_packet_test.go
@@ -45,7 +45,7 @@ func TestPendingPacketStatusWhileDestinationMiningPaused(t *testing.T) {
 	// The relayer only submits to a chain whose clock is current and only
 	// counts blocks behind the tip as final, so delivery completes once the
 	// destination produces blocks again.
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, chainB.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyDelivered(ctx))

--- a/e2e/relayer_lifecycle_test.go
+++ b/e2e/relayer_lifecycle_test.go
@@ -48,7 +48,7 @@ func TestManualRelay_RequestSurvivesRestart(t *testing.T) {
 		return nil
 	}))
 
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, chainB.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyDelivered(ctx))

--- a/e2e/scripts/clean.sh
+++ b/e2e/scripts/clean.sh
@@ -23,10 +23,6 @@ done
 
 note() { printf 'clean-e2e: %s\n' "$*"; }
 
-binary_name="${IBC_BIN:-ibc}"
-binary_name="${binary_name##*/}"
-binary_pattern="$(printf '%s' "$binary_name" | sed 's#[][(){}.^$*+?|\\/]#\\&#g')"
-
 sweep() {
 	local label="$1" pattern="$2" pids
 	pids="$(pgrep -f "$pattern" || true)"
@@ -48,15 +44,14 @@ sweep() {
 	kill -9 $pids 2>/dev/null || true
 }
 
-# Match the configured SUT running `relayer run`, scoped to the
+# Match Link running `relayer run`, scoped to the
 # harness's compiled config (ibc-link.config.yaml, always in --config of a harness-spawned daemon) so a
-# developer's own unrelated `ibc relayer run` is never signaled. Binary is anchored at a path separator
-# or start of the cmdline so an unrelated `…ibc` suffix can't false-match.
-sweep "e2e relayer daemons" "(^|/)$binary_pattern relayer run .*ibc-link\\.config\\.yaml"
+# developer's own unrelated `ibc relayer run` is never signaled.
+sweep "e2e relayer daemons" '(^|[[:space:]])relayer[[:space:]]+run[[:space:]].*ibc-link\.config\.yaml'
 
 # Match harness-spawned attestors by their --home path, which is always nested
 # under the harness-private ibc-environment-private-* workspace.
-sweep "e2e attestor daemons" "(^|/)$binary_pattern attestor run .*--home [^[:space:]]*/ibc-environment-private-[^[:space:]]+"
+sweep "e2e attestor daemons" '(^|[[:space:]])attestor[[:space:]]+run[[:space:]].*--home[[:space:]]+[^[:space:]]*/ibc-environment-private-[^[:space:]]+'
 
 docker_sweep() {
 	if ! command -v docker >/dev/null; then

--- a/e2e/scripts/clean.sh
+++ b/e2e/scripts/clean.sh
@@ -23,6 +23,10 @@ done
 
 note() { printf 'clean-e2e: %s\n' "$*"; }
 
+binary_name="${IBC_BIN:-ibc}"
+binary_name="${binary_name##*/}"
+binary_pattern="$(printf '%s' "$binary_name" | sed 's#[][(){}.^$*+?|\\/]#\\&#g')"
+
 sweep() {
 	local label="$1" pattern="$2" pids
 	pids="$(pgrep -f "$pattern" || true)"
@@ -44,15 +48,15 @@ sweep() {
 	kill -9 $pids 2>/dev/null || true
 }
 
-# Match the `ibc` SUT running `relayer run`, scoped to the
+# Match the configured SUT running `relayer run`, scoped to the
 # harness's compiled config (ibc-link.config.yaml, always in --config of a harness-spawned daemon) so a
 # developer's own unrelated `ibc relayer run` is never signaled. Binary is anchored at a path separator
 # or start of the cmdline so an unrelated `…ibc` suffix can't false-match.
-sweep "e2e relayer daemons" '(^|/)ibc relayer run .*ibc-link\.config\.yaml'
+sweep "e2e relayer daemons" "(^|/)$binary_pattern relayer run .*ibc-link\\.config\\.yaml"
 
 # Match harness-spawned attestors by their --home path, which is always nested
 # under the harness-private ibc-environment-private-* workspace.
-sweep "e2e attestor daemons" '(^|/)ibc attestor run .*--home [^[:space:]]*/ibc-environment-private-[^[:space:]]+'
+sweep "e2e attestor daemons" "(^|/)$binary_pattern attestor run .*--home [^[:space:]]*/ibc-environment-private-[^[:space:]]+"
 
 docker_sweep() {
 	if ! command -v docker >/dev/null; then

--- a/e2e/scripts/clean.sh
+++ b/e2e/scripts/clean.sh
@@ -8,9 +8,9 @@ while [ "$#" -gt 0 ]; do
 		--dry-run) dry_run=1 ;;
 		-h|--help)
 			printf 'Usage: %s [--dry-run]\n\n' "$0"
-			printf 'Stops leaked e2e relayer daemons and removes e2e Docker containers by label.\n'
-			printf 'Daemons are matched by the harness config marker (ibc-link.config.yaml in argv), so a\n'
-			printf 'developer'"'"'s own unrelated "ibc relayer run" is left alone.\n'
+			printf 'Stops leaked e2e relayer and attestor daemons and removes e2e Docker containers by label.\n'
+			printf 'Daemons are matched by harness-only config or private-home markers, so a developer'"'"'s\n'
+			printf 'own unrelated "ibc relayer run" or "ibc attestor run" is left alone.\n'
 			exit 0
 			;;
 		*)
@@ -49,6 +49,10 @@ sweep() {
 # developer's own unrelated `ibc relayer run` is never signaled. Binary is anchored at a path separator
 # or start of the cmdline so an unrelated `…ibc` suffix can't false-match.
 sweep "e2e relayer daemons" '(^|/)ibc relayer run .*ibc-link\.config\.yaml'
+
+# Match harness-spawned attestors by their --home path, which is always nested
+# under the harness-private ibc-environment-private-* workspace.
+sweep "e2e attestor daemons" '(^|/)ibc attestor run .*--home [^[:space:]]*/ibc-environment-private-[^[:space:]]+'
 
 docker_sweep() {
 	if ! command -v docker >/dev/null; then

--- a/e2e/transfer_test.go
+++ b/e2e/transfer_test.go
@@ -31,7 +31,7 @@ func TestTransfer_AutoRelay(t *testing.T) {
 
 	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyDelivered(ctx))
@@ -59,7 +59,7 @@ func TestTransfer_ManualRelay(t *testing.T) {
 		relayerv2.PacketState_PACKET_STATE_PENDING, destination.Timing()))
 	require.NoError(t, transfer.VerifyNotMinted(ctx))
 	require.NoError(t, e2etest.Relay(ctx, relayer, transfer.Packet()))
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyDelivered(ctx))
@@ -104,7 +104,7 @@ func TestTransferTimeout_Refund(t *testing.T) {
 
 	source, err := env.Chain(route.Source)
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
 		relayerv2.PacketState_PACKET_STATE_TIMED_OUT, source.Timing())
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyRefunded(ctx))


### PR DESCRIPTION
## Summary

- add an attested IFT auto-relay acceptance test with distinct remote attestors
- verify burn/mint delivery and anchor both receive and acknowledgement proofs to on-chain client heights
- share the attestation-state decoder for follow-up attested tests
- clean up leaked attestor processes, including custom `IBC_BIN` basenames

## Why

FOU-1072 adds the first end-to-end IFT path whose packet proofs are verified by attestation clients rather than the permissive dummy client.

## Checks

- `make build-link`
- `make lint-e2e`
- `make test-harness`
- full default E2E suite
- focused test on Anvil, interval Anvil, and Besu
- `shellcheck e2e/scripts/clean.sh`

Linear: FOU-1072