### PR TITLE
ci: restrict GitHub Actions token permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: [main, development]
 
+permissions: read-all
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/ibc-link-build.yml
+++ b/.github/workflows/ibc-link-build.yml
@@ -12,9 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.base.ref || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  packages: write
+permissions: read-all
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}
@@ -109,6 +107,9 @@ jobs:
     name: Publish linux-${{ matrix.goarch }} image
     needs: [image-metadata, build]
     runs-on: depot-ubuntu-24.04-4
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -147,6 +148,8 @@ jobs:
     name: Publish multi-platform image
     needs: [image-metadata, publish-image]
     runs-on: depot-ubuntu-24.04-4
+    permissions:
+      packages: write
     timeout-minutes: 10
     env:
       IMAGE_TAG: ${{ needs.image-metadata.outputs.image_tag }}

--- a/.github/workflows/ibc-link-ci.yml
+++ b/.github/workflows/ibc-link-ci.yml
@@ -11,8 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: read-all
 
 defaults:
   run:
@@ -52,6 +51,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.link == 'true'
     runs-on: depot-ubuntu-24.04-4
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
@@ -69,6 +70,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.link == 'true'
     runs-on: depot-ubuntu-24.04-4
+    permissions:
+      contents: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -86,6 +89,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.link == 'true'
     runs-on: depot-ubuntu-24.04-4
+    permissions:
+      contents: read
     timeout-minutes: 30
     env:
       # creates postgres docker container for testing
@@ -104,6 +109,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.sql == 'true' || needs.changes.outputs.proto == 'true'
     runs-on: depot-ubuntu-24.04-4
+    permissions:
+      contents: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -144,6 +151,7 @@ jobs:
     if: always()
     needs: [changes, lint, build, test, verify-codegen]
     runs-on: depot-ubuntu-24.04-4
+    permissions: {}
     steps:
       - name: Check required jobs
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -4,13 +4,14 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  pull-requests: read
+permissions: read-all
 
 jobs:
   validate-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     timeout-minutes: 5
     steps:
       - uses: amannn/action-semantic-pull-request@v6

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -15,6 +15,8 @@ on:
       - ".github/workflows/spec.yml"
       - ".github/workflows/link-check-config.json"
 
+permissions: read-all
+
 jobs:
   markdown-lint:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- set a read-only token default on all 5 workflows
- retain narrow job-level read scopes where less access is sufficient
- grant `packages: write` only to the 2 image-publishing jobs
- disable token permissions entirely for the token-free Link CI finalizer

## Validation
- `actionlint -ignore 'label ".*" is unknown' .github/workflows/*.yml`
- parsed all workflow YAML
- verified every workflow has top-level `permissions: read-all` and each write scope is job-local

Linear: FOU-1160  
Stack: 1/4; followed by #1319
