### PR TITLE
test(e2e): cover multi-attestor quorum recovery

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -3,7 +3,8 @@
 This module contains one root repository-level acceptance package: linear Go tests over the
 `internal/harness` surface. Tests relay real IBC packets through the real Link relayer and
 Solidity IBC stack (ICS26Router, ICS20Transfer, ICS27GMP), usually with a permissive dummy light
-client; `TestAttestedIFTTransfer_AutoRelay` uses attestation clients and managed attestors.
+client; the attested IFT tests use attestation clients and managed attestors, including quorum loss
+and recovery.
 
 - Run everything from the repository root: `make test-e2e` for the complete acceptance package, or
   `make test-e2e E2E_FLAGS='-run TestTransfer_AutoRelay -count=1'` for one focused loop. Lanes:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,12 +1,12 @@
 # Repository E2E Test Surface
 
-This repository-level surface hosts one black-box acceptance package. Its tests drive IBC Link through its public CLI, config, readiness, relay, and status contracts, and relay real IBC packets. Most use a permissive dummy light client that accepts packets without proof verification; `TestAttestedIFTTransfer_AutoRelay` instead uses attestation clients and managed attestors.
+This repository-level surface hosts one black-box acceptance package. Its tests drive IBC Link through its public CLI, config, readiness, relay, and status contracts, and relay real IBC packets. Most use a permissive dummy light client that accepts packets without proof verification; the attested IFT tests instead use attestation clients and managed attestors, including 2-of-3 quorum loss and recovery.
 
 `internal/harness/environment` realizes Chains and protocol resources, including the IBC contract stack and dummy light clients. `e2etest` deploys a test ERC20, a Counter target, and an IFT token per Chain and binds ICS20 transfers, ICS27 GMP calls, and IFT transfers to routes. Tests deploy the applications and start the relayer explicitly, so process restarts, manual relay, fault injection, and teardown remain visible in the behavior under test.
 
 ## Acceptance coverage
 
-The root package covers ICS20 transfer, ICS27 GMP, IFT (burn/mint on top of GMP) relay behavior, an attested IFT relay, timeout refunds, error acknowledgements, pending-packet status, Relayer and node recovery, cross-route handling, and relaying through an attached RPC that `Environment` does not own. These are all acceptance criteria and run together by default.
+The root package covers ICS20 transfer, ICS27 GMP, IFT (burn/mint on top of GMP) relay behavior, attested IFT relay and quorum recovery, timeout refunds, error acknowledgements, pending-packet status, Relayer and node recovery, cross-route handling, and relaying through an attached RPC that `Environment` does not own. These are all acceptance criteria and run together by default.
 
 ## Running the acceptance tests
 

--- a/e2e/attestation_helpers_test.go
+++ b/e2e/attestation_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cosmos/ibc/e2e/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 )
 
@@ -45,4 +46,27 @@ func attestedClientState(
 	values, err := (abi.Arguments{{Type: tuple}}).Unpack(encoded)
 	require.NoError(t, err)
 	return *abi.ConvertType(values[0], new(attestationClientState)).(*attestationClientState)
+}
+
+func requireAttestedIFTClientHeights(
+	t testing.TB,
+	source, destination *environment.EVM,
+	sourceClient, destinationClient environment.EVMAddress,
+	transfer *e2etest.IFTPacket,
+	receiveTxHash string,
+) uint64 {
+	t.Helper()
+	sendReceipt, err := source.TransactionReceipt(t.Context(), common.HexToHash(transfer.Packet().SourceTxHash))
+	require.NoError(t, err)
+	receiveReceipt, err := destination.TransactionReceipt(t.Context(), common.HexToHash(receiveTxHash))
+	require.NoError(t, err)
+
+	destinationState := attestedClientState(t, destination, destinationClient)
+	sourceState := attestedClientState(t, source, sourceClient)
+	sendBlock := sendReceipt.BlockNumber.Uint64()
+	// The receive proof advanced the destination client through the send block.
+	require.GreaterOrEqual(t, destinationState.LatestHeight, sendBlock)
+	// The acknowledgement proof advanced the source client through the receive block.
+	require.GreaterOrEqual(t, sourceState.LatestHeight, receiveReceipt.BlockNumber.Uint64())
+	return sendBlock
 }

