### PR TITLE
test(e2e): gmp ics27 account transfer

### DIFF
--- a/e2e/e2etest/traffic_apps.go
+++ b/e2e/e2etest/traffic_apps.go
@@ -86,6 +86,8 @@ func BindGMP(
 		sourceRouter: sourceApps.ICS26Router,
 		counter:      destinationApps.Counter,
 		sourceClient: clients.SourceClient,
+		destClient:   clients.DestClient,
+		destGMP:      destinationApps.ICS27GMP,
 		defaultCall:  defaultCall,
 	}
 }

--- a/e2e/e2etest/traffic_apps.go
+++ b/e2e/e2etest/traffic_apps.go
@@ -73,6 +73,10 @@ func BindGMP(
 	if err != nil {
 		t.Fatalf("e2etest: bind GMP on route %q: %v", route.ID, err)
 	}
+	defaultCall, err := mustABI(counter.CounterMetaData).Pack("increment")
+	if err != nil {
+		t.Fatalf("e2etest: pack Counter.increment(): %v", err)
+	}
 	return &GMP{
 		routeID:      route.ID,
 		source:       sourceEndpoint,
@@ -80,36 +84,11 @@ func BindGMP(
 		sender:       signers.application.account,
 		sourceGMP:    sourceApps.ICS27GMP,
 		sourceRouter: sourceApps.ICS26Router,
+		counter:      destinationApps.Counter,
 		sourceClient: clients.SourceClient,
 		destClient:   clients.DestClient,
 		destGMP:      destinationApps.ICS27GMP,
-	}
-}
-
-// BindGMPCounter binds ICS27 GMP to a Counter target on the destination
-// chain, adding Counter-specific request defaults and verification on top of
-// the base GMP.
-func BindGMPCounter(
-	t testing.TB,
-	env *environment.Environment,
-	deployment *Deployment,
-	signers Signers,
-	route Route,
-) *GMPCounter {
-	t.Helper()
-	gmp := BindGMP(t, env, deployment, signers, route)
-	destinationApps, ok := deployment.Chain(route.Destination)
-	if !ok {
-		t.Fatalf("e2etest: deployment has no destination Chain %q", route.Destination)
-	}
-	defaultCall, err := mustABI(counter.CounterMetaData).Pack("increment")
-	if err != nil {
-		t.Fatalf("e2etest: pack Counter.increment(): %v", err)
-	}
-	return &GMPCounter{
-		GMP:         gmp,
-		counter:     destinationApps.Counter,
-		defaultCall: defaultCall,
+		defaultCall:  defaultCall,
 	}
 }
 

--- a/e2e/e2etest/traffic_apps.go
+++ b/e2e/e2etest/traffic_apps.go
@@ -73,10 +73,6 @@ func BindGMP(
 	if err != nil {
 		t.Fatalf("e2etest: bind GMP on route %q: %v", route.ID, err)
 	}
-	defaultCall, err := mustABI(counter.CounterMetaData).Pack("increment")
-	if err != nil {
-		t.Fatalf("e2etest: pack Counter.increment(): %v", err)
-	}
 	return &GMP{
 		routeID:      route.ID,
 		source:       sourceEndpoint,
@@ -84,11 +80,36 @@ func BindGMP(
 		sender:       signers.application.account,
 		sourceGMP:    sourceApps.ICS27GMP,
 		sourceRouter: sourceApps.ICS26Router,
-		counter:      destinationApps.Counter,
 		sourceClient: clients.SourceClient,
 		destClient:   clients.DestClient,
 		destGMP:      destinationApps.ICS27GMP,
-		defaultCall:  defaultCall,
+	}
+}
+
+// BindGMPCounter binds ICS27 GMP to a Counter target on the destination
+// chain, adding Counter-specific request defaults and verification on top of
+// the base GMP.
+func BindGMPCounter(
+	t testing.TB,
+	env *environment.Environment,
+	deployment *Deployment,
+	signers Signers,
+	route Route,
+) *GMPCounter {
+	t.Helper()
+	gmp := BindGMP(t, env, deployment, signers, route)
+	destinationApps, ok := deployment.Chain(route.Destination)
+	if !ok {
+		t.Fatalf("e2etest: deployment has no destination Chain %q", route.Destination)
+	}
+	defaultCall, err := mustABI(counter.CounterMetaData).Pack("increment")
+	if err != nil {
+		t.Fatalf("e2etest: pack Counter.increment(): %v", err)
+	}
+	return &GMPCounter{
+		GMP:         gmp,
+		counter:     destinationApps.Counter,
+		defaultCall: defaultCall,
 	}
 }
 

--- a/e2e/e2etest/traffic_apps.go
+++ b/e2e/e2etest/traffic_apps.go
@@ -88,6 +88,7 @@ func BindGMP(
 		sourceClient: clients.SourceClient,
 		destClient:   clients.DestClient,
 		destGMP:      destinationApps.ICS27GMP,
+		destToken:    destinationApps.Token,
 		defaultCall:  defaultCall,
 	}
 }

--- a/e2e/e2etest/traffic_evm.go
+++ b/e2e/e2etest/traffic_evm.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/testerc20"
 
 	ethereum "github.com/ethereum/go-ethereum"
 )
@@ -40,6 +41,27 @@ func NewAddress() (common.Address, error) {
 		return common.Address{}, fmt.Errorf("e2etest: generate address: %w", err)
 	}
 	return account.Address(), nil
