### PR TITLE
lint: enable testifylint and fix violations

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,25 +3,38 @@ name: E2E
 on:
   push:
     branches: [main, development]
-    paths:
-      - "link/**"
-      - "e2e/**"
-      - "proto/**"
-      - "Makefile"
-      - ".golangci.yml"
-      - ".github/workflows/e2e.yml"
   pull_request:
     branches: [main, development]
-    paths:
-      - "link/**"
-      - "e2e/**"
-      - "proto/**"
-      - "Makefile"
-      - ".golangci.yml"
-      - ".github/workflows/e2e.yml"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      lint: ${{ steps.filter.outputs.lint }}
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            lint:
+              - "e2e/**"
+              - ".golangci.yml"
+              - ".github/workflows/e2e.yml"
+            code:
+              - "link/**"
+              - "e2e/**"
+              - "proto/**"
+              - "Makefile"
+              - ".github/workflows/e2e.yml"
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.lint == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +48,8 @@ jobs:
           working-directory: e2e
 
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +67,8 @@ jobs:
           IBC_BIN: ${{ github.workspace }}/link/bin/ibc
 
   e2e:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,11 +19,12 @@ formatters:
     generated: lax
   settings:
     gci:
+      # this order matches gci's fixed default output order; localmodule is not
+      # used because it would split first-party imports across modules (e2e vs link)
       sections:
         - "standard"
-        - "localmodule"
         - "default"
-        - "alias"
+        - "prefix(github.com/cosmos/ibc)"
         - "blank" # e.g. sql drivers
     gofmt:
       rewrite-rules:
@@ -53,6 +54,7 @@ linters:
     - revive
     - errcheck
     - errorlint
+    - testifylint
 
   settings:
     dogsled:
@@ -77,9 +79,10 @@ linters:
   exclusions:
     generated: lax
     rules:
-      # repeated literals in tests are usually clearer inline than as constants
+      # repeated literals and near-identical cases in tests are usually clearer
+      # inline than forced behind an abstraction
       - path: _test\.go
-        linters: [goconst]
+        linters: [goconst, dupl]
       # the e2e helpers are private test infrastructure, not public API
       - path: ^e2e/internal/
         linters: [revive]

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,6 @@ doctor-e2e-tools: ## Check the generation and lint tools used by repository e2e 
 test-harness: build-link ## Run harness tests, including Docker-backed integrations when available
 	go -C $(E2E_DIR) test ./internal/...
 
-test-unit: ## Run pure-Go e2e selection and helper tests; no chains
-	go -C $(E2E_DIR) test ./internal/e2etest
-
 test-e2e: build-link ## Run e2e tests (E2E_FLAGS=... E2E_LANE=...)
 	# -parallel caps concurrent Docker environments; the GOMAXPROCS default can overload a large machine.
 	E2E_LANE=$(E2E_LANE) go -C $(E2E_DIR) test . -timeout 60m -parallel 4 $(E2E_FLAGS)
@@ -82,5 +79,5 @@ check-e2e: doctor-e2e doctor-e2e-tools test-harness lint-e2e check-test-apps tes
 
 check: check-link check-e2e ## Run Link and repository e2e checks
 
-.PHONY: help build-link doctor-e2e doctor-e2e-tools test-harness test-unit test-e2e lint lint-fix lint-link lint-fix-link lint-e2e lint-fix-e2e \
+.PHONY: help build-link doctor-e2e doctor-e2e-tools test-harness test-e2e lint lint-fix lint-link lint-fix-link lint-e2e lint-fix-e2e \
 	clean-e2e-dry-run clean-e2e test-apps check-test-apps check-link check-e2e check

--- a/e2e/attached_chain_test.go
+++ b/e2e/attached_chain_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 
 	"github.com/cosmos/ibc/e2e/internal/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm/anvil"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
 // externalChainID differs from managedChainID so live validate exercises chain-id on a second node.
@@ -34,9 +34,7 @@ func TestAttachedChainRemainsCallerOwned(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		if stopErr := oob.Stop(); stopErr != nil {
-			t.Errorf("stop external Anvil: %v", stopErr)
-		}
+		assert.NoError(t, oob.Stop(), "stop external Anvil")
 	})
 
 	startHeight, err := oob.Height(ctx)

--- a/e2e/cross_route_test.go
+++ b/e2e/cross_route_test.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
-
 	"github.com/cosmos/ibc/e2e/internal/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
 // crossRouteSpec shares destination chain-a; both routes send sequence 1 to probe bare-seq collision.

--- a/e2e/fixtures_test.go
+++ b/e2e/fixtures_test.go
@@ -2,9 +2,10 @@ package e2e_test
 
 import (
 	"fmt"
-	"reflect"
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc/e2e/internal/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
@@ -95,9 +96,7 @@ func TestDummyClientMeshSpec(t *testing.T) {
 			dummyClientConnection("chain-b", "chain-c"),
 		},
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("dummyClientMeshSpec() = %#v, want %#v", got, want)
-	}
+	require.Equal(t, want, got)
 }
 
 func dummyClientConnection(a, b environment.ChainID) environment.ConnectionSpec {

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
-
 	"github.com/cosmos/ibc/e2e/internal/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
 func TestGMPCall_AutoRelay(t *testing.T) {

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -9,11 +9,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
-	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
-
 	"github.com/cosmos/ibc/e2e/internal/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 	"github.com/cosmos/ibc/e2e/internal/harness/ibclink"
+	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
 // zeroAddressReceiver is a well-formed but invalid IFT receiver: the

--- a/e2e/internal/e2etest/config_test.go
+++ b/e2e/internal/e2etest/config_test.go
@@ -1,8 +1,9 @@
 package e2etest
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 )
@@ -21,15 +22,11 @@ func TestRuntimeWithProtocolDeployer(t *testing.T) {
 	got.Endpoints["new"] = environment.EndpointBinding{RPCURL: "http://new.test"}
 	got.Authorities["new"] = environment.EVMAuthority{PrivateKeyHex: "new-key"}
 
-	if got.Authorities[ProtocolAuthorityID].PrivateKeyHex != protocolAuthorityKeyHex {
-		t.Fatalf("protocol authority = %#v", got.Authorities[ProtocolAuthorityID])
-	}
-	if input.Authorities[ProtocolAuthorityID].PrivateKeyHex != "old" || input.Authorities["new"].PrivateKeyHex != "" {
-		t.Fatalf("input authorities mutated: %#v", input.Authorities)
-	}
-	if input.Endpoints["new"].RPCURL != "" || got.Endpoints["rpc"] != input.Endpoints["rpc"] {
-		t.Fatalf("endpoint maps not cloned: input %#v, output %#v", input.Endpoints, got.Endpoints)
-	}
+	require.Equal(t, protocolAuthorityKeyHex, got.Authorities[ProtocolAuthorityID].PrivateKeyHex)
+	require.Equal(t, "old", input.Authorities[ProtocolAuthorityID].PrivateKeyHex)
+	require.Empty(t, input.Authorities["new"].PrivateKeyHex)
+	require.Empty(t, input.Endpoints["new"].RPCURL)
+	require.Equal(t, input.Endpoints["rpc"], got.Endpoints["rpc"])
 }
 
 func TestChainSpecsForConfiguredLane(t *testing.T) {
@@ -65,9 +62,7 @@ func TestChainSpecsForConfiguredLane(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			*laneFlag = tt.flag
 			t.Setenv(laneEnv, tt.env)
-			if got := ChainSpecsForConfiguredLane(t); !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("ChainSpecsForConfiguredLane() = %#v, want %#v", got, tt.want)
-			}
+			require.Equal(t, tt.want, ChainSpecsForConfiguredLane(t))
 		})
 	}
 }

