### PR TITLE
fix(link): avoid cross-chain timeout height comparison

### DIFF
--- a/link/internal/relay/pipeline/pipeline_test.go
+++ b/link/internal/relay/pipeline/pipeline_test.go
@@ -328,7 +328,9 @@ func TestPipelineLifecycle(t *testing.T) {
 		env.dstClient.EXPECT().IsTimestampFinalized(mock.Anything, mock.Anything, (*uint64)(nil)).Return(true, nil).Once()
 
 		// timeout delivery on the source chain
-		mockRelay(env.srcClient, env.srcProofGen, env.srcTxBuilder, []v2.PacketEvent{sendPacketEvent(42)}, "0xrouter")
+		timeoutEvent := sendPacketEvent(42)
+		timeoutEvent.Height = 150 // source height is unrelated to the destination proof height
+		mockRelay(env.srcClient, env.srcProofGen, env.srcTxBuilder, []v2.PacketEvent{timeoutEvent}, "0xrouter")
 		env.srcClient.EXPECT().WaitForChain(mock.Anything).Return(nil).Once()
 		env.srcTxSubmitter.EXPECT().Submit(mock.Anything, mock.Anything).Return(&v2.Submission{
 			TxHash: timeoutTxHash, SubmittedAt: time.Now().UTC(), RelayerAddress: "0xrelayer",

--- a/link/internal/relay/processors/batch_ack_packet.go
+++ b/link/internal/relay/processors/batch_ack_packet.go
@@ -101,7 +101,12 @@ func (p BatchAckPacket) Process(ctx context.Context, transfers []*Transfer) ([]*
 			continue
 		}
 
-		event, errEvent := findPacketEvent(txEvents, tr.PacketSequenceNumber, tr.PacketSourceClientID, proofHeight)
+		event, errEvent := findPacketEventAtOrBeforeHeight(
+			txEvents,
+			tr.PacketSequenceNumber,
+			tr.PacketSourceClientID,
+			proofHeight,
+		)
 		if errEvent != nil {
 			tr.ProcessingError = errors.Wrapf(errEvent, "tx %s", hash)
 

--- a/link/internal/relay/processors/batch_recv_packet.go
+++ b/link/internal/relay/processors/batch_recv_packet.go
@@ -95,7 +95,12 @@ func (p BatchRecvPacket) Process(ctx context.Context, transfers []*Transfer) ([]
 			continue
 		}
 
-		event, errEvent := findPacketEvent(txEvents, tr.PacketSequenceNumber, tr.PacketSourceClientID, proofHeight)
+		event, errEvent := findPacketEventAtOrBeforeHeight(
+			txEvents,
+			tr.PacketSequenceNumber,
+			tr.PacketSourceClientID,
+			proofHeight,
+		)
 		if errEvent != nil {
 			tr.ProcessingError = errors.Wrapf(errEvent, "tx %s", tr.SourceTxHash)
 

--- a/link/internal/relay/processors/batch_relay.go
+++ b/link/internal/relay/processors/batch_relay.go
@@ -20,23 +20,34 @@ func findPacketEvent(
 	events []v2.PacketEvent,
 	sequence uint64,
 	clientID string,
-	provableHeight uint64,
 ) (v2.PacketEvent, error) {
 	for _, event := range events {
 		if event.Packet.Sequence != sequence || event.Packet.SourceClient != clientID {
 			continue
 		}
 
-		if event.Height > provableHeight {
-			return v2.PacketEvent{}, errors.Errorf(
-				"packet observed at height %d exceeds currently provable height %d", event.Height, provableHeight,
-			)
-		}
-
 		return event, nil
 	}
 
 	return v2.PacketEvent{}, errors.Errorf("no packet event for sequence %d client %q", sequence, clientID)
+}
+
+func findPacketEventAtOrBeforeHeight(
+	events []v2.PacketEvent,
+	sequence uint64,
+	clientID string,
+	maxHeight uint64,
+) (v2.PacketEvent, error) {
+	event, err := findPacketEvent(events, sequence, clientID)
+	if err != nil {
+		return v2.PacketEvent{}, err
+	}
+	if event.Height > maxHeight {
+		return v2.PacketEvent{}, errors.Errorf(
+			"packet observed at height %d exceeds maximum height %d", event.Height, maxHeight,
+		)
+	}
+	return event, nil
 }
 
 // proofKindFor maps relayKind to the proof claim it requires

--- a/link/internal/relay/processors/timeout_packet.go
+++ b/link/internal/relay/processors/timeout_packet.go
@@ -85,7 +85,9 @@ func (p BatchTimeoutPacket) Process(ctx context.Context, transfers []*Transfer) 
 			continue
 		}
 
-		event, errEvent := findPacketEvent(txEvents, tr.PacketSequenceNumber, tr.PacketSourceClientID, proofHeight)
+		// The send event supplies packet data; its source-chain height is
+		// unrelated to the destination-chain timeout proof height.
+		sendEvent, errEvent := findPacketEvent(txEvents, tr.PacketSequenceNumber, tr.PacketSourceClientID)
 		if errEvent != nil {
 			tr.ProcessingError = errors.Wrapf(errEvent, "tx %s", tr.SourceTxHash)
 
@@ -100,7 +102,7 @@ func (p BatchTimeoutPacket) Process(ctx context.Context, transfers []*Transfer) 
 			continue
 		}
 
-		events = append(events, event)
+		events = append(events, sendEvent)
 	}
 
 	if len(events) == 0 {


### PR DESCRIPTION
## Summary

- separates packet-event lookup from the same-chain event-height guard used by recv and acknowledgement relays
- keeps the guard where the event and proof heights belong to the same chain
- avoids comparing the source SendPacket height with the destination timeout-proof height
- adds a regression case with source event height 150 and destination proof height 100

## Root cause

The shared packet-event helper assumed every event height and proof height came from the same chain. Timeout relay is different: it reconstructs packet data from the source SendPacket event but proves non-receipt on the destination chain. Comparing those chain-local heights rejected valid timeouts when chain heights diverged.

## Impact

Valid timeout refunds can proceed even when the source and destination chains have substantially different block heights.

## Validation

- `make check` (builds, all Link and harness tests, both linters, generated bindings, and the complete Anvil E2E suite)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>