### PR TITLE
test(e2e): add attested IFT timeout coverage

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -4,7 +4,8 @@ This module contains one root repository-level acceptance package: linear Go tes
 `internal/harness` surface. Tests relay real IBC packets through the real Link relayer and
 Solidity IBC stack (ICS26Router, ICS20Transfer, ICS27GMP), usually with a permissive dummy light
 client; the attested IFT tests use attestation clients and managed attestors, including quorum loss
-and recovery.
+and recovery. `TestAttestedIFTTimeout_Refund` runs only on instant Anvil because it controls mining
+explicitly.
 
 - Run everything from the repository root: `make test-e2e` for the complete acceptance package, or
   `make test-e2e E2E_FLAGS='-run TestTransfer_AutoRelay -count=1'` for one focused loop. Lanes:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,7 +6,7 @@ This repository-level surface hosts one black-box acceptance package. Its tests 
 
 ## Acceptance coverage
 
-The root package covers ICS20 transfer, ICS27 GMP, IFT (burn/mint on top of GMP) relay behavior, attested IFT relay and quorum recovery, timeout refunds, error acknowledgements, pending-packet status, Relayer and node recovery, cross-route handling, and relaying through an attached RPC that `Environment` does not own. These are all acceptance criteria and run together by default.
+The root package covers ICS20 transfer, ICS27 GMP, IFT (burn/mint on top of GMP) relay behavior, attested IFT relay, quorum recovery, and timeout behavior, timeout refunds, error acknowledgements, pending-packet status, Relayer and node recovery, cross-route handling, and relaying through an attached RPC that `Environment` does not own. These are all acceptance criteria and run together by default.
 
 ## Running the acceptance tests
 
@@ -27,7 +27,7 @@ The same tests can select different Chain declarations:
 - `make test-e2e E2E_LANE=besu` uses Besu QBFT.
 - `make test-e2e E2E_FLAGS='-run TestIFTTransfer_AutoRelay -count=1'` runs one test repeatedly.
 
-`-e2e.lane` in `E2E_FLAGS` overrides `E2E_LANE`. Tests pinned to instant Anvil call `e2etest.RequireAnvilLane(t)` so a matrix runs them only in that lane. After a hard crash, use `make clean-e2e-dry-run` and then `make clean-e2e`.
+`-e2e.lane` in `E2E_FLAGS` overrides `E2E_LANE`. Tests pinned to instant Anvil call `e2etest.RequireAnvilLane(t)` so a matrix runs them only in that lane; this includes `TestAttestedIFTTimeout_Refund`, which controls mining explicitly. After a hard crash, use `make clean-e2e-dry-run` and then `make clean-e2e`.
 
 Every test calls `t.Parallel()` and boots its own environment; the Makefile caps concurrency at four environments. Pass `E2E_FLAGS='-parallel 1 -count=1'` to serialize when debugging.
 

--- a/e2e/e2etest/traffic_ift.go
+++ b/e2e/e2etest/traffic_ift.go
@@ -52,6 +52,7 @@ type IFTPacket struct {
 	sourceBefore            *big.Int
 	destinationBefore       *big.Int
 	destinationSupplyBefore *big.Int
+	timeoutTimestamp        uint64
 }
 
 func (i *IFT) Send(ctx context.Context, request IFTRequest) (*IFTPacket, error) {
@@ -108,6 +109,7 @@ func (i *IFT) Send(ctx context.Context, request IFTRequest) (*IFTPacket, error) 
 		sourceBefore:            sourceBefore,
 		destinationBefore:       destinationBefore,
 		destinationSupplyBefore: destinationSupplyBefore,
+		timeoutTimestamp:        timeoutTimestamp,
 	}, nil
 }
 
@@ -242,6 +244,8 @@ func (b *IFTBatch) VerifyBurned(ctx context.Context) error {
 }
 
 func (p *IFTPacket) Packet() Packet { return p.packet }
