### PR TITLE
fix(link): bound remote attestor requests

### DIFF
--- a/link/internal/service/attestor/remote.go
+++ b/link/internal/service/attestor/remote.go
@@ -24,6 +24,8 @@ type RemoteAttestor struct {
 
 var _ Attestor = &RemoteAttestor{}
 
+const remoteRequestTimeout = 5 * time.Second
+
 func NewRemoteFromURL(chainID, name, alias, grpcURL string) *RemoteAttestor {
 	var (
 		httpClient  = newConnectHTTPClient()
@@ -44,6 +46,9 @@ func NewRemote(chainID, name, alias string, client proto.AttestationServiceClien
 }
 
 func (a *RemoteAttestor) LatestHeight(ctx context.Context) (uint64, error) {
+	ctx, cancel := context.WithTimeout(ctx, remoteRequestTimeout)
+	defer cancel()
+
 	req := &proto.LatestHeightRequest{
 		Attestor: a.name,
 	}
@@ -57,6 +62,9 @@ func (a *RemoteAttestor) LatestHeight(ctx context.Context) (uint64, error) {
 }
 
 func (a *RemoteAttestor) StateAttestation(ctx context.Context, height uint64) (Attestation, error) {
+	ctx, cancel := context.WithTimeout(ctx, remoteRequestTimeout)
+	defer cancel()
+
 	req := &proto.StateAttestationRequest{
 		Attestor: a.name,
 		Height:   height,
@@ -71,6 +79,9 @@ func (a *RemoteAttestor) StateAttestation(ctx context.Context, height uint64) (A
 }
 
 func (a *RemoteAttestor) PacketAttestation(ctx context.Context, req PacketAttestationRequest) (Attestation, error) {
+	ctx, cancel := context.WithTimeout(ctx, remoteRequestTimeout)
+	defer cancel()
+
 	ct, err := CommitmentTypeToProto(req.CommitmentType)
 	if err != nil {
 		return Attestation{}, err

--- a/link/internal/service/attestor/remote_test.go
+++ b/link/internal/service/attestor/remote_test.go
@@ -1,0 +1,52 @@
+package attestor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	proto "github.com/cosmos/ibc/link/api/v2/attestor"
+)
+
+func TestRemoteAttestorRequestTimeout(t *testing.T) {
+	client := timeoutAttestationClient{t: t}
+	remote := NewRemote("chain", "name", "alias", client)
+
+	_, err := remote.LatestHeight(context.Background())
+	require.NoError(t, err)
+	_, err = remote.StateAttestation(context.Background(), 1)
+	require.NoError(t, err)
+	_, err = remote.PacketAttestation(context.Background(), PacketAttestationRequest{
+		CommitmentType: CommitmentTypePacket,
+	})
+	require.NoError(t, err)
+}
+
+type timeoutAttestationClient struct {
+	t *testing.T
+}
+
+func (c timeoutAttestationClient) LatestHeight(ctx context.Context, _ *connect.Request[proto.LatestHeightRequest]) (*connect.Response[proto.LatestHeightResponse], error) {
+	c.requireTimeout(ctx)
+	return connect.NewResponse(&proto.LatestHeightResponse{}), nil
+}
+
+func (c timeoutAttestationClient) StateAttestation(ctx context.Context, _ *connect.Request[proto.StateAttestationRequest]) (*connect.Response[proto.StateAttestationResponse], error) {
+	c.requireTimeout(ctx)
+	return connect.NewResponse(&proto.StateAttestationResponse{Attestation: &proto.Attestation{}}), nil
+}
+
+func (c timeoutAttestationClient) PacketAttestation(ctx context.Context, _ *connect.Request[proto.PacketAttestationRequest]) (*connect.Response[proto.PacketAttestationResponse], error) {
+	c.requireTimeout(ctx)
+	return connect.NewResponse(&proto.PacketAttestationResponse{Attestation: &proto.Attestation{}}), nil
+}
+
+func (c timeoutAttestationClient) requireTimeout(ctx context.Context) {
+	c.t.Helper()
+	deadline, ok := ctx.Deadline()
+	require.True(c.t, ok)
+	require.WithinDuration(c.t, time.Now().Add(remoteRequestTimeout), deadline, time.Second)
+}


### PR DESCRIPTION
## Summary

- apply a five-second deadline to remote attestor height, state, and packet-attestation RPCs
- add focused coverage that every remote RPC receives the deadline

## Why

Remote attestor calls inherited the relayer pipeline’s long-lived context. An endpoint that accepted a connection but never responded could therefore stall quorum collection indefinitely, even when enough other attestors were healthy.

The bounded requests let an unresponsive endpoint fail and allow quorum processing to continue or retry.

## Checks

- `make build-link`
- `make -C link test`
- `make -C link lint`
- `make lint-e2e`
- `make test-e2e`