--- a/e2e/internal/e2etest/start.go
+++ b/e2e/internal/e2etest/start.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 )
 
@@ -105,7 +108,9 @@ func selectedLaneName(t testing.TB) string {
 	case laneAnvil, laneAnvilInterval, laneBesu:
 		return name
 	default:
-		t.Fatalf(
+		require.FailNowf(
+			t,
+			"unknown e2e lane",
 			"unknown e2e lane %q; set %s or -e2e.lane to anvil, anvil-interval, or besu",
 			rawLaneName(),
 			laneEnv,
@@ -132,15 +137,11 @@ func normalizeLaneName(name string) string {
 func Start(t testing.TB, spec environment.Spec, runtime environment.Runtime) *environment.Environment {
 	t.Helper()
 	env, err := environment.Start(t.Context(), spec, runtime)
-	if err != nil {
-		t.Fatalf("e2etest: start Environment: %v", err)
-	}
+	require.NoError(t, err, "e2etest: start Environment")
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 		defer cancel()
-		if err := env.Close(ctx); err != nil {
-			t.Errorf("e2etest: close Environment: %v", err)
-		}
+		assert.NoError(t, env.Close(ctx), "e2etest: close Environment")
 	})
 	return env
 }

--- a/e2e/internal/e2etest/traffic_apps.go
+++ b/e2e/internal/e2etest/traffic_apps.go
@@ -3,6 +3,8 @@ package e2etest
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/counter"
 )
@@ -17,9 +19,7 @@ func BindTransfer(
 	t.Helper()
 	source, destination, sourceApps, destinationApps, clients := bindDeploymentRoute(t, env, deployment, route)
 	sourceEndpoint, destinationEndpoint, err := bindRoute(route.ID, source, destination)
-	if err != nil {
-		t.Fatalf("e2etest: bind Transfer on route %q: %v", route.ID, err)
-	}
+	require.NoError(t, err, "e2etest: bind Transfer on route %q", route.ID)
 	return &Transfer{
 		routeID:      route.ID,
 		source:       sourceEndpoint,
@@ -44,9 +44,7 @@ func BindIFT(
 	t.Helper()
 	source, destination, sourceApps, destinationApps, clients := bindDeploymentRoute(t, env, deployment, route)
 	sourceEndpoint, destinationEndpoint, err := bindRoute(route.ID, source, destination)
-	if err != nil {
-		t.Fatalf("e2etest: bind IFT on route %q: %v", route.ID, err)
-	}
+	require.NoError(t, err, "e2etest: bind IFT on route %q", route.ID)
 	return &IFT{
 		routeID:      route.ID,
 		source:       sourceEndpoint,
@@ -70,13 +68,9 @@ func BindGMP(
 	t.Helper()
 	source, destination, sourceApps, destinationApps, clients := bindDeploymentRoute(t, env, deployment, route)
 	sourceEndpoint, destinationEndpoint, err := bindRoute(route.ID, source, destination)
-	if err != nil {
-		t.Fatalf("e2etest: bind GMP on route %q: %v", route.ID, err)
-	}
+	require.NoError(t, err, "e2etest: bind GMP on route %q", route.ID)
 	defaultCall, err := mustABI(counter.CounterMetaData).Pack("increment")
-	if err != nil {
-		t.Fatalf("e2etest: pack Counter.increment(): %v", err)
-	}
+	require.NoError(t, err, "e2etest: pack Counter.increment()")
 	return &GMP{
 		routeID:      route.ID,
 		source:       sourceEndpoint,
@@ -100,32 +94,18 @@ func bindDeploymentRoute(
 	route Route,
 ) (*environment.Chain, *environment.Chain, ChainDeployment, ChainDeployment, RouteClients) {
 	t.Helper()
-	if env == nil {
-		t.Fatal("e2etest: Environment is required")
-	}
-	if deployment == nil {
-		t.Fatal("e2etest: deployment is required")
-	}
+	require.NotNil(t, env, "e2etest: Environment is required")
+	require.NotNil(t, deployment, "e2etest: deployment is required")
 
 	source, err := env.Chain(route.Source)
-	if err != nil {
-		t.Fatalf("e2etest: resolve source Chain %q: %v", route.Source, err)
-	}
+	require.NoError(t, err, "e2etest: resolve source Chain %q", route.Source)
 	destination, err := env.Chain(route.Destination)
-	if err != nil {
-		t.Fatalf("e2etest: resolve destination Chain %q: %v", route.Destination, err)
-	}
+	require.NoError(t, err, "e2etest: resolve destination Chain %q", route.Destination)
 	sourceDeployment, ok := deployment.Chain(route.Source)
-	if !ok {
-		t.Fatalf("e2etest: deployment has no source Chain %q", route.Source)
-	}
+	require.True(t, ok, "e2etest: deployment has no source Chain %q", route.Source)
 	destinationDeployment, ok := deployment.Chain(route.Destination)
-	if !ok {
-		t.Fatalf("e2etest: deployment has no destination Chain %q", route.Destination)
-	}
+	require.True(t, ok, "e2etest: deployment has no destination Chain %q", route.Destination)
 	clients, ok := deployment.RouteClients(route.ID)
-	if !ok {
-		t.Fatalf("e2etest: deployment has no route %q", route.ID)
-	}
+	require.True(t, ok, "e2etest: deployment has no route %q", route.ID)
 	return source, destination, sourceDeployment, destinationDeployment, clients
 }

--- a/e2e/internal/e2etest/traffic_evm.go
+++ b/e2e/internal/e2etest/traffic_evm.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"math/big"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-
-	ethereum "github.com/ethereum/go-ethereum"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"

--- a/e2e/internal/e2etest/traffic_relayer.go
+++ b/e2e/internal/e2etest/traffic_relayer.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
-
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 	"github.com/cosmos/ibc/e2e/internal/harness/ibclink"
+	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
 // AwaitState waits for the packet to reach want. If want is pending and the

--- a/e2e/internal/e2etest/traffic_setup.go
+++ b/e2e/internal/e2etest/traffic_setup.go
@@ -2,7 +2,6 @@ package e2etest
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"path/filepath"
@@ -13,6 +12,8 @@ import (
 	"github.com/cosmos/solidity-ibc-eureka/packages/go-abigen/erc1967proxy"
 	"github.com/cosmos/solidity-ibc-eureka/packages/go-abigen/ift"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
@@ -128,24 +129,16 @@ func DeployWithRelayerConfig(
 	routes ...Route,
 ) (*ibclink.Driver, *Deployment) {
 	t.Helper()
-	if env == nil {
-		t.Fatal("e2etest: Environment is required")
-	}
-	if err := signers.validate(); err != nil {
-		t.Fatalf("e2etest: invalid signers: %v", err)
-	}
+	require.NotNil(t, env, "e2etest: Environment is required")
+	require.NoError(t, signers.validate(), "e2etest: invalid signers")
 	ensureSignerBalances(t, env, signers)
 
 	dir := t.TempDir()
 	signerKeyPath := filepath.Join(dir, "keys", relayerSignerAlias+".json")
 	configPath := filepath.Join(dir, "ibc-link.config.yaml")
 	driver, err := ibclink.NewDriver(configPath)
-	if err != nil {
-		t.Fatalf("e2etest: create driver: %v", err)
-	}
-	if bindErr := env.BindIBCLink(driver); bindErr != nil {
-		t.Fatalf("e2etest: bind IBC Link process: %v", bindErr)
-	}
+	require.NoError(t, err, "e2etest: create driver")
+	require.NoError(t, env.BindIBCLink(driver), "e2etest: bind IBC Link process")
 
 	deployment := deployApps(t, env, signers, routes)
 	config, options := buildConfig(t, env, driver, routes, deployment, signerKeyPath, filepath.Join(dir, "relayer.db"))
@@ -153,18 +146,12 @@ func DeployWithRelayerConfig(
 		configure(&config)
 	}
 	if config.SignerType == "" || config.SignerType == ibclink.RelayerSignerLocal {
-		if err := signers.storeRelayerKey(config.SignerKeyFile); err != nil {
-			t.Fatalf("e2etest: store signers: %v", err)
-		}
+		require.NoError(t, signers.storeRelayerKey(config.SignerKeyFile), "e2etest: store signers")
 	}
-	if writeErr := ibclink.WriteRelayerConfig(configPath, config); writeErr != nil {
-		t.Fatalf("e2etest: write config: %v", writeErr)
-	}
+	require.NoError(t, ibclink.WriteRelayerConfig(configPath, config), "e2etest: write config")
 	driver.ConfigureRelayer(options)
 
-	if migrationErr := driver.MigrateUp(t.Context()); migrationErr != nil {
-		t.Fatalf("e2etest: migrate database: %v", migrationErr)
-	}
+	require.NoError(t, driver.MigrateUp(t.Context()), "e2etest: migrate database")
 	return driver, deployment
 }
 
@@ -175,23 +162,15 @@ func StartRelayer(
 	env *environment.Environment,
 ) *ibclink.Relayer {
 	t.Helper()
-	if driver == nil {
-		t.Fatal("e2etest: driver is required")
-	}
-	if env == nil {
-		t.Fatal("e2etest: Environment is required")
-	}
+	require.NotNil(t, driver, "e2etest: driver is required")
+	require.NotNil(t, env, "e2etest: Environment is required")
 
 	relayer, err := driver.StartRelayer(t.Context())
-	if err != nil {
-		t.Fatalf("e2etest: start relayer: %v", err)
-	}
+	require.NoError(t, err, "e2etest: start relayer")
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), relayerStopTimeout)
 		defer cancel()
-		if err := relayer.Stop(ctx); err != nil {
-			t.Errorf("e2etest: stop relayer: %v", err)
-		}
+		assert.NoError(t, relayer.Stop(ctx), "e2etest: stop relayer")
 	})
 
 	connected := make(map[string]struct{}, len(relayer.Ready().ChainsConnected))
@@ -200,12 +179,14 @@ func StartRelayer(
 	}
 	for _, id := range env.Chains() {
 		chain, chainErr := env.Chain(id)
-		if chainErr != nil {
-			t.Fatalf("e2etest: resolve Chain %q: %v", id, chainErr)
-		}
-		if _, ok := connected[strconv.FormatUint(chain.EVMChainID(), 10)]; !ok {
-			t.Fatalf("e2etest: relayer did not connect to Chain %q", id)
-		}
+		require.NoError(t, chainErr, "e2etest: resolve Chain %q", id)
+		require.Contains(
+			t,
+			connected,
+			strconv.FormatUint(chain.EVMChainID(), 10),
+			"e2etest: relayer did not connect to Chain %q",
+			id,
+		)
 	}
 	startBlockNudger(t, env)
 	return relayer
@@ -221,20 +202,14 @@ func startBlockNudger(t testing.TB, env *environment.Environment) {
 		return
 	}
 	authority, err := evm.AccountFromHex(protocolAuthorityKeyHex)
-	if err != nil {
-		t.Fatalf("e2etest: block nudger authority: %v", err)
-	}
+	require.NoError(t, err, "e2etest: block nudger authority")
 	address := authority.Address()
 	accesses := make([]*environment.EVM, 0, len(env.Chains()))
 	for _, id := range env.Chains() {
 		chain, chainErr := env.Chain(id)
-		if chainErr != nil {
-			t.Fatalf("e2etest: resolve Chain %q: %v", id, chainErr)
-		}
+		require.NoError(t, chainErr, "e2etest: resolve Chain %q", id)
 		evmAccess, evmErr := chain.EVM()
-		if evmErr != nil {
-			t.Fatalf("e2etest: resolve EVM access on Chain %q: %v", id, evmErr)
-		}
+		require.NoError(t, evmErr, "e2etest: resolve EVM access on Chain %q", id)
 		accesses = append(accesses, evmAccess)
 	}
 	ctx := t.Context()
@@ -275,42 +250,33 @@ func deployApps(
 
 	for _, id := range env.Chains() {
 		chain, err := env.Chain(id)
-		if err != nil {
-			t.Fatalf("e2etest: resolve Chain %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: resolve Chain %q", id)
 		instance, err := env.IBCInstanceForChain(id)
-		if err != nil {
-			t.Fatalf("e2etest: resolve IBC Instance on Chain %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: resolve IBC Instance on Chain %q", id)
 		evmAccess, err := chain.EVM()
-		if err != nil {
-			t.Fatalf("e2etest: resolve EVM access on Chain %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: resolve EVM access on Chain %q", id)
 
 		ics20 := common.HexToAddress(string(instance.ICS20TransferAddress()))
 		ics27 := common.HexToAddress(string(instance.ICS27GMPAddress()))
 		router := common.HexToAddress(string(instance.Locator()))
-		if ics20 == (common.Address{}) || ics27 == (common.Address{}) || router == (common.Address{}) {
-			t.Fatalf("e2etest: Chain %q is missing the ICS20/ICS27 app stack", id)
-		}
+		require.False(
+			t,
+			ics20 == (common.Address{}) || ics27 == (common.Address{}) || router == (common.Address{}),
+			"e2etest: Chain %q is missing the ICS20/ICS27 app stack",
+			id,
+		)
 
 		token, err := deployAndMintToken(t.Context(), evmAccess, signers.application.account)
-		if err != nil {
-			t.Fatalf("e2etest: deploy TestERC20 on Chain %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: deploy TestERC20 on Chain %q", id)
 		counterAddr, err := deployContract(
 			t.Context(),
 			evmAccess,
 			signers.application.account,
 			counter.CounterMetaData,
 		)
-		if err != nil {
-			t.Fatalf("e2etest: deploy Counter on Chain %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: deploy Counter on Chain %q", id)
 		iftToken, callConstructor, err := deployIFTToken(t.Context(), evmAccess, signers.application.account, ics27)
-		if err != nil {
-			t.Fatalf("e2etest: deploy IFT on Chain %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: deploy IFT on Chain %q", id)
 		callConstructors[id] = callConstructor
 
 		iftBatchShim, err := deployIFTBatchShim(
@@ -320,9 +286,7 @@ func deployApps(
 			iftToken,
 			initialTokenSupply,
 		)
-		if err != nil {
-			t.Fatalf("e2etest: deploy IFT batch transfer shim on Chain %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: deploy IFT batch transfer shim on Chain %q", id)
 
 		deployment.chains[id] = ChainDeployment{
 			Token:         token,
@@ -337,9 +301,7 @@ func deployApps(
 
 	for _, route := range routes {
 		sourceClient, destClient, err := resolveRouteClients(env, route)
-		if err != nil {
-			t.Fatalf("e2etest: resolve clients for route %q: %v", route.ID, err)
-		}
+		require.NoError(t, err, "e2etest: resolve clients for route %q", route.ID)
 		deployment.routes[route.ID] = RouteClients{
 			SourceClient: sourceClient,
 			DestClient:   destClient,
@@ -377,13 +339,9 @@ func registerIFTBridges(
 				continue
 			}
 			chain, err := env.Chain(end.chain)
-			if err != nil {
-				t.Fatalf("e2etest: resolve Chain %q: %v", end.chain, err)
-			}
+			require.NoError(t, err, "e2etest: resolve Chain %q", end.chain)
 			evmAccess, err := chain.EVM()
-			if err != nil {
-				t.Fatalf("e2etest: resolve EVM access on Chain %q: %v", end.chain, err)
-			}
+			require.NoError(t, err, "e2etest: resolve EVM access on Chain %q", end.chain)
 			iftToken := deployment.chains[end.chain].IFT
 			counterpartyIFT := deployment.chains[end.counterparty].IFT
 			data, err := iftABI.Pack(
@@ -392,18 +350,21 @@ func registerIFTBridges(
 				counterpartyIFT.Hex(),
 				callConstructors[end.chain],
 			)
-			if err != nil {
-				t.Fatalf("e2etest: pack IFT registerIFTBridge: %v", err)
-			}
-			if _, err := evmAccess.BroadcastTx(
+			require.NoError(t, err, "e2etest: pack IFT registerIFTBridge")
+			_, err = evmAccess.BroadcastTx(
 				t.Context(),
 				signers.application.account,
 				&iftToken,
 				data,
 				nil,
-			); err != nil {
-				t.Fatalf("e2etest: register IFT bridge for client %q on Chain %q: %v", end.client, end.chain, err)
-			}
+			)
+			require.NoError(
+				t,
+				err,
+				"e2etest: register IFT bridge for client %q on Chain %q",
+				end.client,
+				end.chain,
+			)
 		}
 	}
 }
@@ -435,17 +396,11 @@ func buildConfig(
 	}
 	for _, id := range env.Chains() {
 		chain, err := env.Chain(id)
-		if err != nil {
-			t.Fatalf("e2etest: resolve Chain %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: resolve Chain %q", id)
 		rpc, err := driver.ChainRPC(string(id))
-		if err != nil {
-			t.Fatalf("e2etest: resolve Chain %q process binding: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: resolve Chain %q process binding", id)
 		apps, ok := deployment.Chain(id)
-		if !ok {
-			t.Fatalf("e2etest: deployment has no Chain %q", id)
-		}
+		require.True(t, ok, "e2etest: deployment has no Chain %q", id)
 		options.ChainIDs[string(id)] = strconv.FormatUint(chain.EVMChainID(), 10)
 		config.Chains = append(config.Chains, ibclink.RelayerChain{
 			ChainID:     options.ChainIDs[string(id)],
@@ -457,9 +412,7 @@ func buildConfig(
 	attestorSets := make(map[string]*ibclink.RelayerAttestorSet, len(attestorIDs))
 	for _, id := range attestorIDs {
 		attestor, err := env.Attestor(id)
-		if err != nil {
-			t.Fatalf("e2etest: resolve Attestor %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: resolve Attestor %q", id)
 		client := attestor.IBCClient()
 		chainID := options.ChainIDs[string(client.IBCInstance().Chain().ID())]
 		key := chainID + "/" + string(client.Locator())
@@ -476,9 +429,7 @@ func buildConfig(
 	connections := map[string]bool{}
 	for _, route := range routes {
 		clients, ok := deployment.RouteClients(route.ID)
-		if !ok {
-			t.Fatalf("e2etest: deployment has no route %q", route.ID)
-		}
+		require.True(t, ok, "e2etest: deployment has no route %q", route.ID)
 		options.ManualRoutes[string(route.ID)] = route.Manual
 
 		sourceChain := options.ChainIDs[string(route.Source)]
@@ -625,40 +576,43 @@ func ensureSignerBalances(t testing.TB, env *environment.Environment, signers Si
 	minimum := RequiredSignerBalance()
 	for _, id := range env.Chains() {
 		chain, err := env.Chain(id)
-		if err != nil {
-			t.Fatalf("e2etest: resolve Chain %q: %v", id, err)
-		}
+		require.NoError(t, err, "e2etest: resolve Chain %q", id)
 		funding, err := chain.Funding()
 		if err == nil {
 			for _, actor := range actors {
-				if fundErr := funding.EnsureEOABalance(t.Context(), actor.address, minimum); fundErr != nil {
-					t.Fatalf("e2etest: fund %s signer on Chain %q: %v", actor.role, id, fundErr)
-				}
+				require.NoError(
+					t,
+					funding.EnsureEOABalance(t.Context(), actor.address, minimum),
+					"e2etest: fund %s signer on Chain %q",
+					actor.role,
+					id,
+				)
 			}
 			continue
 		}
-		if !errors.Is(err, environment.ErrCapabilityUnavailable) {
-			t.Fatalf("e2etest: resolve funding on Chain %q: %v", id, err)
-		}
+		require.ErrorIs(t, err, environment.ErrCapabilityUnavailable, "e2etest: resolve funding on Chain %q", id)
 		evmAccess, evmErr := chain.EVM()
-		if evmErr != nil {
-			t.Fatalf("e2etest: resolve EVM access on attached Chain %q: %v", id, evmErr)
-		}
+		require.NoError(t, evmErr, "e2etest: resolve EVM access on attached Chain %q", id)
 		for _, actor := range actors {
 			balance, balanceErr := evmAccess.BalanceAt(t.Context(), actor.address, nil)
-			if balanceErr != nil {
-				t.Fatalf("e2etest: query %s signer balance on attached Chain %q: %v", actor.role, id, balanceErr)
-			}
-			if balance.Cmp(minimum) < 0 {
-				t.Fatalf(
-					"e2etest: %s signer %s on attached Chain %q has balance %s, need at least %s; provision it out of band",
-					actor.role,
-					actor.address,
-					id,
-					balance,
-					minimum,
-				)
-			}
+			require.NoError(
+				t,
+				balanceErr,
+				"e2etest: query %s signer balance on attached Chain %q",
+				actor.role,
+				id,
+			)
+			require.GreaterOrEqual(
+				t,
+				balance.Cmp(minimum),
+				0,
+				"e2etest: %s signer %s on attached Chain %q has balance %s, need at least %s; provision it out of band",
+				actor.role,
+				actor.address,
+				id,
+				balance,
+				minimum,
+			)
 		}
 	}
 }

--- a/e2e/internal/e2etest/traffic_signers.go
+++ b/e2e/internal/e2etest/traffic_signers.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cosmos/ibc/link/keyfile"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
+	"github.com/cosmos/ibc/link/keyfile"
 )
 
 const (
@@ -71,13 +72,9 @@ func (s Signers) GoString() string {
 func newLocalSigner(t testing.TB, role string) localSigner {
 	t.Helper()
 	key, err := crypto.GenerateKey()
-	if err != nil {
-		t.Fatalf("e2etest: generate %s signer: %v", role, err)
-	}
+	require.NoError(t, err, "e2etest: generate %s signer", role)
 	account, err := evm.AccountFromHex(hex.EncodeToString(crypto.FromECDSA(key)))
-	if err != nil {
-		t.Fatalf("e2etest: create %s account: %v", role, err)
-	}
+	require.NoError(t, err, "e2etest: create %s account", role)
 	return localSigner{key: key, account: account}
 }
 

--- a/e2e/internal/harness/chain/evm/anvil/anvil.go
+++ b/e2e/internal/harness/chain/evm/anvil/anvil.go
@@ -15,10 +15,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
+	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/testcontainers/testcontainers-go"
-
-	containertypes "github.com/moby/moby/api/types/container"
 
 	chainpkg "github.com/cosmos/ibc/e2e/internal/harness/chain"
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"

--- a/e2e/internal/harness/chain/evm/besu/besu.go
+++ b/e2e/internal/harness/chain/evm/besu/besu.go
@@ -16,11 +16,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-
-	containertypes "github.com/moby/moby/api/types/container"
 
 	chainpkg "github.com/cosmos/ibc/e2e/internal/harness/chain"
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"

--- a/e2e/internal/harness/chain/evm/client.go
+++ b/e2e/internal/harness/chain/evm/client.go
@@ -8,12 +8,11 @@ import (
 	"os"
 	"time"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
-
-	ethereum "github.com/ethereum/go-ethereum"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm/poll"
 )

--- a/e2e/internal/harness/chain/evm/container/container.go
+++ b/e2e/internal/harness/chain/evm/container/container.go
@@ -6,9 +6,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/moby/moby/api/types/network"
-
 	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 )
 
 var nameRe = regexp.MustCompile(`[^a-z0-9_.-]+`)

--- a/e2e/internal/harness/chain/evm/container/container_test.go
+++ b/e2e/internal/harness/chain/evm/container/container_test.go
@@ -4,10 +4,9 @@ import (
 	"net/netip"
 	"testing"
 
+	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/require"
-
-	containertypes "github.com/moby/moby/api/types/container"
 )
 
 func TestNamePrefixSanitizesDockerNames(t *testing.T) {

--- a/e2e/internal/harness/environment/chain.go
+++ b/e2e/internal/harness/environment/chain.go
@@ -7,11 +7,10 @@ import (
 	"math/big"
 	"time"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-
-	ethereum "github.com/ethereum/go-ethereum"
 
 	chainimpl "github.com/cosmos/ibc/e2e/internal/harness/chain"
 	chainevm "github.com/cosmos/ibc/e2e/internal/harness/chain/evm"

--- a/e2e/internal/harness/environment/process_test.go
+++ b/e2e/internal/harness/environment/process_test.go
@@ -245,7 +245,7 @@ func requireCloseBlocked(t *testing.T, done <-chan error) {
 	t.Helper()
 	select {
 	case err := <-done:
-		t.Fatalf("Environment.Close returned while a bound process was starting: %v", err)
+		require.FailNow(t, "Environment.Close returned while a bound process was starting", "%v", err)
 	case <-time.After(100 * time.Millisecond):
 	}
 }

--- a/e2e/internal/harness/environment/protocol_start_test.go
+++ b/e2e/internal/harness/environment/protocol_start_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,13 +50,13 @@ func TestEnvironmentCloseWaitsForLeasedAttestorUse(t *testing.T) {
 		select {
 		case <-useFinished:
 		case <-time.After(time.Second):
-			t.Error("leased Attestor use did not finish")
+			assert.Fail(t, "leased Attestor use did not finish")
 		}
 		if closeStarted {
 			select {
 			case <-closeFinished:
 			case <-time.After(time.Second):
-				t.Error("Environment.Close did not finish")
+				assert.Fail(t, "Environment.Close did not finish")
 			}
 		}
 	}()
@@ -63,7 +64,7 @@ func TestEnvironmentCloseWaitsForLeasedAttestorUse(t *testing.T) {
 	select {
 	case <-useStarted:
 	case <-time.After(time.Second):
-		t.Fatal("leased Attestor use did not start")
+		require.FailNow(t, "leased Attestor use did not start")
 	}
 	closeStarted = true
 	go func() {
@@ -76,7 +77,7 @@ func TestEnvironmentCloseWaitsForLeasedAttestorUse(t *testing.T) {
 	}, time.Second, time.Millisecond)
 	select {
 	case <-cleanupStarted:
-		t.Fatal("Attestor cleanup started before the leased use finished")
+		require.FailNow(t, "Attestor cleanup started before the leased use finished")
 	default:
 	}
 
@@ -85,18 +86,18 @@ func TestEnvironmentCloseWaitsForLeasedAttestorUse(t *testing.T) {
 	case err := <-useDone:
 		require.NoError(t, err)
 	case <-time.After(time.Second):
-		t.Fatal("leased Attestor use did not finish")
+		require.FailNow(t, "leased Attestor use did not finish")
 	}
 	select {
 	case err := <-closeDone:
 		require.NoError(t, err)
 	case <-time.After(time.Second):
-		t.Fatal("Environment.Close did not finish")
+		require.FailNow(t, "Environment.Close did not finish")
 	}
 	select {
 	case <-cleanupStarted:
 	default:
-		t.Fatal("Attestor cleanup did not run")
+		require.FailNow(t, "Attestor cleanup did not run")
 	}
 	require.ErrorIs(t, attestor.use(func() error { return nil }), ErrEnvironmentClosed)
 }

--- a/e2e/internal/harness/environment/solidityibc/setup_test.go
+++ b/e2e/internal/harness/environment/solidityibc/setup_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/cosmos/solidity-ibc-eureka/packages/go-abigen/ics26router"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/stretchr/testify/require"
-
-	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/accessmanager"

--- a/e2e/internal/harness/environment/spec_test.go
+++ b/e2e/internal/harness/environment/spec_test.go
@@ -1,7 +1,6 @@
 package environment
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -312,7 +311,7 @@ func TestSpecValidateDoesNotMutate(t *testing.T) {
 	spec := validSpec()
 	want := validSpec()
 	require.NoError(t, spec.validate())
-	require.True(t, reflect.DeepEqual(want, spec))
+	require.Equal(t, want, spec)
 }
 
 func TestSpecValidateRejectsUnrepresentableAnvilTiming(t *testing.T) {

--- a/e2e/internal/harness/environment/start_integration_test.go
+++ b/e2e/internal/harness/environment/start_integration_test.go
@@ -583,7 +583,7 @@ func requireIBCLinkBinary(t *testing.T) {
 	}
 	if info.Mode()&0o111 == 0 {
 		if os.Getenv("IBC_BIN") != "" {
-			t.Fatalf("explicit IBC_BIN is not executable: %s", path)
+			require.FailNow(t, "explicit IBC_BIN is not executable: "+path)
 		}
 		t.Skipf("IBC Link binary is not executable: %s; run `make -C link build`", path)
 	}

--- a/e2e/internal/harness/environment/start_test.go
+++ b/e2e/internal/harness/environment/start_test.go
@@ -352,7 +352,7 @@ func TestStartAcquiresIndependentChainsConcurrently(t *testing.T) {
 		case id := <-started:
 			seen[id] = true
 		case <-time.After(time.Second):
-			t.Fatal("both independent Chain acquisitions did not start concurrently")
+			require.FailNow(t, "both independent Chain acquisitions did not start concurrently")
 		}
 	}
 	close(release)

--- a/e2e/internal/harness/ibclink/attestor.go
+++ b/e2e/internal/harness/ibclink/attestor.go
@@ -20,12 +20,12 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/cosmos/ibc/link/keyfile"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"gopkg.in/yaml.v3"
 
 	attestorv2 "github.com/cosmos/ibc/link/api/v2/attestor"
+	"github.com/cosmos/ibc/link/keyfile"
 )
 
 const (

--- a/e2e/internal/harness/ibclink/attestor_test.go
+++ b/e2e/internal/harness/ibclink/attestor_test.go
@@ -17,12 +17,12 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/cosmos/ibc/link/keyfile"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	attestorv2 "github.com/cosmos/ibc/link/api/v2/attestor"
+	"github.com/cosmos/ibc/link/keyfile"
 )
 
 const testPrivateKey = "0000000000000000000000000000000000000000000000000000000000000006"

--- a/e2e/internal/harness/ibclink/process_handle_test.go
+++ b/e2e/internal/harness/ibclink/process_handle_test.go
@@ -8,18 +8,16 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSignalAndWaitCanceledThenReaps(t *testing.T) {
 	cmd := exec.Command("sh", "-c", "trap '' TERM; printf 'ready\\n'; while :; do sleep 60; done")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Fatalf("create child stdout pipe: %v", err)
-	}
-	if startErr := cmd.Start(); startErr != nil {
-		t.Fatalf("start child: %v", startErr)
-	}
+	require.NoError(t, err, "create child stdout pipe")
+	require.NoError(t, cmd.Start(), "start child")
 	handle := reapProcess(cmd, processHooks{})
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -37,40 +35,28 @@ func TestSignalAndWaitCanceledThenReaps(t *testing.T) {
 	}()
 	select {
 	case readyErr := <-ready:
-		if readyErr != nil {
-			t.Fatalf("wait for child readiness: %v", readyErr)
-		}
+		require.NoError(t, readyErr, "wait for child readiness")
 	case <-time.After(5 * time.Second):
-		t.Fatal("child did not become ready")
+		require.FailNow(t, "child did not become ready")
 	}
 
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
 	started := time.Now()
 	err = handle.signalAndWait(canceled, syscall.SIGTERM, time.Minute)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("canceled SignalAndWait error = %v, want context.Canceled", err)
-	}
-	if elapsed := time.Since(started); elapsed > 2*time.Second {
-		t.Fatalf("canceled SignalAndWait took %v", elapsed)
-	}
+	require.ErrorIs(t, err, context.Canceled, "canceled SignalAndWait")
+	require.Less(t, time.Since(started), 2*time.Second, "canceled SignalAndWait took too long")
 
 	waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer waitCancel()
-	if err := handle.signalAndWait(waitCtx, syscall.SIGTERM, 0); err != nil {
-		t.Fatalf("subsequent SignalAndWait: %v", err)
-	}
-	if handle.err() == nil {
-		t.Fatal("reaped SIGKILL child has no wait error")
-	}
+	require.NoError(t, handle.signalAndWait(waitCtx, syscall.SIGTERM, 0), "subsequent SignalAndWait")
+	require.Error(t, handle.err(), "reaped SIGKILL child has no wait error")
 }
 
 func TestSignalAndWaitSIGKILLWaitsForReap(t *testing.T) {
 	cmd := exec.Command("sh", "-c", "while :; do sleep 60; done")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start child: %v", err)
-	}
+	require.NoError(t, cmd.Start(), "start child")
 
 	allowWait := make(chan struct{})
 	handle := reapProcess(cmd, processHooks{BeforeWait: func() { <-allowWait }})
@@ -90,13 +76,11 @@ func TestSignalAndWaitSIGKILLWaitsForReap(t *testing.T) {
 
 	select {
 	case err := <-result:
-		t.Fatalf("SignalAndWait returned before reap: %v", err)
+		require.FailNow(t, "SignalAndWait returned before reap", "%v", err)
 	case <-time.After(100 * time.Millisecond):
 	}
 	close(allowWait)
-	if err := <-result; err != nil {
-		t.Fatalf("SignalAndWait with SIGKILL and grace: %v", err)
-	}
+	require.NoError(t, <-result, "SignalAndWait with SIGKILL and grace")
 }
 
 func closeIfOpen(ch chan struct{}) {

--- a/e2e/node_recovery_test.go
+++ b/e2e/node_recovery_test.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
-
 	"github.com/cosmos/ibc/e2e/internal/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
 func TestRelayerRecoversAfterNodeRestart(t *testing.T) {

--- a/e2e/pending_packet_test.go
+++ b/e2e/pending_packet_test.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
-
 	"github.com/cosmos/ibc/e2e/internal/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
 func TestPendingPacketStatusWhileDestinationMiningPaused(t *testing.T) {

--- a/e2e/relayer_lifecycle_test.go
+++ b/e2e/relayer_lifecycle_test.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
-
 	"github.com/cosmos/ibc/e2e/internal/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
 func TestManualRelay_RequestSurvivesRestart(t *testing.T) {

--- a/e2e/transfer_test.go
+++ b/e2e/transfer_test.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
-
 	"github.com/cosmos/ibc/e2e/internal/e2etest"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 )
 
 func TestTransfer_AutoRelay(t *testing.T) {

--- a/link/api/v2/attestor/readiness_test.go
+++ b/link/api/v2/attestor/readiness_test.go
@@ -17,5 +17,7 @@ func TestProcessReadiness(t *testing.T) {
 		HTTP:  "127.0.0.1:3000",
 	})
 	require.NoError(t, err)
+	// the e2e harness reads readiness as one exact stdout line; the encoding must stay compact
+	//nolint:testifylint // JSONEq would not catch a switch to indented output
 	require.Equal(t, `{"event":"ready","http":"127.0.0.1:3000"}`, string(encoded))
 }

--- a/link/api/v2/relayer/readiness_test.go
+++ b/link/api/v2/relayer/readiness_test.go
@@ -18,5 +18,7 @@ func TestProcessReadiness(t *testing.T) {
 		HTTP:            "127.0.0.1:3000",
 	})
 	require.NoError(t, err)
+	// the e2e harness reads readiness as one exact stdout line; the encoding must stay compact
+	//nolint:testifylint // JSONEq would not catch a switch to indented output
 	require.Equal(t, `{"event":"ready","chainsConnected":["chain-a"],"http":"127.0.0.1:3000"}`, string(encoded))
 }

--- a/link/cmd/ibc/config_test.go
+++ b/link/cmd/ibc/config_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cosmos/ibc/link/internal/config"
 )
 
@@ -17,10 +19,6 @@ func TestConfigValidate(t *testing.T) {
 	globalFlags.Home = home
 	globalFlags.Quiet = true
 
-	if err := config.DefaultConfig().StoreToFile(filepath.Join(home, globalFlags.Config)); err != nil {
-		t.Fatal(err)
-	}
-	if err := configValidate(nil, nil); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, config.DefaultConfig().StoreToFile(filepath.Join(home, globalFlags.Config)))
+	require.NoError(t, configValidate(nil, nil))
 }

--- a/link/internal/chains/evm/client.go
+++ b/link/internal/chains/evm/client.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"time"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -20,8 +21,6 @@ import (
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
 	hostv2 "github.com/cosmos/ibc-go/v11/modules/core/24-host/v2"
-	ethereum "github.com/ethereum/go-ethereum"
-
 	"github.com/cosmos/ibc/link/internal/chains/evm/contracts/ics26router"
 	v2 "github.com/cosmos/ibc/link/internal/types/v2"
 )

--- a/link/internal/chains/evm/client_test.go
+++ b/link/internal/chains/evm/client_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -14,8 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
-	ethereum "github.com/ethereum/go-ethereum"
 
 	"github.com/cosmos/ibc/link/internal/chains/evm/contracts/ics26router"
 	"github.com/cosmos/ibc/link/internal/tests/mocks"

--- a/link/internal/config/relayer_test.go
+++ b/link/internal/config/relayer_test.go
@@ -29,6 +29,7 @@ func TestRelayerConfig(t *testing.T) {
 		chain := config.Relayer.ChainOverrides[0]
 		assert.Equal(t, "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC", config.Chains[0].EVM.ICS26Router)
 		assert.Equal(t, 2*time.Second, *chain.TxSubmissionDelay)
+		//nolint:testifylint // exact literal from the fixture; a tolerance would mask decoding drift
 		assert.Equal(t, 1.5, *chain.EVM.GasFeeCapMultiplier)
 		assert.Equal(t, 20, *chain.PacketBatchSize)
 		assert.Equal(t, 10*time.Second, *chain.PacketBatchTimeout)

--- a/link/internal/pkg/logging/logging_test.go
+++ b/link/internal/pkg/logging/logging_test.go
@@ -6,9 +6,8 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	pkgerrors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReplaceErrorAttr(t *testing.T) {

--- a/link/internal/relay/pipeline/batch_processor_test.go
+++ b/link/internal/relay/pipeline/batch_processor_test.go
@@ -114,7 +114,7 @@ func TestBatchProcess(t *testing.T) {
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			t.Fatal("collector stalled while a batch was processing")
+			require.FailNow(t, "collector stalled while a batch was processing")
 		}
 
 		close(release)

--- a/link/internal/relay/pipeline/pipeline_test.go
+++ b/link/internal/relay/pipeline/pipeline_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/chains"
 	"github.com/cosmos/ibc/link/internal/relay/processors"
 	"github.com/cosmos/ibc/link/internal/relay/proofgen"
@@ -231,7 +230,7 @@ func runPipeline(t *testing.T, deps Deps, opts Options, tr *processors.Transfer)
 
 		return result.transfer
 	case <-time.After(15 * time.Second):
-		t.Fatal("pipeline did not emit the transfer in time")
+		require.FailNow(t, "pipeline did not emit the transfer in time")
 
 		return nil
 	}
@@ -398,7 +397,7 @@ func TestPipelineLifecycle(t *testing.T) {
 
 		out := runPipeline(t, deps, fastOpts(), tr)
 
-		assert.ErrorIs(t, out.ProcessingError, processors.ErrSendNotFinalized)
+		require.ErrorIs(t, out.ProcessingError, processors.ErrSendNotFinalized)
 
 		// the packet stays unfinished for the next run
 		unfinished, err := env.store.ListUnfinishedPackets(context.Background())
@@ -431,7 +430,7 @@ func TestPipelinePushRespectsContextCancellation(t *testing.T) {
 
 	select {
 	case <-done:
-		t.Fatal("Push returned before the input was read or the context was canceled")
+		require.FailNow(t, "Push returned before the input was read or the context was canceled")
 	case <-time.After(50 * time.Millisecond):
 	}
 
@@ -441,6 +440,6 @@ func TestPipelinePushRespectsContextCancellation(t *testing.T) {
 	case pushed := <-done:
 		assert.False(t, pushed, "Push must report failure when canceled before the send lands")
 	case <-time.After(time.Second):
-		t.Fatal("Push did not return after its context was canceled; it is still blocked on the full buffer")
+		require.FailNow(t, "Push did not return after its context was canceled; it is still blocked on the full buffer")
 	}
 }

--- a/link/internal/relay/pipeline/processor_mw.go
+++ b/link/internal/relay/pipeline/processor_mw.go
@@ -139,6 +139,10 @@ func (mw BatchProcessorMW) Process(ctx context.Context, batch []*processors.Tran
 		toProcess = append(toProcess, input)
 	}
 
+	if len(toProcess) == 0 {
+		return notProcessing, nil
+	}
+
 	output, err := mw.internal.Process(ctx, toProcess)
 	if err != nil {
 		// on shutdown the outer processor cancels for us

--- a/link/internal/relay/pipeline/processor_mw_test.go
+++ b/link/internal/relay/pipeline/processor_mw_test.go
@@ -214,9 +214,9 @@ func TestBatchProcessorMW(t *testing.T) {
 		assert.NotEmpty(t, tr.Error())
 		require.Len(t, internal.canceled, 1)
 		assert.Equal(t, []*processors.Transfer{tr}, internal.canceled[0])
-		// the transfer whose status update failed must not be processed
-		require.Len(t, internal.processed, 1)
-		assert.Empty(t, internal.processed[0])
+		// the transfer whose status update failed must not be processed,
+		// and an all-failed batch must not reach the processor at all
+		assert.Empty(t, internal.processed)
 	})
 
 	t.Run("processErrorPoisonsProcessedOnly", func(t *testing.T) {

--- a/link/internal/relay/processors/batch_recv_packet_test.go
+++ b/link/internal/relay/processors/batch_recv_packet_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/chains"
 	"github.com/cosmos/ibc/link/internal/relay/proofgen"
 	"github.com/cosmos/ibc/link/internal/relay/txbuilder"
@@ -132,8 +131,8 @@ func TestBatchRecvPacketSequenceAlignment(t *testing.T) {
 
 	require.Len(t, capturedTxIDs, 1, "only the valid tx hash should be included")
 
-	require.NotNil(t, invalid.ProcessingError)
-	require.Nil(t, valid.ProcessingError)
+	require.Error(t, invalid.ProcessingError)
+	require.NoError(t, valid.ProcessingError)
 	require.NotNil(t, valid.RecvTxHash)
 }
 
@@ -227,12 +226,12 @@ func TestBatchRecvPacketToleratesPartialEventFetchFailure(t *testing.T) {
 	_, err = p.Process(context.Background(), []*Transfer{healthy, failing})
 	require.NoError(t, err, "the batch as a whole must not fail just because one tx's events failed to fetch")
 
-	require.NotNil(
+	require.Error(
 		t,
 		failing.ProcessingError,
 		"the transfer whose tx failed to fetch must be excluded and retried later",
 	)
-	require.Nil(t, healthy.ProcessingError, "the transfer whose tx fetched fine must still be relayed")
+	require.NoError(t, healthy.ProcessingError, "the transfer whose tx fetched fine must still be relayed")
 	require.NotNil(t, healthy.RecvTxHash)
 }
 
@@ -332,10 +331,10 @@ func TestBatchRecvPacketExcludesNotYetProvablePackets(t *testing.T) {
 	_, err = p.Process(context.Background(), []*Transfer{provable, tooRecent})
 	require.NoError(t, err, "the batch as a whole must not fail just because one packet isn't provable yet")
 
-	require.Nil(t, provable.ProcessingError)
+	require.NoError(t, provable.ProcessingError)
 	require.NotNil(t, provable.RecvTxHash)
 
-	require.NotNil(
+	require.Error(
 		t,
 		tooRecent.ProcessingError,
 		"the too-recent packet must be excluded and retried once attestors catch up",

--- a/link/internal/relay/processors/batch_relay.go
+++ b/link/internal/relay/processors/batch_relay.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/chains"
 	"github.com/cosmos/ibc/link/internal/relay/proofgen"
 	"github.com/cosmos/ibc/link/internal/relay/txbuilder"

--- a/link/internal/relay/proofgen/attestation/generator.go
+++ b/link/internal/relay/proofgen/attestation/generator.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/chains"
 	"github.com/cosmos/ibc/link/internal/service/attestor"
 	attestorevm "github.com/cosmos/ibc/link/internal/service/attestor/evm"

--- a/link/internal/relay/proofgen/attestation/generator_test.go
+++ b/link/internal/relay/proofgen/attestation/generator_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/service/attestor"
 	attestorevm "github.com/cosmos/ibc/link/internal/service/attestor/evm"
 	"github.com/cosmos/ibc/link/internal/tests/mocks"

--- a/link/internal/relay/proofgen/proofgen.go
+++ b/link/internal/relay/proofgen/proofgen.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/chains"
 	"github.com/cosmos/ibc/link/internal/config"
 	"github.com/cosmos/ibc/link/internal/relay/proofgen/attestation"

--- a/link/internal/relay/txbuilder/evm/evm.go
+++ b/link/internal/relay/txbuilder/evm/evm.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/chains/evm/contracts/ics26router"
 	v2 "github.com/cosmos/ibc/link/internal/types/v2"
 )

--- a/link/internal/relay/txbuilder/evm/evm_test.go
+++ b/link/internal/relay/txbuilder/evm/evm_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/chains/evm/contracts/ics26router"
 	v2 "github.com/cosmos/ibc/link/internal/types/v2"
 )

--- a/link/internal/service/attestor/evm/encoding_test.go
+++ b/link/internal/service/attestor/evm/encoding_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/chains/evm/contracts/ics26router"
 )
 

--- a/link/internal/service/attestor/local.go
+++ b/link/internal/service/attestor/local.go
@@ -10,7 +10,6 @@ import (
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
 	hostv2 "github.com/cosmos/ibc-go/v11/modules/core/24-host/v2"
-
 	"github.com/cosmos/ibc/link/internal/chains"
 	"github.com/cosmos/ibc/link/internal/config"
 	evm "github.com/cosmos/ibc/link/internal/service/attestor/evm"

--- a/link/internal/service/attestor/local_test.go
+++ b/link/internal/service/attestor/local_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	kms "github.com/cosmos/kms/signing/file"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -15,8 +16,6 @@ import (
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
 	hostv2 "github.com/cosmos/ibc-go/v11/modules/core/24-host/v2"
-	kms "github.com/cosmos/kms/signing/file"
-
 	"github.com/cosmos/ibc/link/internal/chains"
 	"github.com/cosmos/ibc/link/internal/chains/evm/contracts/ics26router"
 	"github.com/cosmos/ibc/link/internal/config"

--- a/link/internal/service/relayer/service_test.go
+++ b/link/internal/service/relayer/service_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	channeltypesv2 "github.com/cosmos/ibc-go/v11/modules/core/04-channel/v2/types"
-
 	"github.com/cosmos/ibc/link/internal/config"
 	"github.com/cosmos/ibc/link/internal/store"
 	"github.com/cosmos/ibc/link/internal/tests/mocks"

--- a/link/internal/service/signer/local_ed25519.go
+++ b/link/internal/service/signer/local_ed25519.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
-
 	kms "github.com/cosmos/kms/signing/file"
 
 	"github.com/cosmos/ibc/link/keyfile"

--- a/link/internal/service/signer/local_secp256k1.go
+++ b/link/internal/service/signer/local_secp256k1.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"crypto/rand"
 
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-
 	kms "github.com/cosmos/kms/signing/file"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 
 	"github.com/cosmos/ibc/link/keyfile"
 )

--- a/link/internal/store/migrations.go
+++ b/link/internal/store/migrations.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	migrate "github.com/rubenv/sql-migrate"
 
 	"github.com/cosmos/ibc/link/internal/config"

--- a/link/internal/store/store.go
+++ b/link/internal/store/store.go
@@ -6,9 +6,8 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/pkg/errors"
-
 	pgx "github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
 
 	"github.com/cosmos/ibc/link/internal/config"
 )

--- a/link/internal/store/store_postgres.go
+++ b/link/internal/store/store_postgres.go
@@ -6,12 +6,11 @@ import (
 	"log/slog"
 	"time"
 
+	pgx "github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pkg/errors"
-
-	pgx "github.com/jackc/pgx/v5"
 	migrate "github.com/rubenv/sql-migrate"
 
 	"github.com/cosmos/ibc/link/internal/config"

--- a/link/internal/store/store_sqlite.go
+++ b/link/internal/store/store_sqlite.go
@@ -9,14 +9,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
-	//nolint:blank-imports // SQL driver
-	_ "modernc.org/sqlite"
-
 	migrate "github.com/rubenv/sql-migrate"
 
 	"github.com/cosmos/ibc/link/internal/config"
 	reposqlite "github.com/cosmos/ibc/link/internal/store/repository/sqlite"
+
+	//nolint:blank-imports // SQL driver
+	_ "modernc.org/sqlite"
 )
 
 // SqliteInMemory tells sqlite to use a fully in-memory database

--- a/link/internal/txsubmitter/evm/evm.go
+++ b/link/internal/txsubmitter/evm/evm.go
@@ -8,13 +8,12 @@ import (
 	"sync"
 	"time"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/pkg/errors"
-
-	ethereum "github.com/ethereum/go-ethereum"
 
 	"github.com/cosmos/ibc/link/internal/service/signer"
 	v2 "github.com/cosmos/ibc/link/internal/types/v2"

--- a/link/internal/txsubmitter/evm/evm_test.go
+++ b/link/internal/txsubmitter/evm/evm_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 	"time"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
-	ethereum "github.com/ethereum/go-ethereum"
 
 	"github.com/cosmos/ibc/link/internal/service/signer"
 	"github.com/cosmos/ibc/link/internal/tests/mocks"

--- a/link/keyfile/keyfile_test.go
+++ b/link/keyfile/keyfile_test.go
@@ -19,6 +19,8 @@ func TestSignerFileContract(t *testing.T) {
 
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
+	// the on-disk shape is a contract with external consumers; assert exact bytes
+	//nolint:testifylint // JSONEq would not catch a switch to indented output
 	require.Equal(t, `{"type":"ecdsa","privateKeyBase64":"AQID"}`, string(data))
 
 	dirInfo, err := os.Stat(dir)


### PR DESCRIPTION
enable testifylint, fix violations and use testify everywhere.

Also pin gci import ordering to prefix(github.com/cosmos/ibc) instead of
localmodule, and exclude dupl in test files.

Closes FOU-1231