### PR TITLE
ci: add CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: manual
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        if: matrix.language == 'go'
+        with:
+          go-version-file: link/go.mod
+          cache-dependency-path: |
+            link/go.sum
+            e2e/go.sum
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Build Link
+        if: matrix.language == 'go'
+        working-directory: link
+        run: go build ./...
+      - name: Build E2E
+        if: matrix.language == 'go'
+        working-directory: e2e
+        run: go build ./...
+      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

- run CodeQL against GitHub Actions and Go on pushes, pull requests, and a weekly schedule
- explicitly build both Go modules so all repository tooling is analyzed
- pin the workflow actions by full commit SHA

## Repository setting

Disabled GitHub's default CodeQL setup, which only scanned Actions weekly, so this advanced workflow can upload results and add Go coverage.

## Validation

- `actionlint .github/workflows/codeql.yml`
- `make check-license-headers`
- `go -C link build ./...`
- `go -C e2e build ./...`

[FOU-1164](https://linear.app/cosmoslabs/issue/FOU-1164/add-codeql-sast-workflow)