+}
+
+// erc20BalanceOf queries a TestERC20 contract's balance for holder.
+func erc20BalanceOf(
+	ctx context.Context,
+	client *environment.EVM,
+	contract, holder common.Address,
+) (*big.Int, error) {
+	var balance *big.Int
+	err := client.UseContractCaller(func(caller bind.ContractCaller) error {
+		bound, err := testerc20.NewTestERC20Caller(contract, caller)
+		if err != nil {
+			return fmt.Errorf("e2etest: bind TestERC20 %s: %w", contract, err)
+		}
+		balance, err = bound.BalanceOf(&bind.CallOpts{Context: ctx}, holder)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("e2etest: query TestERC20 %s balance of %s: %w", contract, holder, err)
+	}
+	return balance, nil
 }
 
 func deployContract(

--- a/e2e/e2etest/traffic_evm.go
+++ b/e2e/e2etest/traffic_evm.go
@@ -32,6 +32,16 @@ func mustBinding[T any](binding T, err error) T {
 	return binding
 }
 
+// NewAddress generates a fresh, unfunded EVM address for use as a test
+// recipient (e.g. an ERC20 transfer target).
+func NewAddress() (common.Address, error) {
+	account, err := evm.NewAccount()
+	if err != nil {
+		return common.Address{}, fmt.Errorf("e2etest: generate address: %w", err)
+	}
+	return account.Address(), nil
+}
+
 func deployContract(
 	ctx context.Context,
 	client *environment.EVM,

--- a/e2e/e2etest/traffic_gmp.go
+++ b/e2e/e2etest/traffic_gmp.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/counter"
-	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/testerc20"
 )
 
 var gmpABI = mustABI(ics27gmp.ContractMetaData)
@@ -198,19 +197,7 @@ func (g *GMP) StoredAccountIdentifier(
 
 // ERC20BalanceOf queries the bound TestERC20's balance on the destination chain.
 func (g *GMP) ERC20BalanceOf(ctx context.Context, holder common.Address) (*big.Int, error) {
-	var balance *big.Int
-	err := g.destination.evm.UseContractCaller(func(caller bind.ContractCaller) error {
-		bound, err := testerc20.NewTestERC20Caller(g.destToken, caller)
-		if err != nil {
-			return fmt.Errorf("e2etest: bind TestERC20 %s: %w", g.destToken, err)
-		}
-		balance, err = bound.BalanceOf(&bind.CallOpts{Context: ctx}, holder)
-		return err
-	})
-	if err != nil {
-		return nil, fmt.Errorf("e2etest: query TestERC20 %s balance of %s: %w", g.destToken, holder, err)
-	}
-	return balance, nil
+	return erc20BalanceOf(ctx, g.destination.evm, g.destToken, holder)
 }
 
 // FundERC20 mints amount of the bound TestERC20 to holder on the destination

--- a/e2e/e2etest/traffic_gmp.go
+++ b/e2e/e2etest/traffic_gmp.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/counter"
+	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/testerc20"
 )
 
 var gmpABI = mustABI(ics27gmp.ContractMetaData)
@@ -18,6 +19,10 @@ var gmpABI = mustABI(ics27gmp.ContractMetaData)
 type GMPRequest struct {
 	// Payload defaults to Counter.increment(). Call takes its own copy.
 	Payload []byte
+	// Receiver defaults to the bound Counter's address.
+	Receiver string
+	// Salt defaults to empty, matching sendCall's default account identifier.
+	Salt []byte
 }
 
 // GMP binds ICS27 GMP and its default Counter target on a single directed route.
@@ -30,6 +35,8 @@ type GMP struct {
 	sourceRouter common.Address
 	counter      common.Address
 	sourceClient string
+	destClient   string
+	destGMP      common.Address
 	defaultCall  []byte
 }
 
@@ -45,6 +52,10 @@ func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
 		payload = g.defaultCall
 	}
 	payload = append([]byte(nil), payload...)
+	receiver := request.Receiver
+	if receiver == "" {
+		receiver = g.counter.Hex()
+	}
 	before, err := g.count(ctx)
 	if err != nil {
 		return nil, err
@@ -55,8 +66,8 @@ func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
 	}
 	msg := ics27gmp.IICS27GMPMsgsSendCallMsg{
 		SourceClient:     g.sourceClient,
-		Receiver:         g.counter.Hex(),
-		Salt:             nil,
+		Receiver:         receiver,
+		Salt:             request.Salt,
 		Payload:          payload,
 		TimeoutTimestamp: timeoutTimestamp,
 		Memo:             "",
@@ -122,6 +133,121 @@ func (g *GMP) count(ctx context.Context) (*big.Int, error) {
 		return nil, fmt.Errorf("e2etest: query Counter %s: %w", g.counter, err)
 	}
 	return count, nil
+}
+
+// AccountIdentifier builds the ICS27 account identifier that onRecvPacket
+// constructs on the destination chain for a call sent by sender with salt:
+// AccountIdentifier{ClientId: destinationClient, Sender: sender.Hex(), Salt: salt}.
+// sender.Hex() is EIP-55 checksummed, matching Strings.toChecksumHexString(_msgSender())
+// used by ICS27GMP.sendCall on the source chain.
+func (g *GMP) AccountIdentifier(sender common.Address, salt []byte) ics27gmp.IICS27GMPMsgsAccountIdentifier {
+	return ics27gmp.IICS27GMPMsgsAccountIdentifier{
+		ClientId: g.destClient,
+		Sender:   sender.Hex(),
+		Salt:     salt,
+	}
+}
+
+// AccountAddress derives the ICS27 account address for id via the destination
+// ICS27GMP contract's getOrComputeAccountAddress view, rather than
+// reimplementing its CREATE2 derivation. Safe to call before the account
+// contract is deployed.
+func (g *GMP) AccountAddress(
+	ctx context.Context,
+	id ics27gmp.IICS27GMPMsgsAccountIdentifier,
+) (common.Address, error) {
+	var address common.Address
+	err := g.destination.evm.UseContractCaller(func(caller bind.ContractCaller) error {
+		bound, err := ics27gmp.NewContractCaller(g.destGMP, caller)
+		if err != nil {
+			return fmt.Errorf("e2etest: bind ICS27GMP %s: %w", g.destGMP, err)
+		}
+		address, err = bound.GetOrComputeAccountAddress(&bind.CallOpts{Context: ctx}, id)
+		return err
+	})
+	if err != nil {
+		return common.Address{}, fmt.Errorf("e2etest: compute ICS27 account address: %w", err)
+	}
+	return address, nil
+}
+
+// StoredAccountIdentifier reads back the account identifier the destination
+// ICS27GMP contract recorded for account.
+func (g *GMP) StoredAccountIdentifier(
+	ctx context.Context,
+	account common.Address,
+) (ics27gmp.IICS27GMPMsgsAccountIdentifier, error) {
+	var id ics27gmp.IICS27GMPMsgsAccountIdentifier
+	err := g.destination.evm.UseContractCaller(func(caller bind.ContractCaller) error {
+		bound, err := ics27gmp.NewContractCaller(g.destGMP, caller)
+		if err != nil {
+			return fmt.Errorf("e2etest: bind ICS27GMP %s: %w", g.destGMP, err)
+		}
+		id, err = bound.GetAccountIdentifier(&bind.CallOpts{Context: ctx}, account)
+		return err
+	})
+	if err != nil {
+		return ics27gmp.IICS27GMPMsgsAccountIdentifier{}, fmt.Errorf(
+			"e2etest: query ICS27 account identifier for %s: %w", account, err,
+		)
+	}
+	return id, nil
+}
+
+// ERC20BalanceOf queries an ERC20 token balance on the destination chain.
+func (g *GMP) ERC20BalanceOf(ctx context.Context, token, holder common.Address) (*big.Int, error) {
+	var balance *big.Int
+	err := g.destination.evm.UseContractCaller(func(caller bind.ContractCaller) error {
+		bound, err := testerc20.NewTestERC20Caller(token, caller)
+		if err != nil {
+			return fmt.Errorf("e2etest: bind TestERC20 %s: %w", token, err)
+		}
+		balance, err = bound.BalanceOf(&bind.CallOpts{Context: ctx}, holder)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("e2etest: query TestERC20 %s balance of %s: %w", token, holder, err)
+	}
+	return balance, nil
+}
+
+// FundERC20 mints amount of token to holder on the destination chain. holder
+// need not have any code deployed yet: minting only writes a balance entry.
+func (g *GMP) FundERC20(ctx context.Context, token, holder common.Address, amount *big.Int) error {
+	data, err := tokenABI.Pack("mint", holder, amount)
+	if err != nil {
+		return fmt.Errorf("e2etest: pack TestERC20.mint: %w", err)
+	}
+	if _, err := g.destination.evm.BroadcastTx(ctx, g.sender, &token, data, nil); err != nil {
+		return fmt.Errorf("e2etest: fund %s with TestERC20 %s: %w", holder, token, err)
+	}
+	return nil
+}
+
+// AwaitERC20Balance waits until token's holder balance equals want.
+func (g *GMP) AwaitERC20Balance(
+	ctx context.Context,
+	token, holder common.Address,
+	want *big.Int,
+	description string,
+) error {
+	return awaitBalance(
+		ctx,
+		g.destination.chain,
+		description,
+		func(ctx context.Context) (*big.Int, error) { return g.ERC20BalanceOf(ctx, token, holder) },
+		want,
+	)
+}
+
+// PackERC20Transfer ABI-encodes an erc20.transfer(to, amount) call, for use as
+// a GMPRequest.Payload delivered to an ICS27 account.
+func PackERC20Transfer(to common.Address, amount *big.Int) ([]byte, error) {
+	data, err := tokenABI.Pack("transfer", to, amount)
+	if err != nil {
+		return nil, fmt.Errorf("e2etest: pack TestERC20.transfer: %w", err)
+	}
+	return data, nil
 }
 
 func (c *GMPCall) verifyCount(ctx context.Context, want *big.Int, state string) error {

--- a/e2e/e2etest/traffic_gmp.go
+++ b/e2e/e2etest/traffic_gmp.go
@@ -2,7 +2,6 @@ package e2etest
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -18,18 +17,15 @@ import (
 var gmpABI = mustABI(ics27gmp.ContractMetaData)
 
 type GMPRequest struct {
-	// Payload is the calldata delivered to Receiver. Call takes its own copy.
-	// Required, except through GMPCounter.Call, which defaults it to Counter.increment().
+	// Payload defaults to Counter.increment(). Call takes its own copy.
 	Payload []byte
-	// Receiver is the destination-chain contract address invoked through the
-	// ICS27 account. Required, except through GMPCounter.Call, which defaults
-	// it to the bound Counter's address.
+	// Receiver defaults to the bound Counter's address.
 	Receiver string
 	// Salt defaults to empty, matching sendCall's default account identifier.
 	Salt []byte
 }
 
-// GMP binds ICS27 GMP on a single directed route.
+// GMP binds ICS27 GMP and its default Counter target on a single directed route.
 type GMP struct {
 	routeID      RouteID
 	source       endpoint
@@ -37,31 +33,40 @@ type GMP struct {
 	sender       evm.Account
 	sourceGMP    common.Address
 	sourceRouter common.Address
+	counter      common.Address
 	sourceClient string
 	destClient   string
 	destGMP      common.Address
+	defaultCall  []byte
 }
 
 type GMPCall struct {
 	app    *GMP
 	packet Packet
+	before *big.Int
 }
 
 func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
-	if request.Receiver == "" {
-		return nil, errors.New("e2etest: GMPRequest.Receiver is required")
+	payload := request.Payload
+	if len(payload) == 0 {
+		payload = g.defaultCall
 	}
-	if len(request.Payload) == 0 {
-		return nil, errors.New("e2etest: GMPRequest.Payload is required")
+	payload = append([]byte(nil), payload...)
+	receiver := request.Receiver
+	if receiver == "" {
+		receiver = g.counter.Hex()
 	}
-	payload := append([]byte(nil), request.Payload...)
+	before, err := g.count(ctx)
+	if err != nil {
+		return nil, err
+	}
 	timeoutTimestamp, err := destinationTimeout(ctx, g.destination, 0)
 	if err != nil {
 		return nil, err
 	}
 	msg := ics27gmp.IICS27GMPMsgsSendCallMsg{
 		SourceClient:     g.sourceClient,
-		Receiver:         request.Receiver,
+		Receiver:         receiver,
 		Salt:             request.Salt,
 		Payload:          payload,
 		TimeoutTimestamp: timeoutTimestamp,
@@ -91,54 +96,14 @@ func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
 			SourceTxHash: txHash,
 			Sequence:     sequence,
 		},
+		before: before,
 	}, nil
 }
 
 func (c *GMPCall) Packet() Packet { return c.packet }
 
-// GMPCounter composes GMP with a Counter target on the destination chain,
-// adding Counter-specific request defaults and verification. Keeping this
-// separate from GMP means VerifyExecuted/VerifyRejected can never be called
-// against a GMPCall whose receiver isn't the bound Counter.
-type GMPCounter struct {
-	*GMP
-	counter     common.Address
-	defaultCall []byte
-}
-
-type GMPCounterCall struct {
-	*GMPCall
-	app    *GMPCounter
-	before *big.Int
-}
-
-func (g *GMPCounter) Call(ctx context.Context, request GMPRequest) (*GMPCounterCall, error) {
-	switch request.Receiver {
-	case "":
-		request.Receiver = g.counter.Hex()
-	case g.counter.Hex():
-	default:
-		return nil, fmt.Errorf(
-			"e2etest: GMPCounter is bound to Counter %s; use the base GMP for receiver %s",
-			g.counter, request.Receiver,
-		)
-	}
-	if len(request.Payload) == 0 {
-		request.Payload = g.defaultCall
-	}
-	before, err := g.count(ctx)
-	if err != nil {
-		return nil, err
-	}
-	call, err := g.GMP.Call(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-	return &GMPCounterCall{GMPCall: call, app: g, before: before}, nil
-}
-
 // VerifyExecuted waits for the destination Counter to change exactly once.
-func (c *GMPCounterCall) VerifyExecuted(ctx context.Context) error {
+func (c *GMPCall) VerifyExecuted(ctx context.Context) error {
 	want := new(big.Int).Add(c.before, big.NewInt(1))
 	return awaitBalance(
 		ctx,
@@ -150,11 +115,11 @@ func (c *GMPCounterCall) VerifyExecuted(ctx context.Context) error {
 }
 
 // VerifyRejected checks that the target state did not change after an error acknowledgement.
-func (c *GMPCounterCall) VerifyRejected(ctx context.Context) error {
+func (c *GMPCall) VerifyRejected(ctx context.Context) error {
 	return c.verifyCount(ctx, c.before, "unchanged")
 }
 
-func (g *GMPCounter) count(ctx context.Context) (*big.Int, error) {
+func (g *GMP) count(ctx context.Context) (*big.Int, error) {
 	var count *big.Int
 	err := g.destination.evm.UseContractCaller(func(caller bind.ContractCaller) error {
 		bound, err := counter.NewCounterCaller(g.counter, caller)
@@ -168,24 +133,6 @@ func (g *GMPCounter) count(ctx context.Context) (*big.Int, error) {
 		return nil, fmt.Errorf("e2etest: query Counter %s: %w", g.counter, err)
 	}
 	return count, nil
-}
-
-func (c *GMPCounterCall) verifyCount(ctx context.Context, want *big.Int, state string) error {
-	got, err := c.app.count(ctx)
-	if err != nil {
-		return err
-	}
-	if got.Cmp(want) != 0 {
-		return fmt.Errorf(
-			"e2etest: GMP packet %s target %s %s count: got %s, want %s",
-			c.packet.reference(),
-			c.app.counter.Hex(),
-			state,
-			got,
-			want,
-		)
-	}
-	return nil
 }
 
 // AccountIdentifier builds the ICS27 account identifier that onRecvPacket
@@ -295,4 +242,22 @@ func PackERC20Transfer(to common.Address, amount *big.Int) ([]byte, error) {
 		return nil, fmt.Errorf("e2etest: pack TestERC20.transfer: %w", err)
 	}
 	return data, nil
+}
+
+func (c *GMPCall) verifyCount(ctx context.Context, want *big.Int, state string) error {
+	got, err := c.app.count(ctx)
+	if err != nil {
+		return err
+	}
+	if got.Cmp(want) != 0 {
+		return fmt.Errorf(
+			"e2etest: GMP packet %s target %s %s count: got %s, want %s",
+			c.packet.reference(),
+			c.app.counter.Hex(),
+			state,
+			got,
+			want,
+		)
+	}
+	return nil
 }

--- a/e2e/e2etest/traffic_gmp.go
+++ b/e2e/e2etest/traffic_gmp.go
@@ -137,9 +137,6 @@ func (g *GMP) count(ctx context.Context) (*big.Int, error) {
 
 // AccountIdentifier builds the ICS27 account identifier that onRecvPacket
 // constructs on the destination chain for a call sent by sender with salt:
-// AccountIdentifier{ClientId: destinationClient, Sender: sender.Hex(), Salt: salt}.
-// sender.Hex() is EIP-55 checksummed, matching Strings.toChecksumHexString(_msgSender())
-// used by ICS27GMP.sendCall on the source chain.
 func (g *GMP) AccountIdentifier(sender common.Address, salt []byte) ics27gmp.IICS27GMPMsgsAccountIdentifier {
 	return ics27gmp.IICS27GMPMsgsAccountIdentifier{
 		ClientId: g.destClient,
@@ -148,10 +145,7 @@ func (g *GMP) AccountIdentifier(sender common.Address, salt []byte) ics27gmp.IIC
 	}
 }
 
-// AccountAddress derives the ICS27 account address for id via the destination
-// ICS27GMP contract's getOrComputeAccountAddress view, rather than
-// reimplementing its CREATE2 derivation. Safe to call before the account
-// contract is deployed.
+// AccountAddress derives the ICS27 account address for id
 func (g *GMP) AccountAddress(
 	ctx context.Context,
 	id ics27gmp.IICS27GMPMsgsAccountIdentifier,

--- a/e2e/e2etest/traffic_gmp.go
+++ b/e2e/e2etest/traffic_gmp.go
@@ -25,7 +25,8 @@ type GMPRequest struct {
 	Salt []byte
 }
 
-// GMP binds ICS27 GMP and its default Counter target on a single directed route.
+// GMP binds ICS27 GMP and its default Counter and TestERC20 targets on a
+// single directed route.
 type GMP struct {
 	routeID      RouteID
 	source       endpoint
@@ -37,8 +38,12 @@ type GMP struct {
 	sourceClient string
 	destClient   string
 	destGMP      common.Address
+	destToken    common.Address
 	defaultCall  []byte
 }
+
+// Token returns the destination-chain TestERC20 bound to this GMP.
+func (g *GMP) Token() common.Address { return g.destToken }
 
 type GMPCall struct {
 	app    *GMP
@@ -102,8 +107,9 @@ func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
 
 func (c *GMPCall) Packet() Packet { return c.packet }
 
-// VerifyExecuted waits for the destination Counter to change exactly once.
-func (c *GMPCall) VerifyExecuted(ctx context.Context) error {
+// VerifyCounterExecuted waits for the destination Counter to change exactly
+// once. Only meaningful when the call's receiver was the bound Counter.
+func (c *GMPCall) VerifyCounterExecuted(ctx context.Context) error {
 	want := new(big.Int).Add(c.before, big.NewInt(1))
 	return awaitBalance(
 		ctx,
@@ -114,8 +120,10 @@ func (c *GMPCall) VerifyExecuted(ctx context.Context) error {
 	)
 }
 
-// VerifyRejected checks that the target state did not change after an error acknowledgement.
-func (c *GMPCall) VerifyRejected(ctx context.Context) error {
+// VerifyCounterRejected checks that the destination Counter did not change
+// after an error acknowledgement. Only meaningful when the call's receiver
+// was the bound Counter.
+func (c *GMPCall) VerifyCounterRejected(ctx context.Context) error {
 	return c.verifyCount(ctx, c.before, "unchanged")
 }
 
@@ -188,40 +196,41 @@ func (g *GMP) StoredAccountIdentifier(
 	return id, nil
 }
 
-// ERC20BalanceOf queries an ERC20 token balance on the destination chain.
-func (g *GMP) ERC20BalanceOf(ctx context.Context, token, holder common.Address) (*big.Int, error) {
+// ERC20BalanceOf queries the bound TestERC20's balance on the destination chain.
+func (g *GMP) ERC20BalanceOf(ctx context.Context, holder common.Address) (*big.Int, error) {
 	var balance *big.Int
 	err := g.destination.evm.UseContractCaller(func(caller bind.ContractCaller) error {
-		bound, err := testerc20.NewTestERC20Caller(token, caller)
+		bound, err := testerc20.NewTestERC20Caller(g.destToken, caller)
 		if err != nil {
-			return fmt.Errorf("e2etest: bind TestERC20 %s: %w", token, err)
+			return fmt.Errorf("e2etest: bind TestERC20 %s: %w", g.destToken, err)
 		}
 		balance, err = bound.BalanceOf(&bind.CallOpts{Context: ctx}, holder)
 		return err
 	})
 	if err != nil {
-		return nil, fmt.Errorf("e2etest: query TestERC20 %s balance of %s: %w", token, holder, err)
+		return nil, fmt.Errorf("e2etest: query TestERC20 %s balance of %s: %w", g.destToken, holder, err)
 	}
 	return balance, nil
 }
 
-// FundERC20 mints amount of token to holder on the destination chain. holder
-// need not have any code deployed yet: minting only writes a balance entry.
-func (g *GMP) FundERC20(ctx context.Context, token, holder common.Address, amount *big.Int) error {
+// FundERC20 mints amount of the bound TestERC20 to holder on the destination
+// chain. holder need not have any code deployed yet: minting only writes a
+// balance entry.
+func (g *GMP) FundERC20(ctx context.Context, holder common.Address, amount *big.Int) error {
 	data, err := tokenABI.Pack("mint", holder, amount)
 	if err != nil {
 		return fmt.Errorf("e2etest: pack TestERC20.mint: %w", err)
 	}
-	if _, err := g.destination.evm.BroadcastTx(ctx, g.sender, &token, data, nil); err != nil {
-		return fmt.Errorf("e2etest: fund %s with TestERC20 %s: %w", holder, token, err)
+	if _, err := g.destination.evm.BroadcastTx(ctx, g.sender, &g.destToken, data, nil); err != nil {
+		return fmt.Errorf("e2etest: fund %s with TestERC20 %s: %w", holder, g.destToken, err)
 	}
 	return nil
 }
 
-// AwaitERC20Balance waits until token's holder balance equals want.
+// AwaitERC20Balance waits until the bound TestERC20's holder balance equals want.
 func (g *GMP) AwaitERC20Balance(
 	ctx context.Context,
-	token, holder common.Address,
+	holder common.Address,
 	want *big.Int,
 	description string,
 ) error {
@@ -229,7 +238,7 @@ func (g *GMP) AwaitERC20Balance(
 		ctx,
 		g.destination.chain,
 		description,
-		func(ctx context.Context) (*big.Int, error) { return g.ERC20BalanceOf(ctx, token, holder) },
+		func(ctx context.Context) (*big.Int, error) { return g.ERC20BalanceOf(ctx, holder) },
 		want,
 	)
 }

--- a/e2e/e2etest/traffic_gmp.go
+++ b/e2e/e2etest/traffic_gmp.go
@@ -2,6 +2,7 @@ package e2etest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -17,15 +18,18 @@ import (
 var gmpABI = mustABI(ics27gmp.ContractMetaData)
 
 type GMPRequest struct {
-	// Payload defaults to Counter.increment(). Call takes its own copy.
+	// Payload is the calldata delivered to Receiver. Call takes its own copy.
+	// Required, except through GMPCounter.Call, which defaults it to Counter.increment().
 	Payload []byte
-	// Receiver defaults to the bound Counter's address.
+	// Receiver is the destination-chain contract address invoked through the
+	// ICS27 account. Required, except through GMPCounter.Call, which defaults
+	// it to the bound Counter's address.
 	Receiver string
 	// Salt defaults to empty, matching sendCall's default account identifier.
 	Salt []byte
 }
 
-// GMP binds ICS27 GMP and its default Counter target on a single directed route.
+// GMP binds ICS27 GMP on a single directed route.
 type GMP struct {
 	routeID      RouteID
 	source       endpoint
@@ -33,40 +37,31 @@ type GMP struct {
 	sender       evm.Account
 	sourceGMP    common.Address
 	sourceRouter common.Address
-	counter      common.Address
 	sourceClient string
 	destClient   string
 	destGMP      common.Address
-	defaultCall  []byte
 }
 
 type GMPCall struct {
 	app    *GMP
 	packet Packet
-	before *big.Int
 }
 
 func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
-	payload := request.Payload
-	if len(payload) == 0 {
-		payload = g.defaultCall
+	if request.Receiver == "" {
+		return nil, errors.New("e2etest: GMPRequest.Receiver is required")
 	}
-	payload = append([]byte(nil), payload...)
-	receiver := request.Receiver
-	if receiver == "" {
-		receiver = g.counter.Hex()
+	if len(request.Payload) == 0 {
+		return nil, errors.New("e2etest: GMPRequest.Payload is required")
 	}
-	before, err := g.count(ctx)
-	if err != nil {
-		return nil, err
-	}
+	payload := append([]byte(nil), request.Payload...)
 	timeoutTimestamp, err := destinationTimeout(ctx, g.destination, 0)
 	if err != nil {
 		return nil, err
 	}
 	msg := ics27gmp.IICS27GMPMsgsSendCallMsg{
 		SourceClient:     g.sourceClient,
-		Receiver:         receiver,
+		Receiver:         request.Receiver,
 		Salt:             request.Salt,
 		Payload:          payload,
 		TimeoutTimestamp: timeoutTimestamp,
@@ -96,14 +91,54 @@ func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
 			SourceTxHash: txHash,
 			Sequence:     sequence,
 		},
-		before: before,
 	}, nil
 }
 
 func (c *GMPCall) Packet() Packet { return c.packet }
 
+// GMPCounter composes GMP with a Counter target on the destination chain,
+// adding Counter-specific request defaults and verification. Keeping this
+// separate from GMP means VerifyExecuted/VerifyRejected can never be called
+// against a GMPCall whose receiver isn't the bound Counter.
+type GMPCounter struct {
+	*GMP
+	counter     common.Address
+	defaultCall []byte
+}
+
+type GMPCounterCall struct {
+	*GMPCall
+	app    *GMPCounter
+	before *big.Int
+}
+
+func (g *GMPCounter) Call(ctx context.Context, request GMPRequest) (*GMPCounterCall, error) {
+	switch request.Receiver {
+	case "":
+		request.Receiver = g.counter.Hex()
+	case g.counter.Hex():
+	default:
+		return nil, fmt.Errorf(
+			"e2etest: GMPCounter is bound to Counter %s; use the base GMP for receiver %s",
+			g.counter, request.Receiver,
+		)
+	}
+	if len(request.Payload) == 0 {
+		request.Payload = g.defaultCall
+	}
+	before, err := g.count(ctx)
+	if err != nil {
+		return nil, err
+	}
+	call, err := g.GMP.Call(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return &GMPCounterCall{GMPCall: call, app: g, before: before}, nil
+}
+
 // VerifyExecuted waits for the destination Counter to change exactly once.
-func (c *GMPCall) VerifyExecuted(ctx context.Context) error {
+func (c *GMPCounterCall) VerifyExecuted(ctx context.Context) error {
 	want := new(big.Int).Add(c.before, big.NewInt(1))
 	return awaitBalance(
 		ctx,
@@ -115,11 +150,11 @@ func (c *GMPCall) VerifyExecuted(ctx context.Context) error {
 }
 
 // VerifyRejected checks that the target state did not change after an error acknowledgement.
-func (c *GMPCall) VerifyRejected(ctx context.Context) error {
+func (c *GMPCounterCall) VerifyRejected(ctx context.Context) error {
 	return c.verifyCount(ctx, c.before, "unchanged")
 }
 
-func (g *GMP) count(ctx context.Context) (*big.Int, error) {
+func (g *GMPCounter) count(ctx context.Context) (*big.Int, error) {
 	var count *big.Int
 	err := g.destination.evm.UseContractCaller(func(caller bind.ContractCaller) error {
 		bound, err := counter.NewCounterCaller(g.counter, caller)
@@ -133,6 +168,24 @@ func (g *GMP) count(ctx context.Context) (*big.Int, error) {
 		return nil, fmt.Errorf("e2etest: query Counter %s: %w", g.counter, err)
 	}
 	return count, nil
+}
+
+func (c *GMPCounterCall) verifyCount(ctx context.Context, want *big.Int, state string) error {
+	got, err := c.app.count(ctx)
+	if err != nil {
+		return err
+	}
+	if got.Cmp(want) != 0 {
+		return fmt.Errorf(
+			"e2etest: GMP packet %s target %s %s count: got %s, want %s",
+			c.packet.reference(),
+			c.app.counter.Hex(),
+			state,
+			got,
+			want,
+		)
+	}
+	return nil
 }
 
 // AccountIdentifier builds the ICS27 account identifier that onRecvPacket
@@ -242,22 +295,4 @@ func PackERC20Transfer(to common.Address, amount *big.Int) ([]byte, error) {
 		return nil, fmt.Errorf("e2etest: pack TestERC20.transfer: %w", err)
 	}
 	return data, nil
-}
-
-func (c *GMPCall) verifyCount(ctx context.Context, want *big.Int, state string) error {
-	got, err := c.app.count(ctx)
-	if err != nil {
-		return err
-	}
-	if got.Cmp(want) != 0 {
-		return fmt.Errorf(
-			"e2etest: GMP packet %s target %s %s count: got %s, want %s",
-			c.packet.reference(),
-			c.app.counter.Hex(),
-			state,
-			got,
-			want,
-		)
-	}
-	return nil
 }

--- a/e2e/e2etest/traffic_transfer.go
+++ b/e2e/e2etest/traffic_transfer.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
-	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/testerc20"
 )
 
@@ -96,7 +95,7 @@ func (i *Transfer) Prepare(ctx context.Context, request TransferRequest) (*Prepa
 	if err != nil {
 		return nil, err
 	}
-	sourceBefore, err := i.tokenBalance(ctx, i.source.evm, i.sourceToken, i.sender.Address())
+	sourceBefore, err := erc20BalanceOf(ctx, i.source.evm, i.sourceToken, i.sender.Address())
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +199,7 @@ func (t *TransferPacket) VerifyDelivered(ctx context.Context) error {
 
 func (t *TransferPacket) VerifyEscrowed(ctx context.Context) error {
 	want := new(big.Int).Sub(t.sourceBefore, t.amount)
-	got, err := t.app.tokenBalance(ctx, t.app.source.evm, t.app.sourceToken, t.app.sender.Address())
+	got, err := erc20BalanceOf(ctx, t.app.source.evm, t.app.sourceToken, t.app.sender.Address())
 	if err != nil {
 		return err
 	}
@@ -243,7 +242,7 @@ func (t *TransferPacket) VerifyRefunded(ctx context.Context) error {
 		t.app.source.chain,
 		fmt.Sprintf("Transfer packet %s refund", t.packet.reference()),
 		func(ctx context.Context) (*big.Int, error) {
-			return t.app.tokenBalance(ctx, t.app.source.evm, t.app.sourceToken, t.app.sender.Address())
+			return erc20BalanceOf(ctx, t.app.source.evm, t.app.sourceToken, t.app.sender.Address())
 		},
 		t.sourceBefore,
 	)
@@ -345,26 +344,6 @@ func isICS20DenomNotFound(err error) bool {
 	copy(selector[:], revertData)
 	contractErr, lookupErr := ics20ABI.ErrorByID(selector)
 	return lookupErr == nil && contractErr.Name == "ICS20DenomNotFound"
-}
-
-func (i *Transfer) tokenBalance(
-	ctx context.Context,
-	client *environment.EVM,
-	contract, holder common.Address,
-) (*big.Int, error) {
-	var balance *big.Int
-	err := client.UseContractCaller(func(caller bind.ContractCaller) error {
-		bound, err := testerc20.NewTestERC20Caller(contract, caller)
-		if err != nil {
-			return fmt.Errorf("e2etest: bind TestERC20 %s: %w", contract, err)
-		}
-		balance, err = bound.BalanceOf(&bind.CallOpts{Context: ctx}, holder)
-		return err
-	})
-	if err != nil {
-		return nil, fmt.Errorf("e2etest: query TestERC20 balance of %s: %w", holder, err)
-	}
-	return balance, nil
 }
 
 // awaitPacketTimeout waits for the source router to emit TimeoutPacket for the

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -35,8 +35,7 @@ func TestGMPCall_AutoRelay(t *testing.T) {
 }
 
 // TestGMPCall_ICS27AccountTransfer sends a GMP call whose payload is an
-// erc20.transfer executed by the destination ICS27 account: it drains a
-// pre-funded, precomputed account into a fresh target address.
+// erc20.transfer executed by the destination ICS27 account.
 func TestGMPCall_ICS27AccountTransfer(t *testing.T) {
 	t.Parallel()
 	spec := dummyClientMeshSpec(e2etest.ChainSpecsForConfiguredLane(t))

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -20,7 +20,7 @@ func TestGMPCall_AutoRelay(t *testing.T) {
 	signers := e2etest.NewSigners(t)
 	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
 	driver, deployment := e2etest.Deploy(t, env, signers, route)
-	gmp := e2etest.BindGMPCounter(t, env, deployment, signers, route)
+	gmp := e2etest.BindGMP(t, env, deployment, signers, route)
 	relayer := e2etest.StartRelayer(t, driver, env)
 	ctx := t.Context()
 
@@ -96,7 +96,7 @@ func TestGMPCall_ErrorAcknowledgement(t *testing.T) {
 	signers := e2etest.NewSigners(t)
 	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
 	driver, deployment := e2etest.Deploy(t, env, signers, route)
-	gmp := e2etest.BindGMPCounter(t, env, deployment, signers, route)
+	gmp := e2etest.BindGMP(t, env, deployment, signers, route)
 	relayer := e2etest.StartRelayer(t, driver, env)
 	ctx := t.Context()
 

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -20,7 +20,7 @@ func TestGMPCall_AutoRelay(t *testing.T) {
 	signers := e2etest.NewSigners(t)
 	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
 	driver, deployment := e2etest.Deploy(t, env, signers, route)
-	gmp := e2etest.BindGMP(t, env, deployment, signers, route)
+	gmp := e2etest.BindGMPCounter(t, env, deployment, signers, route)
 	relayer := e2etest.StartRelayer(t, driver, env)
 	ctx := t.Context()
 
@@ -96,7 +96,7 @@ func TestGMPCall_ErrorAcknowledgement(t *testing.T) {
 	signers := e2etest.NewSigners(t)
 	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
 	driver, deployment := e2etest.Deploy(t, env, signers, route)
-	gmp := e2etest.BindGMP(t, env, deployment, signers, route)
+	gmp := e2etest.BindGMPCounter(t, env, deployment, signers, route)
 	relayer := e2etest.StartRelayer(t, driver, env)
 	ctx := t.Context()
 

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -31,7 +31,7 @@ func TestGMPCall_AutoRelay(t *testing.T) {
 	err = e2etest.AwaitState(ctx, relayer, call.Packet(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
-	require.NoError(t, call.VerifyExecuted(ctx))
+	require.NoError(t, call.VerifyCounterExecuted(ctx))
 }
 
 // TestGMPCall_ICS27AccountTransfer sends a GMP call whose payload is an
@@ -48,9 +48,7 @@ func TestGMPCall_ICS27AccountTransfer(t *testing.T) {
 	relayer := e2etest.StartRelayer(t, driver, env)
 	ctx := t.Context()
 
-	destApps, ok := deployment.Chain(route.Destination)
-	require.True(t, ok)
-	token := destApps.Token
+	token := gmp.Token()
 	applicationSigner := signers.Addresses().Application
 
 	salt := []byte("ics27-account-transfer")
@@ -62,7 +60,7 @@ func TestGMPCall_ICS27AccountTransfer(t *testing.T) {
 	target, err := e2etest.NewAddress()
 	require.NoError(t, err)
 
-	require.NoError(t, gmp.FundERC20(ctx, token, account, amount))
+	require.NoError(t, gmp.FundERC20(ctx, account, amount))
 
 	payload, err := e2etest.PackERC20Transfer(target, amount)
 	require.NoError(t, err)
@@ -75,8 +73,8 @@ func TestGMPCall_ICS27AccountTransfer(t *testing.T) {
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
 
-	require.NoError(t, gmp.AwaitERC20Balance(ctx, token, account, big.NewInt(0), "ICS27 account drained"))
-	require.NoError(t, gmp.AwaitERC20Balance(ctx, token, target, amount, "ICS27 account transfer target credited"))
+	require.NoError(t, gmp.AwaitERC20Balance(ctx, account, big.NewInt(0), "ICS27 account drained"))
+	require.NoError(t, gmp.AwaitERC20Balance(ctx, target, amount, "ICS27 account transfer target credited"))
 
 	stored, err := gmp.StoredAccountIdentifier(ctx, account)
 	require.NoError(t, err)
@@ -107,5 +105,5 @@ func TestGMPCall_ErrorAcknowledgement(t *testing.T) {
 	err = e2etest.AwaitState(ctx, relayer, call.Packet(),
 		relayerv2.PacketState_PACKET_STATE_REJECTED, destination.Timing())
 	require.NoError(t, err)
-	require.NoError(t, call.VerifyRejected(ctx))
+	require.NoError(t, call.VerifyCounterRejected(ctx))
 }

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -78,9 +78,7 @@ func TestGMPCall_ICS27AccountTransfer(t *testing.T) {
 
 	stored, err := gmp.StoredAccountIdentifier(ctx, account)
 	require.NoError(t, err)
-	require.Equal(t, id.ClientId, stored.ClientId)
-	require.Equal(t, id.Sender, stored.Sender)
-	require.Equal(t, id.Salt, stored.Salt)
+	require.Equal(t, id, stored)
 }
 
 // invalidGMPPayload does not match Counter's call surface, so delivery produces an error acknowledgement.

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,6 +32,58 @@ func TestGMPCall_AutoRelay(t *testing.T) {
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
 	require.NoError(t, err)
 	require.NoError(t, call.VerifyExecuted(ctx))
+}
+
+// TestGMPCall_ICS27AccountTransfer sends a GMP call whose payload is an
+// erc20.transfer executed by the destination ICS27 account: it drains a
+// pre-funded, precomputed account into a fresh target address.
+func TestGMPCall_ICS27AccountTransfer(t *testing.T) {
+	t.Parallel()
+	spec := dummyClientMeshSpec(e2etest.ChainSpecsForConfiguredLane(t))
+	runtime := e2etest.RuntimeWithProtocolDeployer(environment.Runtime{})
+	env := e2etest.Start(t, spec, runtime)
+	signers := e2etest.NewSigners(t)
+	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
+	driver, deployment := e2etest.Deploy(t, env, signers, route)
+	gmp := e2etest.BindGMP(t, env, deployment, signers, route)
+	relayer := e2etest.StartRelayer(t, driver, env)
+	ctx := t.Context()
+
+	destApps, ok := deployment.Chain(route.Destination)
+	require.True(t, ok)
+	token := destApps.Token
+	applicationSigner := signers.Addresses().Application
+
+	salt := []byte("ics27-account-transfer")
+	id := gmp.AccountIdentifier(applicationSigner, salt)
+	account, err := gmp.AccountAddress(ctx, id)
+	require.NoError(t, err)
+
+	amount := big.NewInt(1_000)
+	target, err := e2etest.NewAddress()
+	require.NoError(t, err)
+
+	require.NoError(t, gmp.FundERC20(ctx, token, account, amount))
+
+	payload, err := e2etest.PackERC20Transfer(target, amount)
+	require.NoError(t, err)
+
+	call, err := gmp.Call(ctx, e2etest.GMPRequest{Receiver: token.Hex(), Salt: salt, Payload: payload})
+	require.NoError(t, err)
+	destination, err := env.Chain(route.Destination)
+	require.NoError(t, err)
+	err = e2etest.AwaitState(ctx, relayer, call.Packet(),
+		relayerv2.PacketState_PACKET_STATE_SUCCEEDED, destination.Timing())
+	require.NoError(t, err)
+
+	require.NoError(t, gmp.AwaitERC20Balance(ctx, token, account, big.NewInt(0), "ICS27 account drained"))
+	require.NoError(t, gmp.AwaitERC20Balance(ctx, token, target, amount, "ICS27 account transfer target credited"))
+
+	stored, err := gmp.StoredAccountIdentifier(ctx, account)
+	require.NoError(t, err)
+	require.Equal(t, id.ClientId, stored.ClientId)
+	require.Equal(t, id.Sender, stored.Sender)
+	require.Equal(t, id.Salt, stored.Salt)
 }
 
 // invalidGMPPayload does not match Counter's call surface, so delivery produces an error acknowledgement.


### PR DESCRIPTION
Summary
- Add TestGMPCall_ICS27AccountTransfer: precomputes and funds an ICS27 account, sends an erc20.transfer payload through it via GMP, and asserts balances are as expected.

closes FOU-1097