### PR TITLE
ci: target main after development promotion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
-    target-branch: development
+    target-branch: main
     schedule:
       interval: weekly
 
@@ -12,6 +12,6 @@ updates:
     directories:
       - "/link"
       - "/e2e"
-    target-branch: development
+    target-branch: main
     schedule:
       interval: weekly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, development]
+    branches: [main]
   pull_request:
-    branches: [main, development]
+    branches: [main]
   schedule:
     - cron: "17 3 * * 1"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,9 @@ on:
   schedule:
     - cron: "0 3 * * *"
   push:
-    branches: [main, development]
+    branches: [main]
   pull_request:
-    branches: [main, development]
+    branches: [main]
 
 permissions: read-all
 

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -4,7 +4,7 @@ name: License Headers
 
 on:
   push:
-    branches: [main, development]
+    branches: [main]
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -10,7 +10,7 @@ on:
       - ".github/workflows/spec.yml"
       - ".github/workflows/link-check-config.json"
   pull_request:
-    branches: [main, development]
+    branches: [main]
     paths:
       - "README.md"
       - "spec/**"


### PR DESCRIPTION
## Summary

- target Dependabot updates at `main`
- run CodeQL, E2E, license-header, and spec workflows against `main`
- remove `development` triggers before retiring the integration branch

Part of [FOU-1223](https://linear.app/cosmoslabs/issue/FOU-1223/merge-ibc-link-development-branch-into-main).

## Validation

- `actionlint .github/workflows/codeql.yml .github/workflows/e2e.yml .github/workflows/license-headers.yml .github/workflows/spec.yml`
- `make check-license-headers`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