--- a/e2e/e2etest/traffic_relayer.go
+++ b/e2e/e2etest/traffic_relayer.go
@@ -59,8 +59,8 @@ func AwaitState(
 	)
 }
 
-// AwaitStable requires the packet to remain in one state across the Chain's
-// settle window after that state is first observed.
+// AwaitStable requires the packet to remain in one state across the
+// environment's end-to-end settle window after that state is first observed.
 func AwaitStable(
 	ctx context.Context,
 	relayer *ibclink.Relayer,

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -69,7 +69,7 @@ func TestGMPCall_ICS27AccountTransfer(t *testing.T) {
 	require.NoError(t, err)
 	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
-	err = e2etest.AwaitState(ctx, relayer, call.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, call.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
 

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -25,8 +25,12 @@ const (
 	attestedClientBID  environment.ClientID    = "attested-client-b"
 	attestorAID        environment.AttestorID  = "attestor-a"
 	attestorBID        environment.AttestorID  = "attestor-b"
+	attestorCID        environment.AttestorID  = "attestor-c"
+	attestorDID        environment.AttestorID  = "attestor-d"
 	attestorAAuthority environment.AuthorityID = "attestor-a-authority"
 	attestorBAuthority environment.AuthorityID = "attestor-b-authority"
+	attestorCAuthority environment.AuthorityID = "attestor-c-authority"
+	attestorDAuthority environment.AuthorityID = "attestor-d-authority"
 )
 
 func TestAttestedIFTTransfer_AutoRelay(t *testing.T) {
@@ -98,19 +102,132 @@ func TestAttestedIFTTransfer_AutoRelay(t *testing.T) {
 	require.NoError(t, err)
 	sourceEVM, err := source.EVM()
 	require.NoError(t, err)
-	sendReceipt, err := sourceEVM.TransactionReceipt(ctx, common.HexToHash(transfer.Packet().SourceTxHash))
+	destinationEVM, err := destination.EVM()
+	require.NoError(t, err)
+	requireAttestedIFTClientHeights(t, sourceEVM, destinationEVM,
+		attestorA.IBCClient().LightClientAddress(), attestorB.IBCClient().LightClientAddress(),
+		transfer, status.GetRecvTx().GetTxHash())
+}
+
+func TestAttestedIFTTransfer_MultiAttestorQuorum(t *testing.T) {
+	t.Parallel()
+	spec := environment.Spec{
+		Chains: e2etest.ChainSpecsForConfiguredLane(t),
+		IBCInstances: []environment.IBCInstanceSpec{
+			environment.NewIBCInstance{
+				ID:        "attested-quorum-ibc-a",
+				Chain:     e2etest.ChainA,
+				Authority: e2etest.ProtocolAuthorityID,
+			},
+			environment.NewIBCInstance{
+				ID:        "attested-quorum-ibc-b",
+				Chain:     e2etest.ChainB,
+				Authority: e2etest.ProtocolAuthorityID,
+			},
+		},
+		Connections: []environment.ConnectionSpec{{
+			ID: "attested-quorum-connection",
+			A: environment.NewClient{
+				ID: attestedClientAID, IBCInstance: "attested-quorum-ibc-a", Authority: e2etest.ProtocolAuthorityID,
+				MinRequiredSignatures: 1,
+			},
+			B: environment.NewClient{
+				ID: attestedClientBID, IBCInstance: "attested-quorum-ibc-b", Authority: e2etest.ProtocolAuthorityID,
+				MinRequiredSignatures: 2,
+			},
+		}},
+		Attestors: []environment.AttestorSpec{
+			{ID: attestorAID, Client: attestedClientAID, Authority: attestorAAuthority},
+			{ID: attestorBID, Client: attestedClientBID, Authority: attestorBAuthority},
+			{ID: attestorCID, Client: attestedClientBID, Authority: attestorCAuthority},
+			{ID: attestorDID, Client: attestedClientBID, Authority: attestorDAuthority},
+		},
+	}
+	runtime := e2etest.RuntimeWithProtocolDeployer(
+		environment.Runtime{Authorities: map[environment.AuthorityID]environment.EVMAuthority{
+			attestorAAuthority: {
+				PrivateKeyHex: "0000000000000000000000000000000000000000000000000000000000000006",
+			},
+			attestorBAuthority: {
+				PrivateKeyHex: "0000000000000000000000000000000000000000000000000000000000000007",
+			},
+			attestorCAuthority: {
+				PrivateKeyHex: "0000000000000000000000000000000000000000000000000000000000000008",
+			},
+			attestorDAuthority: {
+				PrivateKeyHex: "0000000000000000000000000000000000000000000000000000000000000009",
+			},
+		}},
+	)
+	env := e2etest.Start(t, spec, runtime)
+	signers := e2etest.NewSigners(t)
+	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
+	sourceAttestor, err := env.Attestor(attestorAID)
+	require.NoError(t, err)
+	destinationAttestorB, err := env.Attestor(attestorBID)
+	require.NoError(t, err)
+	destinationAttestorC, err := env.Attestor(attestorCID)
+	require.NoError(t, err)
+	destinationAttestorD, err := env.Attestor(attestorDID)
+	require.NoError(t, err)
+	driver, deployment := e2etest.Deploy(t, env, signers, route)
+	iftApp := e2etest.BindIFT(t, env, deployment, signers, route)
+	ctx := t.Context()
+	// Keep every endpoint in Link's config while starting it with one attestor unavailable.
+	require.NoError(t, destinationAttestorD.Stop(ctx))
+	relayer := e2etest.StartRelayer(t, driver, env)
+
+	destination, err := env.Chain(route.Destination)
 	require.NoError(t, err)
 	destinationEVM, err := destination.EVM()
 	require.NoError(t, err)
-	receiveReceipt, err := destinationEVM.TransactionReceipt(ctx, common.HexToHash(status.GetRecvTx().GetTxHash()))
-	require.NoError(t, err)
+	destinationClient := destinationAttestorB.IBCClient()
+	require.ElementsMatch(t, []environment.EVMAddress{
+		destinationAttestorB.SignerAddress(),
+		destinationAttestorC.SignerAddress(),
+		destinationAttestorD.SignerAddress(),
+	}, destinationClient.AttestorAddresses())
+	require.Equal(t, uint8(2), destinationClient.MinRequiredSignatures())
 
-	destinationState := attestedClientState(t, destinationEVM, attestorB.IBCClient().LightClientAddress())
-	sourceState := attestedClientState(t, sourceEVM, attestorA.IBCClient().LightClientAddress())
-	// The receive proof advanced the destination client through the send block.
-	require.GreaterOrEqual(t, destinationState.LatestHeight, sendReceipt.BlockNumber.Uint64())
-	// The acknowledgement proof advanced the source client through the receive block.
-	require.GreaterOrEqual(t, sourceState.LatestHeight, receiveReceipt.BlockNumber.Uint64())
+	// Two live attestors satisfy the destination client's quorum.
+	transfer, err := iftApp.Send(ctx, e2etest.IFTRequest{Amount: big.NewInt(1_234_000)})
+	require.NoError(t, err)
+	require.NoError(t, transfer.VerifyBurned(ctx))
+	status, err := e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
+	require.NoError(t, err)
+	require.NoError(t, transfer.VerifyDelivered(ctx))
+
+	source, err := env.Chain(route.Source)
+	require.NoError(t, err)
+	sourceEVM, err := source.EVM()
+	require.NoError(t, err)
+	sendBlock := requireAttestedIFTClientHeights(t, sourceEVM, destinationEVM,
+		sourceAttestor.IBCClient().LightClientAddress(), destinationClient.LightClientAddress(),
+		transfer, status.GetRecvTx().GetTxHash())
+	destinationAttestorBHeight, err := destinationAttestorB.LatestHeight(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, destinationAttestorBHeight, sendBlock)
+	destinationAttestorCHeight, err := destinationAttestorC.LatestHeight(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, destinationAttestorCHeight, sendBlock)
+
+	// One live attestor cannot satisfy the destination client's quorum.
+	require.NoError(t, destinationAttestorC.Stop(ctx))
+	pending, err := iftApp.Send(ctx, e2etest.IFTRequest{Amount: big.NewInt(2_345_000)})
+	require.NoError(t, err)
+	require.NoError(t, pending.VerifyBurned(ctx))
+	require.NoError(t, e2etest.Relay(ctx, relayer, pending.Packet()))
+	require.NoError(t, e2etest.AwaitStable(ctx, relayer, pending.Packet(),
+		relayerv2.PacketState_PACKET_STATE_PENDING, destination.Timing()))
+	require.NoError(t, pending.VerifyNotMinted(ctx))
+
+	// Restoring a second attestor lets the pending transfer complete.
+	require.NoError(t, destinationAttestorC.Restart(ctx))
+	_, err = e2etest.AwaitState(ctx, relayer, pending.Packet(),
+		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
+	require.NoError(t, err)
+	require.NoError(t, pending.VerifyDelivered(ctx))
 }
 
 func TestIFTTransfer_AutoRelay(t *testing.T) {
@@ -401,7 +518,7 @@ func TestIFTTransfer_BatchedRecvAck(t *testing.T) {
 	recvTxCounts := make(map[string]int, packetCount)
 	ackTxCounts := make(map[string]int, packetCount)
 	for _, packet := range packets {
-		err = e2etest.AwaitState(ctx, relayer, packet.Packet(),
+		_, err = e2etest.AwaitState(ctx, relayer, packet.Packet(),
 			relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 		require.NoError(t, err)
 		require.NoError(t, packet.VerifyDelivered(ctx))
@@ -485,7 +602,7 @@ func TestIFTTransfer_BatchedTimeout(t *testing.T) {
 	require.NoError(t, err)
 	timeoutTxCounts := make(map[string]int, packetCount)
 	for _, packet := range packets {
-		err = e2etest.AwaitState(ctx, relayer, packet.Packet(),
+		_, err = e2etest.AwaitState(ctx, relayer, packet.Packet(),
 			relayerv2.PacketState_PACKET_STATE_TIMED_OUT, source.Timing())
 		require.NoError(t, err)
 		require.NoError(t, packet.VerifyNotMinted(ctx))

--- a/e2e/internal/harness/environment/spec.go
+++ b/e2e/internal/harness/environment/spec.go
@@ -132,9 +132,10 @@ func (c AttachedEVM) validateChain() error {
 	return c.Timing.validate(c.ID)
 }
 
-// Timing describes the behavior workflows need in order to wait for an
-// attached Chain without assuming Anvil or Besu defaults. BlockInterval may be
-// zero for instant mining; all wait budgets must be positive.
+// Timing describes the end-to-end wait behavior workflows need without
+// assuming Anvil or Besu defaults. SettleWindow must cover chain progress and
+// harness-managed relayer and attestor delays. BlockInterval may be zero for
+// instant mining; all wait budgets must be positive.
 type Timing struct {
 	BlockInterval    time.Duration
 	CompletionBudget time.Duration


### PR DESCRIPTION
## Summary

- add a 2-of-3 destination-attestor quorum acceptance test
- prove one inactive attestor still permits delivery, losing a second leaves the packet pending without minting, and restoring quorum completes the same transfer
- verify the configured signer set, threshold, client heights, and both live attestors’ latest attestable heights

## Why

FOU-1076 covers Link quorum aggregation and recovery through the black-box E2E surface.

## Checks

- `make build-link`
- `make lint-e2e`
- `make test-e2e`
- focused test on Anvil, interval Anvil, and Besu

Linear: FOU-1076

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>