### PR TITLE
governance: configure binding TSC votes

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,0 +1,12 @@
+version: "1"
+
+audit:
+  enabled: true
+
+profiles:
+  default:
+    duration: 14d
+    pass_threshold: 55
+    allowed_voters:
+      teams:
+        - ibc-tsc


### PR DESCRIPTION
## Summary
- add an audited default GitVote profile
- 55% pass threshold and 14-day voting window
- restrict binding votes to the future `@cosmos/ibc-tsc` team

## Activation remaining
- land `.gitvote.yml` on the default `main` branch during the default-branch rollout
- create and populate `@cosmos/ibc-tsc`
- install the GitVote app on `cosmos/ibc`

GitVote reads configuration from the default branch, so the profile is inert until these repository-level steps are completed.

Linear: FOU-1169  
Stack: 3/4; depends on #1319
