### PR TITLE
test(e2e): parse receipt events with bindings

### DIFF
--- a/e2e/internal/e2etest/traffic_evm.go
+++ b/e2e/internal/e2etest/traffic_evm.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/big"
 
-	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -32,6 +31,29 @@ func mustBinding[T any](binding T, err error) T {
 		panic(fmt.Sprintf("e2etest: construct generated contract binding: %v", err))
 	}
 	return binding
+}
+
+func receiptEvents[T any](
+	receipt *types.Receipt,
+	contract common.Address,
+	parse func(types.Log) (*T, error),
+) ([]*T, error) {
+	var events []*T
+	for _, log := range receipt.Logs {
+		if log.Address != contract {
+			continue
+		}
+		event, err := parse(*log)
+		switch {
+		case errors.Is(err, bind.ErrNoEventSignature), errors.Is(err, bind.ErrEventSignatureMismatch):
+			continue
+		case err != nil:
+			return nil, err
+		default:
+			events = append(events, event)
+		}
+	}
+	return events, nil
 }
 
 // NewAddress generates a fresh, unfunded EVM address for use as a test
@@ -114,50 +136,6 @@ func send(
 		)
 	}
 	return receipt, sequence, nil
-}
-
-type eventSource struct {
-	endpoint endpoint
-	contract common.Address
-}
-
-func awaitEvent[T any](
-	ctx context.Context,
-	source eventSource,
-	topic common.Hash,
-	description string,
-	decode func(types.Log) (T, error),
-	match func(T) bool,
-) (T, error) {
-	query := ethereum.FilterQuery{
-		FromBlock: big.NewInt(0),
-		Addresses: []common.Address{source.contract},
-		Topics:    [][]common.Hash{{topic}},
-	}
-	timing := source.endpoint.chain.Timing()
-	return await(
-		ctx,
-		timing.CompletionBudget,
-		timing.PollInterval,
-		description,
-		func(ctx context.Context) (T, bool, error) {
-			var zero T
-			logs, err := source.endpoint.evm.Logs(ctx, query)
-			if err != nil {
-				return zero, false, err
-			}
-			for _, log := range logs {
-				event, err := decode(log)
-				if err != nil {
-					return zero, true, err
-				}
-				if match(event) {
-					return event, true, nil
-				}
-			}
-			return zero, false, nil
-		},
-	)
 }
 
 func awaitBalance(

--- a/e2e/internal/e2etest/traffic_evm_test.go
+++ b/e2e/internal/e2etest/traffic_evm_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package e2etest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReceiptEvents(t *testing.T) {
+	contract := common.HexToAddress("0x1")
+	wanted := common.HexToHash("0x1")
+	decodeErr := errors.New("decode event")
+	parse := func(log types.Log) (*byte, error) {
+		if len(log.Topics) == 0 {
+			return nil, bind.ErrNoEventSignature
+		}
+		if log.Topics[0] != wanted {
+			return nil, bind.ErrEventSignatureMismatch
+		}
+		if len(log.Data) == 0 {
+			return nil, decodeErr
+		}
+		return &log.Data[0], nil
+	}
+
+	events, err := receiptEvents(&types.Receipt{Logs: []*types.Log{
+		{Address: common.HexToAddress("0x2"), Topics: []common.Hash{wanted}},
+		{Address: contract},
+		{Address: contract, Topics: []common.Hash{common.HexToHash("0x2")}},
+		{Address: contract, Topics: []common.Hash{wanted}, Data: []byte{7}},
+		{Address: contract, Topics: []common.Hash{wanted}, Data: []byte{8}},
+	}}, contract, parse)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	require.Equal(t, byte(7), *events[0])
+	require.Equal(t, byte(8), *events[1])
+
+	_, err = receiptEvents(&types.Receipt{Logs: []*types.Log{
+		{Address: contract, Topics: []common.Hash{wanted}},
+	}}, contract, parse)
+	require.ErrorIs(t, err, decodeErr)
+}

--- a/e2e/internal/e2etest/traffic_transfer.go
+++ b/e2e/internal/e2etest/traffic_transfer.go
@@ -356,7 +356,7 @@ func verifyPacketTimeout(
 	packetTx PacketTx,
 	txHash string,
 ) error {
-	receipt, err := source.evm.TransactionReceipt(ctx, common.HexToHash(txHash))
+	receipt, err := source.evm.AwaitTransactionReceipt(ctx, common.HexToHash(txHash))
 	if err != nil {
 		return fmt.Errorf("e2etest: fetch packet %s timeout transaction %s: %w", packetTx.reference(), txHash, err)
 	}

--- a/e2e/internal/e2etest/traffic_transfer.go
+++ b/e2e/internal/e2etest/traffic_transfer.go
@@ -25,13 +25,10 @@ import (
 const (
 	ics20DestPort         = "transfer"
 	defaultTimeoutHorizon = 12 * time.Hour
-	eventSendPacket       = "SendPacket"
-	eventTimeoutPacket    = "TimeoutPacket"
 )
 
 var (
 	ics20ABI = mustABI(ics20transfer.ContractMetaData)
-	ics26ABI = mustABI(ics26router.ContractMetaData)
 	tokenABI = mustABI(testerc20.TestERC20MetaData)
 )
 
@@ -235,8 +232,10 @@ func (t *TransferSend) VerifyNotMinted(ctx context.Context) error {
 }
 
 // VerifyRefunded waits for the source sender balance to be restored after timeout.
-func (t *TransferSend) VerifyRefunded(ctx context.Context) error {
-	if err := awaitPacketTimeout(ctx, t.app.source, t.app.sourceRouter, t.app.sourceClientID, t.packetTx); err != nil {
+func (t *TransferSend) VerifyRefunded(ctx context.Context, txHash string) error {
+	if err := verifyPacketTimeout(
+		ctx, t.app.source, t.app.sourceRouter, t.app.sourceClientID, t.packetTx, txHash,
+	); err != nil {
 		return err
 	}
 	return awaitBalance(
@@ -348,53 +347,53 @@ func isICS20DenomNotFound(err error) bool {
 	return lookupErr == nil && contractErr.Name == "ICS20DenomNotFound"
 }
 
-// awaitPacketTimeout waits for the source router to emit TimeoutPacket for the
-// given packet.
-func awaitPacketTimeout(
+// verifyPacketTimeout checks that txHash succeeded with one TimeoutPacket for the packet.
+func verifyPacketTimeout(
 	ctx context.Context,
 	source endpoint,
 	router common.Address,
 	sourceClientID string,
 	packetTx PacketTx,
+	txHash string,
 ) error {
-	definition := ics26ABI.Events[eventTimeoutPacket]
+	receipt, err := source.evm.TransactionReceipt(ctx, common.HexToHash(txHash))
+	if err != nil {
+		return fmt.Errorf("e2etest: fetch packet %s timeout transaction %s: %w", packetTx.reference(), txHash, err)
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("e2etest: packet %s timeout transaction %s failed", packetTx.reference(), txHash)
+	}
+
 	parser := mustBinding(ics26router.NewContractFilterer(router, nil))
-	description := fmt.Sprintf("timeout for packet %s", packetTx.reference())
-	_, err := awaitEvent(
-		ctx,
-		eventSource{endpoint: source, contract: router},
-		definition.ID,
-		description,
-		func(log types.Log) (*ics26router.ContractTimeoutPacket, error) {
-			event, err := parser.ParseTimeoutPacket(log)
-			if err != nil {
-				return nil, fmt.Errorf("e2etest: decode TimeoutPacket: %w", err)
-			}
-			return event, nil
-		},
-		func(event *ics26router.ContractTimeoutPacket) bool {
-			return event.Packet.Sequence == packetTx.Sequence &&
-				event.Packet.SourceClient == sourceClientID
-		},
-	)
-	return err
+	events, err := receiptEvents(receipt, router, parser.ParseTimeoutPacket)
+	if err != nil {
+		return fmt.Errorf("e2etest: decode TimeoutPacket: %w", err)
+	}
+	matches := 0
+	for _, event := range events {
+		if event.Packet.SourceClient == sourceClientID && event.Packet.Sequence == packetTx.Sequence {
+			matches++
+		}
+	}
+	if matches != 1 {
+		return fmt.Errorf(
+			"e2etest: packet %s timeout transaction %s emitted %d matching TimeoutPacket events, want 1",
+			packetTx.reference(), txHash, matches,
+		)
+	}
+	return nil
 }
 
 func sendPacketSequence(router common.Address) func(*types.Receipt) (uint64, bool, error) {
-	parser := mustBinding(ics26router.NewContractFilterer(router, nil))
 	return func(receipt *types.Receipt) (uint64, bool, error) {
-		definition := ics26ABI.Events[eventSendPacket]
-		for _, log := range receipt.Logs {
-			if log.Address != router || len(log.Topics) == 0 || log.Topics[0] != definition.ID {
-				continue
-			}
-			event, err := parser.ParseSendPacket(*log)
-			if err != nil {
-				return 0, false, fmt.Errorf("e2etest: decode SendPacket: %w", err)
-			}
-			return event.Packet.Sequence, true, nil
+		sequences, err := sendPacketSequences(router, receipt)
+		if err != nil {
+			return 0, false, err
 		}
-		return 0, false, nil
+		if len(sequences) == 0 {
+			return 0, false, nil
+		}
+		return sequences[0], true, nil
 	}
 }
 
@@ -402,17 +401,13 @@ func sendPacketSequence(router common.Address) func(*types.Receipt) (uint64, boo
 // in one receipt, in log order
 func sendPacketSequences(router common.Address, receipt *types.Receipt) ([]uint64, error) {
 	parser := mustBinding(ics26router.NewContractFilterer(router, nil))
-	definition := ics26ABI.Events[eventSendPacket]
-	var sequences []uint64
-	for _, log := range receipt.Logs {
-		if log.Address != router || len(log.Topics) == 0 || log.Topics[0] != definition.ID {
-			continue
-		}
-		event, err := parser.ParseSendPacket(*log)
-		if err != nil {
-			return nil, fmt.Errorf("e2etest: decode SendPacket: %w", err)
-		}
-		sequences = append(sequences, event.Packet.Sequence)
+	events, err := receiptEvents(receipt, router, parser.ParseSendPacket)
+	if err != nil {
+		return nil, fmt.Errorf("e2etest: decode SendPacket: %w", err)
+	}
+	sequences := make([]uint64, len(events))
+	for i, event := range events {
+		sequences[i] = event.Packet.Sequence
 	}
 	return sequences, nil
 }

--- a/e2e/internal/harness/chain/evm/client.go
+++ b/e2e/internal/harness/chain/evm/client.go
@@ -281,6 +281,20 @@ func (e *EVMClient) WaitNextPendingTx(ctx context.Context, wait TransactionWait)
 	return nil
 }
 
+// WaitForReceipt polls until hash is mined or the configured wait expires.
+func (e *EVMClient) WaitForReceipt(
+	ctx context.Context,
+	hash common.Hash,
+	wait TransactionWait,
+) (*types.Receipt, error) {
+	waitCtx, cancel, err := wait.context(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return e.waitForReceipt(waitCtx, hash, wait)
+}
+
 func (e *EVMClient) waitForReceipt(
 	ctx context.Context,
 	hash common.Hash,

--- a/e2e/internal/harness/environment/chain.go
+++ b/e2e/internal/harness/environment/chain.go
@@ -130,6 +130,17 @@ func (e *EVM) TransactionReceipt(ctx context.Context, hash common.Hash) (*types.
 	return receipt, err
 }
 
+// AwaitTransactionReceipt polls until hash is mined using the Chain's timing policy.
+func (e *EVM) AwaitTransactionReceipt(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+	var receipt *types.Receipt
+	err := e.use(func(client *chainevm.EVMClient) error {
+		var err error
+		receipt, err = client.WaitForReceipt(ctx, hash, e.transactionWait())
+		return err
+	})
+	return receipt, err
+}
+
 func (e *EVM) transactionWait() chainevm.TransactionWait {
 	return chainevm.TransactionWait{
 		Timeout:      e.chain.timing.CompletionBudget,

--- a/e2e/transfer_test.go
+++ b/e2e/transfer_test.go
@@ -98,9 +98,9 @@ func TestTransferTimeout_Refund(t *testing.T) {
 	require.NoError(t, mining.AdvanceTime(ctx, transferTimeoutAdvance))
 	relayer = e2etest.StartRelayer(t, driver, env)
 
-	_, err = e2etest.AwaitState(ctx, relayer, transfer.PacketTx(),
+	status, err := e2etest.AwaitState(ctx, relayer, transfer.PacketTx(),
 		relayerv2.PacketState_PACKET_STATE_TIMED_OUT)
 	require.NoError(t, err)
-	require.NoError(t, transfer.VerifyRefunded(ctx))
+	require.NoError(t, transfer.VerifyRefunded(ctx, status.GetTimeoutTx().GetTxHash()))
 	require.NoError(t, transfer.VerifyNotMinted(ctx))
 }


### PR DESCRIPTION
## Summary
- Adds a generic `receiptEvents` helper that decodes receipt logs with generated abigen parsers, ignores unrelated contracts and event signatures, and propagates genuine decode errors.
- Replaces chain-wide timeout log polling by waiting for the relayer-reported timeout transaction receipt and requiring exactly one matching `TimeoutPacket` event.
- Reuses the same helper for `SendPacket` sequence extraction, removing manual event-name constants and ABI topic lookups.

## Testing
- `make check`
- `make test-e2e E2E_MODE=complete`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

