### PR TITLE
test(e2e): cover attested client misbehaviour freeze

### DIFF
--- a/e2e/attestation_helpers_test.go
+++ b/e2e/attestation_helpers_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/environment"
+	attestorevm "github.com/cosmos/ibc/link/attestor/evm"
 )
 
 type attestationClientState struct {
@@ -47,4 +49,49 @@ func attestedClientState(
 	values, err := (abi.Arguments{{Type: tuple}}).Unpack(encoded)
 	require.NoError(t, err)
 	return *abi.ConvertType(values[0], new(attestationClientState)).(*attestationClientState)
+}
+
+func attestedConsensusTimestamp(
+	t testing.TB,
+	evm *environment.EVM,
+	address environment.EVMAddress,
+	height uint64,
+) uint64 {
+	t.Helper()
+	var timestamp uint64
+	err := evm.UseContractCaller(func(caller bind.ContractCaller) error {
+		client, err := attestation.NewContractCaller(common.HexToAddress(string(address)), caller)
+		if err != nil {
+			return err
+		}
+		timestamp, err = client.GetConsensusTimestamp(&bind.CallOpts{Context: t.Context()}, height)
+		return err
+	})
+	require.NoError(t, err)
+	return timestamp
+}
+
+func signedStateAttestationProof(
+	t testing.TB,
+	privateKeyHex string,
+	height, timestamp uint64,
+) []byte {
+	t.Helper()
+	attestationData, err := attestorevm.EncodeStateAttestation(height, timestamp)
+	require.NoError(t, err)
+
+	digest := attestorevm.Digest(attestorevm.TagStateAttestation, attestationData)
+	privateKey, err := crypto.HexToECDSA(privateKeyHex)
+	require.NoError(t, err)
+	signature, err := crypto.Sign(digest[:], privateKey)
+	require.NoError(t, err)
+	signature, err = attestorevm.NormalizeSignature(signature)
+	require.NoError(t, err)
+
+	proof, err := attestorevm.EncodeAttestationProof(attestorevm.AttestationProof{
+		AttestationData: attestationData,
+		Signatures:      [][]byte{signature},
+	})
+	require.NoError(t, err)
+	return proof
 }

--- a/e2e/attestation_helpers_test.go
+++ b/e2e/attestation_helpers_test.go
@@ -85,8 +85,7 @@ func signedStateAttestationProof(
 	require.NoError(t, err)
 	signature, err := crypto.Sign(digest[:], privateKey)
 	require.NoError(t, err)
-	signature, err = attestorevm.NormalizeSignature(signature)
-	require.NoError(t, err)
+	signature[64] += 27
 
 	proof, err := attestorevm.EncodeAttestationProof(attestorevm.AttestationProof{
 		AttestationData: attestationData,

--- a/e2e/attestation_helpers_test.go
+++ b/e2e/attestation_helpers_test.go
@@ -87,10 +87,7 @@ func signedStateAttestationProof(
 	require.NoError(t, err)
 	signature[64] += 27
 
-	proof, err := attestorevm.EncodeAttestationProof(attestorevm.AttestationProof{
-		AttestationData: attestationData,
-		Signatures:      [][]byte{signature},
-	})
+	proof, err := attestorevm.EncodeAttestationProof(attestationData, [][]byte{signature})
 	require.NoError(t, err)
 	return proof
 }

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -166,7 +166,7 @@ func TestAttestedClient_MisbehaviourFreeze(t *testing.T) {
 	transfer, err := iftApp.Send(ctx, e2etest.IFTRequest{Amount: big.NewInt(1_234_000)})
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyBurned(ctx))
-	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.PacketTx(),
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED)
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyDelivered(ctx))
@@ -178,7 +178,7 @@ func TestAttestedClient_MisbehaviourFreeze(t *testing.T) {
 	proof := signedStateAttestationProof(t, destinationAttestorKey, height, trustedTimestamp+1)
 	routerABI, err := ics26router.ContractMetaData.GetAbi()
 	require.NoError(t, err)
-	updateClient, err := routerABI.Pack("updateClient", string(destinationClient.Locator()), proof)
+	updateClient, err := routerABI.Pack("updateClient", destinationClient.ID(), proof)
 	require.NoError(t, err)
 	router := common.HexToAddress(string(destinationClient.IBCInstance().Locator()))
 	require.NoError(t, sender.BroadcastTx(ctx, destinationEVM, router, updateClient))
@@ -191,10 +191,10 @@ func TestAttestedClient_MisbehaviourFreeze(t *testing.T) {
 	pending, err := iftApp.Send(ctx, e2etest.IFTRequest{Amount: big.NewInt(2_345_000)})
 	require.NoError(t, err)
 	require.NoError(t, pending.VerifyBurned(ctx))
-	require.NoError(t, e2etest.Relay(ctx, relayer, pending.Packet()))
-	require.NoError(t, e2etest.AwaitStable(ctx, relayer, pending.Packet(),
+	require.NoError(t, e2etest.Relay(ctx, relayer, pending.PacketTx()))
+	require.NoError(t, e2etest.AwaitStable(ctx, relayer, pending.PacketTx(),
 		relayerv2.PacketState_PACKET_STATE_PENDING))
-	status, err := e2etest.AwaitState(ctx, relayer, pending.Packet(),
+	status, err := e2etest.AwaitState(ctx, relayer, pending.PacketTx(),
 		relayerv2.PacketState_PACKET_STATE_PENDING)
 	require.NoError(t, err)
 	require.Empty(t, status.GetRecvTx().GetTxHash())

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/solidity-ibc-eureka/packages/go-abigen/ics26router"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -134,6 +135,71 @@ func TestIFTTransfer_MultiAttestorQuorum(t *testing.T) {
 		relayerv2.PacketState_PACKET_STATE_SUCCEEDED)
 	require.NoError(t, err)
 	require.NoError(t, pending.VerifyDelivered(ctx))
+}
+
+func TestAttestedClient_MisbehaviourFreeze(t *testing.T) {
+	t.Parallel()
+	spec, runtime := attestedMesh(e2etest.EVMChains(t,
+		e2etest.EVMRequirements{}, e2etest.ChainA, e2etest.ChainB))
+	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
+	destinationAttestorID := meshAttestorFor(route.Destination, route.Source)
+	destinationAttestorKey := runtime.Authorities[environment.AuthorityID(destinationAttestorID)].PrivateKeyHex
+
+	env := e2etest.Start(t, spec, runtime)
+	sender := e2etest.NewSigner(t)
+	relayerSigner := e2etest.NewSigner(t)
+	destinationAttestor, err := env.Attestor(destinationAttestorID)
+	require.NoError(t, err)
+	driver, deployment := e2etest.Deploy(t, env, sender, relayerSigner, route)
+	iftApp := e2etest.NewIFT(t, env, deployment, sender, route)
+	relayer := e2etest.StartRelayer(t, driver, env)
+	ctx := t.Context()
+
+	destination, err := env.Chain(route.Destination)
+	require.NoError(t, err)
+	destinationEVM, err := destination.EVM()
+	require.NoError(t, err)
+	destinationClient := destinationAttestor.IBCClient()
+	clientAddress := destinationClient.LightClientAddress()
+	initialState := attestedClientState(t, destinationEVM, clientAddress)
+
+	transfer, err := iftApp.Send(ctx, e2etest.IFTRequest{Amount: big.NewInt(1_234_000)})
+	require.NoError(t, err)
+	require.NoError(t, transfer.VerifyBurned(ctx))
+	_, err = e2etest.AwaitState(ctx, relayer, transfer.Packet(),
+		relayerv2.PacketState_PACKET_STATE_SUCCEEDED)
+	require.NoError(t, err)
+	require.NoError(t, transfer.VerifyDelivered(ctx))
+
+	installedState := attestedClientState(t, destinationEVM, clientAddress)
+	require.Greater(t, installedState.LatestHeight, initialState.LatestHeight)
+	height := installedState.LatestHeight
+	trustedTimestamp := attestedConsensusTimestamp(t, destinationEVM, clientAddress, height)
+	proof := signedStateAttestationProof(t, destinationAttestorKey, height, trustedTimestamp+1)
+	routerABI, err := ics26router.ContractMetaData.GetAbi()
+	require.NoError(t, err)
+	updateClient, err := routerABI.Pack("updateClient", string(destinationClient.Locator()), proof)
+	require.NoError(t, err)
+	router := common.HexToAddress(string(destinationClient.IBCInstance().Locator()))
+	require.NoError(t, sender.BroadcastTx(ctx, destinationEVM, router, updateClient))
+
+	frozenState := attestedClientState(t, destinationEVM, clientAddress)
+	require.True(t, frozenState.IsFrozen)
+	require.Equal(t, height, frozenState.LatestHeight)
+	require.Equal(t, trustedTimestamp, attestedConsensusTimestamp(t, destinationEVM, clientAddress, height))
+
+	pending, err := iftApp.Send(ctx, e2etest.IFTRequest{Amount: big.NewInt(2_345_000)})
+	require.NoError(t, err)
+	require.NoError(t, pending.VerifyBurned(ctx))
+	require.NoError(t, e2etest.Relay(ctx, relayer, pending.Packet()))
+	require.NoError(t, e2etest.AwaitStable(ctx, relayer, pending.Packet(),
+		relayerv2.PacketState_PACKET_STATE_PENDING))
+	status, err := e2etest.AwaitState(ctx, relayer, pending.Packet(),
+		relayerv2.PacketState_PACKET_STATE_PENDING)
+	require.NoError(t, err)
+	require.Empty(t, status.GetRecvTx().GetTxHash())
+	require.NoError(t, pending.VerifyPending(ctx))
+	require.NoError(t, pending.VerifyNotMinted(ctx))
 }
 
 // TestIFTTimeout_RefundUsesFinalizedDestinationAnchor proves timeouts anchor

--- a/e2e/internal/e2etest/traffic_signers.go
+++ b/e2e/internal/e2etest/traffic_signers.go
@@ -3,6 +3,7 @@
 package e2etest
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
+	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 	"github.com/cosmos/ibc/link/keyfile"
 )
 
@@ -38,6 +40,17 @@ func NewSigner(t testing.TB) Signer {
 // Address returns the signer's public identity.
 func (s Signer) Address() common.Address {
 	return s.account.Address()
+}
+
+// BroadcastTx signs, submits, and waits for a zero-value transaction from the signer.
+func (s Signer) BroadcastTx(
+	ctx context.Context,
+	evm *environment.EVM,
+	to common.Address,
+	data []byte,
+) error {
+	_, err := evm.BroadcastTx(ctx, s.account, &to, data, nil)
+	return err
 }
 
 // String renders only the public signer address.

--- a/e2e/test-matrix.md
+++ b/e2e/test-matrix.md
@@ -7,6 +7,7 @@
 | Test | Requirements | Fast | Complete | Production |
 | --- | --- | --- | --- | --- |
 | `TestAttachedChainRemainsCallerOwned` | EVM portable | environment: 1× Anvil; 1× Attached EVM; 2 IBC instances; 1 connection; 2 attestors | environment: 1× Anvil; 1× Attached EVM; 2 IBC instances; 1 connection; 2 attestors | environment: 1× Attached EVM; 1× Besu; 2 IBC instances; 1 connection; 2 attestors |
+| `TestAttestedClient_MisbehaviourFreeze` | EVM portable | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Besu; 2 IBC instances; 1 connection; 2 attestors |
 | `TestAttestedMesh` | None | No environment | No environment | No environment |
 | `TestAttestedMeshConnectsEveryChainPair` | None | No environment | No environment | No environment |
 | `TestCrossRoutePacketsDoNotCollideBySequence` | EVM portable | 3× Anvil; 3 IBC instances; 3 connections; 6 attestors | 3× Anvil; 3 IBC instances; 3 connections; 6 attestors | 3× Besu; 3 IBC instances; 3 connections; 6 attestors |


### PR DESCRIPTION
## Summary

- add a portable E2E scenario for a conflicting same-height attested client update
- submit a signed different-timestamp update through `ICS26Router`
- verify the destination client freezes without changing its trusted height or timestamp
- verify a subsequent IFT remains stably pending, has no receive transaction, and mints nothing
- add the bounded signer transaction helper and update the generated E2E matrix

## Why

FOU-1079 requires end-to-end coverage proving that attestor equivocation freezes the destination client and prevents subsequent packet delivery without corrupting trusted state.

Depends on #1332 for the production attestation types and codecs used to construct the conflicting proof.

## Validation

- `make test-harness`
- `make test-e2e`
- focused `TestAttestedClient_MisbehaviourFreeze` runs on Anvil and Besu
- `go test ./... -run "^$"` in `e2e`

Closes FOU-1079