### PR TITLE
test(e2e): cover GMP packet timeout

### DIFF
--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -56,7 +56,7 @@ func TestGMPCall_Timeout(t *testing.T) {
 	require.NoError(t, mining.AdvanceTime(ctx, packetTimeoutAdvance))
 	relayer = e2etest.StartRelayer(t, driver, env)
 
-	status, err := e2etest.AwaitState(ctx, relayer, call.Packet(),
+	status, err := e2etest.AwaitState(ctx, relayer, call.PacketTx(),
 		relayerv2.PacketState_PACKET_STATE_TIMED_OUT)
 	require.NoError(t, err)
 	require.NoError(t, call.VerifyTimeoutExecuted(ctx, status.GetTimeoutTx().GetTxHash()))

--- a/e2e/gmp_test.go
+++ b/e2e/gmp_test.go
@@ -32,6 +32,37 @@ func TestGMPCall_AutoRelay(t *testing.T) {
 	require.NoError(t, call.VerifyCounterExecuted(ctx))
 }
 
+func TestGMPCall_Timeout(t *testing.T) {
+	t.Parallel()
+	spec, runtime := attestedMesh(e2etest.EVMChains(t,
+		e2etest.EVMRequirements{ControlledMining: true}, e2etest.ChainA, e2etest.ChainB))
+	env := e2etest.Start(t, spec, runtime)
+	sender := e2etest.NewSigner(t)
+	relayerSigner := e2etest.NewSigner(t)
+	route := e2etest.AtoB(e2etest.ChainA, e2etest.ChainB)
+	driver, deployment := e2etest.Deploy(t, env, sender, relayerSigner, route)
+	gmp := e2etest.NewGMP(t, env, deployment, sender, route)
+	relayer := e2etest.StartRelayer(t, driver, env)
+	ctx := t.Context()
+
+	require.NoError(t, relayer.Stop(ctx))
+	call, err := gmp.Call(ctx, e2etest.GMPRequest{Timeout: packetTimeout})
+	require.NoError(t, err)
+
+	destination, err := env.Chain(route.Destination)
+	require.NoError(t, err)
+	mining, err := destination.Mining()
+	require.NoError(t, err)
+	require.NoError(t, mining.AdvanceTime(ctx, packetTimeoutAdvance))
+	relayer = e2etest.StartRelayer(t, driver, env)
+
+	status, err := e2etest.AwaitState(ctx, relayer, call.Packet(),
+		relayerv2.PacketState_PACKET_STATE_TIMED_OUT)
+	require.NoError(t, err)
+	require.NoError(t, call.VerifyTimeoutExecuted(ctx, status.GetTimeoutTx().GetTxHash()))
+	require.NoError(t, call.VerifyCounterUnchanged(ctx))
+}
+
 // TestGMPCall_ICS27AccountTransfer sends a GMP call whose payload is an
 // erc20.transfer executed by the destination ICS27 account.
 func TestGMPCall_ICS27AccountTransfer(t *testing.T) {
@@ -95,5 +126,5 @@ func TestGMPCall_ErrorAcknowledgement(t *testing.T) {
 	_, err = e2etest.AwaitState(ctx, relayer, call.PacketTx(),
 		relayerv2.PacketState_PACKET_STATE_REJECTED)
 	require.NoError(t, err)
-	require.NoError(t, call.VerifyCounterRejected(ctx))
+	require.NoError(t, call.VerifyCounterUnchanged(ctx))
 }

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -172,12 +172,12 @@ func TestIFTTimeout_RefundUsesFinalizedDestinationAnchor(t *testing.T) {
 	require.NoError(t, relayer.Stop(ctx))
 	asymmetricTransfer, err := iftApp.Send(ctx, e2etest.IFTRequest{
 		Amount:  big.NewInt(4_000_000),
-		Timeout: transferTimeout,
+		Timeout: packetTimeout,
 	})
 	require.NoError(t, err)
 	require.NoError(t, asymmetricTransfer.VerifyBurned(ctx))
 	require.NoError(t, asymmetricTransfer.VerifyPending(ctx))
-	require.NoError(t, destinationMining.AdvanceTime(ctx, transferTimeoutAdvance))
+	require.NoError(t, destinationMining.AdvanceTime(ctx, packetTimeoutAdvance))
 	require.NoError(t, destinationMining.Mine(ctx, 1))
 	destinationHeight, err := destination.Height(ctx)
 	require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestIFTTimeout_Refund(t *testing.T) {
 
 	transfer, err := iftApp.Send(ctx, e2etest.IFTRequest{
 		Amount:  big.NewInt(3_000_000),
-		Timeout: transferTimeout,
+		Timeout: packetTimeout,
 	})
 	require.NoError(t, err)
 	require.NoError(t, transfer.VerifyBurned(ctx))
@@ -361,7 +361,7 @@ func TestIFTTimeout_WaitsForFinality(t *testing.T) {
 	require.NoError(t, mining.WithPaused(ctx, func() error {
 		transfer, err = iftApp.Send(ctx, e2etest.IFTRequest{
 			Amount:  big.NewInt(3_000_000),
-			Timeout: transferTimeout,
+			Timeout: packetTimeout,
 		})
 		require.NoError(t, err)
 		require.NoError(t, transfer.VerifyBurned(ctx))
@@ -680,7 +680,7 @@ func TestIFTTransfer_BatchedTimeout(t *testing.T) {
 	for i := range sends {
 		transfer, err := iftApp.Send(ctx, e2etest.IFTRequest{
 			Amount:  big.NewInt(int64(1_000_000 + i)),
-			Timeout: transferTimeout,
+			Timeout: packetTimeout,
 		})
 		require.NoError(t, err)
 		require.NoError(t, transfer.VerifyBurned(ctx))
@@ -691,7 +691,7 @@ func TestIFTTransfer_BatchedTimeout(t *testing.T) {
 	require.NoError(t, err)
 	mining, err := destination.Mining()
 	require.NoError(t, err)
-	require.NoError(t, mining.AdvanceTime(ctx, transferTimeoutAdvance))
+	require.NoError(t, mining.AdvanceTime(ctx, packetTimeoutAdvance))
 
 	relayErrs := make([]error, packetCount)
 	var wg sync.WaitGroup

--- a/e2e/internal/e2etest/traffic_gmp.go
+++ b/e2e/internal/e2etest/traffic_gmp.go
@@ -128,7 +128,7 @@ func (c *GMPCall) VerifyCounterUnchanged(ctx context.Context) error {
 // VerifyTimeoutExecuted checks that txHash succeeded with a TimeoutPacket for this packet.
 func (c *GMPCall) VerifyTimeoutExecuted(ctx context.Context, txHash string) error {
 	return verifyPacketTimeout(
-		ctx, c.app.source, c.app.sourceRouter, c.app.sourceClient, c.packet, txHash,
+		ctx, c.app.source, c.app.sourceRouter, c.app.sourceClientID, c.packetTx, txHash,
 	)
 }
 

--- a/e2e/internal/e2etest/traffic_gmp.go
+++ b/e2e/internal/e2etest/traffic_gmp.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/cosmos/solidity-ibc-eureka/packages/go-abigen/ics27gmp"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -24,6 +25,9 @@ type GMPRequest struct {
 	Receiver string
 	// Salt defaults to empty, matching sendCall's default account identifier.
 	Salt []byte
+	// Timeout is the destination-relative packet lifetime. Non-positive selects
+	// a far-future-but-valid default; positive values are rounded up to whole seconds.
+	Timeout time.Duration
 }
 
 // GMP drives ICS27 GMP and its default Counter and TestERC20 targets on a
@@ -68,7 +72,7 @@ func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
 	if err != nil {
 		return nil, err
 	}
-	timeoutTimestamp, err := destinationTimeout(ctx, g.destination, 0)
+	timeoutTimestamp, err := destinationTimeout(ctx, g.destination, request.Timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -115,11 +119,17 @@ func (c *GMPCall) VerifyCounterExecuted(ctx context.Context) error {
 	)
 }
 
-// VerifyCounterRejected checks that the destination Counter did not change
-// after an error acknowledgement. Only meaningful when the call's receiver
-// was the bound Counter.
-func (c *GMPCall) VerifyCounterRejected(ctx context.Context) error {
+// VerifyCounterUnchanged checks that the destination Counter did not change.
+// Only meaningful when the call's receiver was the bound Counter.
+func (c *GMPCall) VerifyCounterUnchanged(ctx context.Context) error {
 	return c.verifyCount(ctx, c.before, "unchanged")
+}
+
+// VerifyTimeoutExecuted checks that txHash succeeded with a TimeoutPacket for this packet.
+func (c *GMPCall) VerifyTimeoutExecuted(ctx context.Context, txHash string) error {
+	return verifyPacketTimeout(
+		ctx, c.app.source, c.app.sourceRouter, c.app.sourceClient, c.packet, txHash,
+	)
 }
 
 func (g *GMP) count(ctx context.Context) (*big.Int, error) {

--- a/e2e/test-matrix.md
+++ b/e2e/test-matrix.md
@@ -14,6 +14,7 @@
 | `TestGMPCall_AutoRelay` | EVM portable | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Besu; 2 IBC instances; 1 connection; 2 attestors |
 | `TestGMPCall_ErrorAcknowledgement` | EVM portable | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Besu; 2 IBC instances; 1 connection; 2 attestors |
 | `TestGMPCall_ICS27AccountTransfer` | EVM portable | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Besu; 2 IBC instances; 1 connection; 2 attestors |
+| `TestGMPCall_Timeout` | EVM (controlled mining) | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors |
 | `TestIFTTimeout_Refund` | EVM portable | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Besu; 2 IBC instances; 1 connection; 2 attestors |
 | `TestIFTTimeout_RefundUsesFinalizedDestinationAnchor` | EVM (controlled mining) | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors |
 | `TestIFTTimeout_WaitsForFinality` | EVM (controlled mining) | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors | 2× Anvil; 2 IBC instances; 1 connection; 2 attestors |

--- a/e2e/transfer_test.go
+++ b/e2e/transfer_test.go
@@ -62,13 +62,13 @@ func TestTransfer_ManualRelay(t *testing.T) {
 }
 
 const (
-	// transferTimeout must elapse in real time before the relayer times a
+	// packetTimeout must elapse in real time before the relayer times a
 	// packet out (the pipeline gates on the relayer's own clock), so it has
 	// to fit well inside the await budget.
-	transferTimeout = 5 * time.Second
-	// Advance well past transferTimeout so the packet is decisively expired
+	packetTimeout = 5 * time.Second
+	// Advance well past packetTimeout so the packet is decisively expired
 	// when the relayer starts.
-	transferTimeoutAdvance = 5 * transferTimeout
+	packetTimeoutAdvance = 5 * packetTimeout
 )
 
 func TestTransferTimeout_Refund(t *testing.T) {
@@ -87,7 +87,7 @@ func TestTransferTimeout_Refund(t *testing.T) {
 	require.NoError(t, relayer.Stop(ctx))
 	transfer, err := transferApp.Send(ctx, e2etest.TransferRequest{
 		Amount:  big.NewInt(3_000_000),
-		Timeout: transferTimeout,
+		Timeout: packetTimeout,
 	})
 	require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestTransferTimeout_Refund(t *testing.T) {
 	require.NoError(t, err)
 	mining, err := chainB.Mining()
 	require.NoError(t, err)
-	require.NoError(t, mining.AdvanceTime(ctx, transferTimeoutAdvance))
+	require.NoError(t, mining.AdvanceTime(ctx, packetTimeoutAdvance))
 	relayer = e2etest.StartRelayer(t, driver, env)
 
 	status, err := e2etest.AwaitState(ctx, relayer, transfer.PacketTx(),


### PR DESCRIPTION
## Summary
- Adds GMP timeout coverage that sends a short-lived call, advances destination time, waits for the relayer-reported timeout, verifies the matching `TimeoutPacket` event, and confirms the destination Counter remains unchanged.
- Adds configurable GMP packet timeouts and reuses the shared receipt-based timeout verifier introduced earlier in the stack.
- Renames the shared timeout constants and unchanged-counter assertion so they apply across Transfer, IFT, and GMP tests.

## Testing
- `make check`
- `make test-e2e E2E_MODE=complete`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

Closes FOU-1103