+
+func (p *IFTPacket) TimeoutTimestamp() uint64 { return p.timeoutTimestamp }
 
 // VerifyBurned checks that the submitted amount left the source sender balance.
 func (p *IFTPacket) VerifyBurned(ctx context.Context) error {

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -230,6 +230,139 @@ func TestAttestedIFTTransfer_MultiAttestorQuorum(t *testing.T) {
 	require.NoError(t, pending.VerifyDelivered(ctx))
 }
 
+func TestAttestedIFTTimeout_Refund(t *testing.T) {
+	t.Parallel()
+	e2etest.RequireAnvilLane(t)
+	spec := environment.Spec{
+		Chains: e2etest.ChainSpecsForConfiguredLane(t),
+		IBCInstances: []environment.IBCInstanceSpec{
+			environment.NewIBCInstance{
+				ID:        "attested-timeout-ibc-a",
+				Chain:     e2etest.ChainA,
+				Authority: e2etest.ProtocolAuthorityID,
+			},
+			environment.NewIBCInstance{
+				ID:        "attested-timeout-ibc-b",
+				Chain:     e2etest.ChainB,
+				Authority: e2etest.ProtocolAuthorityID,
+			},
+		},
+		Connections: []environment.ConnectionSpec{{
+			ID: "attested-timeout-connection",
+			A: environment.NewClient{
+				ID:                    attestedClientAID,
+				IBCInstance:           "attested-timeout-ibc-a",
+				Authority:             e2etest.ProtocolAuthorityID,
+				MinRequiredSignatures: 1,
+			},
+			B: environment.NewClient{
+				ID:                    attestedClientBID,
+				IBCInstance:           "attested-timeout-ibc-b",
+				Authority:             e2etest.ProtocolAuthorityID,
+				MinRequiredSignatures: 1,
+			},
+		}},
+		Attestors: []environment.AttestorSpec{
+			{ID: attestorAID, Client: attestedClientAID, Authority: attestorAAuthority},
+			{ID: attestorBID, Client: attestedClientBID, Authority: attestorBAuthority},
+		},
+	}
+	runtime := e2etest.RuntimeWithProtocolDeployer(
+		environment.Runtime{Authorities: map[environment.AuthorityID]environment.EVMAuthority{
+			attestorAAuthority: {PrivateKeyHex: "0000000000000000000000000000000000000000000000000000000000000006"},
+			attestorBAuthority: {PrivateKeyHex: "0000000000000000000000000000000000000000000000000000000000000007"},
+		}},
+	)
+	env := e2etest.Start(t, spec, runtime)
+	signers := e2etest.NewSigners(t)
+	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
+	attestorA, err := env.Attestor(attestorAID)
+	require.NoError(t, err)
+	driver, deployment := e2etest.Deploy(t, env, signers, route)
+	iftApp := e2etest.BindIFT(t, env, deployment, signers, route)
+	relayer := e2etest.StartRelayer(t, driver, env)
+	ctx := t.Context()
+
+	source, err := env.Chain(route.Source)
+	require.NoError(t, err)
+	sourceEVM, err := source.EVM()
+	require.NoError(t, err)
+	destination, err := env.Chain(route.Destination)
+	require.NoError(t, err)
+	destinationEVM, err := destination.EVM()
+	require.NoError(t, err)
+	destinationMining, err := destination.Mining()
+	require.NoError(t, err)
+	sourceMining, err := source.Mining()
+	require.NoError(t, err)
+
+	// First prove the ordinary attested timeout path.
+	require.NoError(t, relayer.Stop(ctx))
+	transfer, err := iftApp.Send(ctx, e2etest.IFTRequest{
+		Amount:  big.NewInt(3_000_000),
+		Timeout: transferTimeout,
+	})
+	require.NoError(t, err)
+	require.NoError(t, transfer.VerifyBurned(ctx))
+	require.NoError(t, transfer.VerifyPending(ctx))
+	require.NoError(t, destinationMining.AdvanceTime(ctx, transferTimeoutAdvance))
+	require.NoError(t, destinationMining.Mine(ctx, 1))
+	destinationHeight, err := destination.Height(ctx)
+	require.NoError(t, err)
+	destinationAnchor := destinationHeight - 1
+	anchorHeader, err := destinationEVM.HeaderByNumber(ctx, new(big.Int).SetUint64(destinationAnchor))
+	require.NoError(t, err)
+	require.Greater(t, anchorHeader.Time, transfer.TimeoutTimestamp())
+	relayer = e2etest.StartRelayer(t, driver, env)
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+		relayerv2.PacketState_PACKET_STATE_TIMED_OUT, source.Timing())
+	require.NoError(t, err)
+	require.NoError(t, transfer.VerifyRefunded(ctx))
+	require.NoError(t, transfer.VerifyNotMinted(ctx))
+	require.NoError(t, transfer.VerifyPendingCleared(ctx))
+	sourceState := attestedClientState(t, sourceEVM, attestorA.IBCClient().LightClientAddress())
+	require.GreaterOrEqual(t, sourceState.LatestHeight, destinationAnchor)
+
+	// Then keep the destination fixed while the source moves far ahead. Timeout
+	// still uses the finalized destination anchor rather than the source height.
+	require.NoError(t, relayer.Stop(ctx))
+	asymmetricTransfer, err := iftApp.Send(ctx, e2etest.IFTRequest{
+		Amount:  big.NewInt(4_000_000),
+		Timeout: transferTimeout,
+	})
+	require.NoError(t, err)
+	require.NoError(t, asymmetricTransfer.VerifyBurned(ctx))
+	require.NoError(t, asymmetricTransfer.VerifyPending(ctx))
+	require.NoError(t, destinationMining.AdvanceTime(ctx, transferTimeoutAdvance))
+	require.NoError(t, destinationMining.Mine(ctx, 1))
+	destinationHeight, err = destination.Height(ctx)
+	require.NoError(t, err)
+	destinationAnchor = destinationHeight - 1
+	anchorHeader, err = destinationEVM.HeaderByNumber(ctx, new(big.Int).SetUint64(destinationAnchor))
+	require.NoError(t, err)
+	require.Greater(t, anchorHeader.Time, asymmetricTransfer.TimeoutTimestamp())
+
+	require.NoError(t, destinationMining.WithPaused(ctx, func() error {
+		require.NoError(t, sourceMining.Mine(ctx, 50))
+		sourceHeight, heightErr := source.Height(ctx)
+		require.NoError(t, heightErr)
+		pausedDestinationHeight, heightErr := destination.Height(ctx)
+		require.NoError(t, heightErr)
+		require.GreaterOrEqual(t, sourceHeight, pausedDestinationHeight+40)
+
+		relayer = e2etest.StartRelayer(t, driver, env)
+		_, awaitErr := e2etest.AwaitState(ctx, relayer, asymmetricTransfer.Packet(),
+			relayerv2.PacketState_PACKET_STATE_TIMED_OUT, source.Timing())
+		require.NoError(t, awaitErr)
+		require.NoError(t, asymmetricTransfer.VerifyRefunded(ctx))
+		require.NoError(t, asymmetricTransfer.VerifyNotMinted(ctx))
+		require.NoError(t, asymmetricTransfer.VerifyPendingCleared(ctx))
+		sourceState = attestedClientState(t, sourceEVM, attestorA.IBCClient().LightClientAddress())
+		require.GreaterOrEqual(t, sourceState.LatestHeight, destinationAnchor)
+		return nil
+	}))
+}
+
 func TestIFTTransfer_AutoRelay(t *testing.T) {
 	t.Parallel()
 	spec := dummyClientMeshSpec(e2etest.ChainSpecsForConfiguredLane(t))


### PR DESCRIPTION
## Summary

- adds attested IFT timeout and refund coverage using standalone 1-of-1 attestors
- verifies the packet reaches TIMED_OUT, the source balance is refunded, and no destination tokens are minted
- verifies both attestation clients advance far enough to support the timeout path

## Why

FOU-1073 needs end-to-end coverage that timeout proofs and refunds work over real attestation light clients rather than the permissive dummy client.

Closes FOU-1073

## Validation

- `make check` (builds, all Link and harness tests, both linters, generated bindings, and the complete Anvil E2E suite)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>