### PR TITLE
test(e2e): verify batched relay receipt events

### DIFF
--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -690,39 +690,36 @@ func TestIFTTransfer_BatchedRecvAck(t *testing.T) {
 		require.Equal(t, send.PacketTx().Sequence, statuses[0].SequenceNumber)
 	}
 
-	recvTxCounts := make(map[string]int, packetCount)
-	ackTxCounts := make(map[string]int, packetCount)
+	recvTxSequences := make(map[string][]uint64, packetCount)
+	ackTxSequences := make(map[string][]uint64, packetCount)
 	for _, send := range sends {
-		_, err := e2etest.AwaitState(ctx, relayer, send.PacketTx(),
+		status, err := e2etest.AwaitState(ctx, relayer, send.PacketTx(),
 			relayerv2.PacketState_PACKET_STATE_SUCCEEDED)
 		require.NoError(t, err)
 		require.NoError(t, send.VerifyDelivered(ctx))
 
-		statuses, err := relayer.PacketStatuses(ctx, string(route.Source), send.TxHash())
-		require.NoError(t, err)
-		require.Len(t, statuses, 1)
-		recvTxCounts[statuses[0].GetRecvTx().GetTxHash()]++
-		ackTxCounts[statuses[0].GetAckTx().GetTxHash()]++
+		sequence := send.PacketTx().Sequence
+		recvHash := status.GetRecvTx().GetTxHash()
+		ackHash := status.GetAckTx().GetTxHash()
+		recvTxSequences[recvHash] = append(recvTxSequences[recvHash], sequence)
+		ackTxSequences[ackHash] = append(ackTxSequences[ackHash], sequence)
 	}
 	require.NoError(t, sends[packetCount-1].VerifyBurned(ctx), "successful acks must not refund")
 
-	require.Lessf(t, len(recvTxCounts), packetCount,
-		"expected batched recv, got one recv tx per packet: %v", recvTxCounts)
-	require.Lessf(t, len(ackTxCounts), packetCount,
-		"expected batched ack, got one ack tx per packet: %v", ackTxCounts)
-	require.Truef(t, hasBatchedTx(recvTxCounts), "no recv tx carried multiple packets: %v", recvTxCounts)
-	require.Truef(t, hasBatchedTx(ackTxCounts), "no ack tx carried multiple packets: %v", ackTxCounts)
-}
-
-// hasBatchedTx reports whether any transaction hash in counts covers more
-// than one packet.
-func hasBatchedTx(counts map[string]int) bool {
-	for _, count := range counts {
-		if count >= 2 {
-			return true
-		}
+	for txHash, want := range recvTxSequences {
+		got, err := iftApp.WriteAcknowledgementSequences(ctx, txHash)
+		require.NoError(t, err)
+		require.ElementsMatchf(t, want, got, "receive transaction %s packet sequences", txHash)
 	}
-	return false
+	for txHash, want := range ackTxSequences {
+		got, err := iftApp.AckPacketSequences(ctx, txHash)
+		require.NoError(t, err)
+		require.ElementsMatchf(t, want, got, "acknowledgement transaction %s packet sequences", txHash)
+	}
+	require.Lessf(t, len(recvTxSequences), packetCount,
+		"expected batched recv, got one recv tx per packet: %v", recvTxSequences)
+	require.Lessf(t, len(ackTxSequences), packetCount,
+		"expected batched ack, got one ack tx per packet: %v", ackTxSequences)
 }
 
 // TestIFTTransfer_BatchedTimeout sends more IFT transfers
@@ -773,20 +770,22 @@ func TestIFTTransfer_BatchedTimeout(t *testing.T) {
 		require.NoErrorf(t, err, "relay call for packet %d (seq %d) failed", i, sends[i].PacketTx().Sequence)
 	}
 
-	timeoutTxCounts := make(map[string]int, packetCount)
+	timeoutTxSequences := make(map[string][]uint64, packetCount)
 	for _, send := range sends {
-		_, err = e2etest.AwaitState(ctx, relayer, send.PacketTx(),
+		status, err := e2etest.AwaitState(ctx, relayer, send.PacketTx(),
 			relayerv2.PacketState_PACKET_STATE_TIMED_OUT)
 		require.NoError(t, err)
 		require.NoError(t, send.VerifyNotMinted(ctx))
 
-		statuses, err := relayer.PacketStatuses(ctx, string(route.Source), send.TxHash())
-		require.NoError(t, err)
-		require.Len(t, statuses, 1)
-		timeoutTxCounts[statuses[0].GetTimeoutTx().GetTxHash()]++
+		txHash := status.GetTimeoutTx().GetTxHash()
+		timeoutTxSequences[txHash] = append(timeoutTxSequences[txHash], send.PacketTx().Sequence)
 	}
 
-	require.Lessf(t, len(timeoutTxCounts), packetCount,
-		"expected batched timeouts, got one timeout tx per packet: %v", timeoutTxCounts)
-	require.Truef(t, hasBatchedTx(timeoutTxCounts), "no timeout tx carried multiple packets: %v", timeoutTxCounts)
+	for txHash, want := range timeoutTxSequences {
+		got, err := iftApp.TimeoutPacketSequences(ctx, txHash)
+		require.NoError(t, err)
+		require.ElementsMatchf(t, want, got, "timeout transaction %s packet sequences", txHash)
+	}
+	require.Lessf(t, len(timeoutTxSequences), packetCount,
+		"expected batched timeouts, got one timeout tx per packet: %v", timeoutTxSequences)
 }

--- a/e2e/internal/e2etest/traffic_apps.go
+++ b/e2e/internal/e2etest/traffic_apps.go
@@ -59,6 +59,7 @@ func NewIFT(
 		sourceIFT:      sourceApps.IFT,
 		destIFT:        destinationApps.IFT,
 		sourceRouter:   sourceApps.ICS26Router,
+		destRouter:     destinationApps.ICS26Router,
 		sourceClientID: clients.SourceClientID,
 		batcher:        sourceApps.IFTBatchShim,
 	}
@@ -109,6 +110,7 @@ func DeployIFTTokenPair(
 		sourceIFT:      sourceIFT,
 		destIFT:        destinationIFT,
 		sourceRouter:   sourceApps.ICS26Router,
+		destRouter:     destinationApps.ICS26Router,
 		sourceClientID: clients.SourceClientID,
 		batcher:        batcher,
 	}

--- a/e2e/internal/e2etest/traffic_evm.go
+++ b/e2e/internal/e2etest/traffic_evm.go
@@ -56,6 +56,32 @@ func receiptEvents[T any](
 	return events, nil
 }
 
+func transactionEventSequences[T any](
+	ctx context.Context,
+	target endpoint,
+	contract common.Address,
+	txHash string,
+	parse func(types.Log) (*T, error),
+	sequence func(*T) uint64,
+) ([]uint64, error) {
+	receipt, err := target.evm.TransactionReceipt(ctx, common.HexToHash(txHash))
+	if err != nil {
+		return nil, fmt.Errorf("fetch transaction %s: %w", txHash, err)
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return nil, fmt.Errorf("transaction %s failed", txHash)
+	}
+	events, err := receiptEvents(receipt, contract, parse)
+	if err != nil {
+		return nil, err
+	}
+	sequences := make([]uint64, len(events))
+	for i, event := range events {
+		sequences[i] = sequence(event)
+	}
+	return sequences, nil
+}
+
 // NewAddress generates a fresh, unfunded EVM address for use as a test
 // recipient (e.g. an ERC20 transfer target).
 func NewAddress() (common.Address, error) {

--- a/e2e/internal/e2etest/traffic_evm.go
+++ b/e2e/internal/e2etest/traffic_evm.go
@@ -64,7 +64,7 @@ func transactionEventSequences[T any](
 	parse func(types.Log) (*T, error),
 	sequence func(*T) uint64,
 ) ([]uint64, error) {
-	receipt, err := target.evm.TransactionReceipt(ctx, common.HexToHash(txHash))
+	receipt, err := target.evm.AwaitTransactionReceipt(ctx, common.HexToHash(txHash))
 	if err != nil {
 		return nil, fmt.Errorf("fetch transaction %s: %w", txHash, err)
 	}

--- a/e2e/internal/e2etest/traffic_ift.go
+++ b/e2e/internal/e2etest/traffic_ift.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/cosmos/solidity-ibc-eureka/packages/go-abigen/ics26router"
 	"github.com/cosmos/solidity-ibc-eureka/packages/go-abigen/ift"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -43,6 +44,7 @@ type IFT struct {
 	sourceIFT      common.Address
 	destIFT        common.Address
 	sourceRouter   common.Address
+	destRouter     common.Address
 	sourceClientID string
 	batcher        common.Address
 }
@@ -252,6 +254,57 @@ func (b *IFTBatch) VerifyBurned(ctx context.Context) error {
 }
 
 func (p *IFTSend) TimeoutTimestamp() uint64 { return p.timeoutTimestamp }
+
+// WriteAcknowledgementSequences returns the packet sequences written by a destination receive transaction.
+func (i *IFT) WriteAcknowledgementSequences(ctx context.Context, txHash string) ([]uint64, error) {
+	parser := mustBinding(ics26router.NewContractFilterer(i.destRouter, nil))
+	sequences, err := transactionEventSequences(
+		ctx,
+		i.destination,
+		i.destRouter,
+		txHash,
+		parser.ParseWriteAcknowledgement,
+		func(event *ics26router.ContractWriteAcknowledgement) uint64 { return event.Packet.Sequence },
+	)
+	if err != nil {
+		return nil, fmt.Errorf("e2etest: read IFT WriteAcknowledgement events: %w", err)
+	}
+	return sequences, nil
+}
+
+// AckPacketSequences returns the packet sequences acknowledged by a source acknowledgement transaction.
+func (i *IFT) AckPacketSequences(ctx context.Context, txHash string) ([]uint64, error) {
+	parser := mustBinding(ics26router.NewContractFilterer(i.sourceRouter, nil))
+	sequences, err := transactionEventSequences(
+		ctx,
+		i.source,
+		i.sourceRouter,
+		txHash,
+		parser.ParseAckPacket,
+		func(event *ics26router.ContractAckPacket) uint64 { return event.Packet.Sequence },
+	)
+	if err != nil {
+		return nil, fmt.Errorf("e2etest: read IFT AckPacket events: %w", err)
+	}
+	return sequences, nil
+}
+
+// TimeoutPacketSequences returns the packet sequences timed out by a source timeout transaction.
+func (i *IFT) TimeoutPacketSequences(ctx context.Context, txHash string) ([]uint64, error) {
+	parser := mustBinding(ics26router.NewContractFilterer(i.sourceRouter, nil))
+	sequences, err := transactionEventSequences(
+		ctx,
+		i.source,
+		i.sourceRouter,
+		txHash,
+		parser.ParseTimeoutPacket,
+		func(event *ics26router.ContractTimeoutPacket) uint64 { return event.Packet.Sequence },
+	)
+	if err != nil {
+		return nil, fmt.Errorf("e2etest: read IFT TimeoutPacket events: %w", err)
+	}
+	return sequences, nil
+}
 
 // VerifyBurned checks that the submitted amount left the source sender balance.
 func (p *IFTSend) VerifyBurned(ctx context.Context) error {


### PR DESCRIPTION
## Summary
- Strengthens batched IFT receive, acknowledgement, and timeout tests by checking the exact packet sequence set emitted by each relayer transaction.
- Adds receipt helpers for extracting `WriteAcknowledgement`, `AckPacket`, and `TimeoutPacket` sequences through generated router bindings.
- Tracks the destination router in the IFT test app so receive-side acknowledgement events can be decoded from their receipts.

## Testing
- `make check`
- `make test-e2e E2E_MODE=complete`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
