### PR TITLE
refactor(e2e): introduce stable client identities

### DIFF
--- a/e2e/fixtures_test.go
+++ b/e2e/fixtures_test.go
@@ -5,6 +5,7 @@ package e2e_test
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,16 +35,22 @@ func attestedMesh(chains []environment.ChainSpec) (environment.Spec, environment
 	for i, a := range chainIDs {
 		for _, b := range chainIDs[i+1:] {
 			connectionID := fixtureConnectionID(a, b)
-			spec.Connections = append(spec.Connections, environment.ConnectionSpec{
+			connection := environment.ConnectionSpec{
 				ID: connectionID,
-				A:  meshClient(connectionID, "a", a),
-				B:  meshClient(connectionID, "b", b),
-			})
-			for _, end := range []string{"a", "b"} {
+				A:  meshClient(a),
+				B:  meshClient(b),
+			}
+			spec.Connections = append(spec.Connections, connection)
+			for _, end := range []environment.ConnectionEnd{environment.ConnectionEndA, environment.ConnectionEndB} {
 				attestor := meshAttestorID(connectionID, end)
 				authority := environment.AuthorityID(attestor)
 				spec.Attestors = append(spec.Attestors, environment.AttestorSpec{
-					ID: attestor, Client: fixtureClientID(connectionID, end), Authority: authority,
+					ID: attestor,
+					Client: environment.IBCClientRef{
+						Connection: connectionID,
+						End:        end,
+					},
+					Authority: authority,
 				})
 				authorities[authority] = environment.EVMAuthority{
 					PrivateKeyHex: fmt.Sprintf("%064x", nextKey),
@@ -55,25 +62,24 @@ func attestedMesh(chains []environment.ChainSpec) (environment.Spec, environment
 	return spec, e2etest.RuntimeWithProtocolDeployer(environment.Runtime{Authorities: authorities})
 }
 
-func meshClient(connection environment.ConnectionID, end string, chain environment.ChainID) environment.NewClient {
+func meshClient(chain environment.ChainID) environment.NewClient {
 	return environment.NewClient{
-		ID:                    fixtureClientID(connection, end),
 		IBCInstance:           fixtureInstanceID(chain),
 		Authority:             e2etest.ProtocolAuthorityID,
 		MinRequiredSignatures: 1,
 	}
 }
 
-func meshAttestorID(connection environment.ConnectionID, end string) environment.AttestorID {
-	return environment.AttestorID(fmt.Sprintf("%s-attestor", fixtureClientID(connection, end)))
+func meshAttestorID(connection environment.ConnectionID, end environment.ConnectionEnd) environment.AttestorID {
+	return environment.AttestorID(fmt.Sprintf("%s-%s-attestor", connection, strings.ToLower(end.String())))
 }
 
 // meshAttestorFor returns the Attestor backing the mesh Client hosted on chain
 // and tracking counterparty, hiding that end labels follow sort order.
 func meshAttestorFor(chain, counterparty environment.ChainID) environment.AttestorID {
-	end := "a"
+	end := environment.ConnectionEndA
 	if counterparty < chain {
-		end = "b"
+		end = environment.ConnectionEndB
 	}
 	return meshAttestorID(fixtureConnectionID(chain, counterparty), end)
 }
@@ -104,10 +110,6 @@ func fixtureConnectionID(a, b environment.ChainID) environment.ConnectionID {
 	return environment.ConnectionID(fmt.Sprintf("conn-%s-%s", a, b))
 }
 
-func fixtureClientID(connection environment.ConnectionID, end string) environment.ClientID {
-	return environment.ClientID(fmt.Sprintf("%s-%s", connection, end))
-}
-
 func TestAttestedMesh(t *testing.T) {
 	chains := []environment.ChainSpec{
 		environment.ManagedAnvil{ID: "chain-b", EVMChainID: 2},
@@ -128,13 +130,11 @@ func TestAttestedMesh(t *testing.T) {
 		Connections: []environment.ConnectionSpec{{
 			ID: "conn-chain-a-chain-b",
 			A: environment.NewClient{
-				ID:                    "conn-chain-a-chain-b-a",
 				IBCInstance:           "ibc-chain-a",
 				Authority:             e2etest.ProtocolAuthorityID,
 				MinRequiredSignatures: 1,
 			},
 			B: environment.NewClient{
-				ID:                    "conn-chain-a-chain-b-b",
 				IBCInstance:           "ibc-chain-b",
 				Authority:             e2etest.ProtocolAuthorityID,
 				MinRequiredSignatures: 1,
@@ -142,13 +142,17 @@ func TestAttestedMesh(t *testing.T) {
 		}},
 		Attestors: []environment.AttestorSpec{
 			{
-				ID:        "conn-chain-a-chain-b-a-attestor",
-				Client:    "conn-chain-a-chain-b-a",
+				ID: "conn-chain-a-chain-b-a-attestor",
+				Client: environment.IBCClientRef{
+					Connection: "conn-chain-a-chain-b", End: environment.ConnectionEndA,
+				},
 				Authority: "conn-chain-a-chain-b-a-attestor",
 			},
 			{
-				ID:        "conn-chain-a-chain-b-b-attestor",
-				Client:    "conn-chain-a-chain-b-b",
+				ID: "conn-chain-a-chain-b-b-attestor",
+				Client: environment.IBCClientRef{
+					Connection: "conn-chain-a-chain-b", End: environment.ConnectionEndB,
+				},
 				Authority: "conn-chain-a-chain-b-b-attestor",
 			},
 		},

--- a/e2e/fixtures_test.go
+++ b/e2e/fixtures_test.go
@@ -5,7 +5,6 @@ package e2e_test
 import (
 	"fmt"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,23 +34,16 @@ func attestedMesh(chains []environment.ChainSpec) (environment.Spec, environment
 	for i, a := range chainIDs {
 		for _, b := range chainIDs[i+1:] {
 			connectionID := fixtureConnectionID(a, b)
+			attestorA := meshAttestorID(connectionID, "a")
+			attestorB := meshAttestorID(connectionID, "b")
 			connection := environment.ConnectionSpec{
 				ID: connectionID,
-				A:  meshClient(a),
-				B:  meshClient(b),
+				A:  meshClient(a, attestorA),
+				B:  meshClient(b, attestorB),
 			}
 			spec.Connections = append(spec.Connections, connection)
-			for _, end := range []environment.ConnectionEnd{environment.ConnectionEndA, environment.ConnectionEndB} {
-				attestor := meshAttestorID(connectionID, end)
+			for _, attestor := range []environment.AttestorID{attestorA, attestorB} {
 				authority := environment.AuthorityID(attestor)
-				spec.Attestors = append(spec.Attestors, environment.AttestorSpec{
-					ID: attestor,
-					Client: environment.IBCClientRef{
-						Connection: connectionID,
-						End:        end,
-					},
-					Authority: authority,
-				})
 				authorities[authority] = environment.EVMAuthority{
 					PrivateKeyHex: fmt.Sprintf("%064x", nextKey),
 				}
@@ -62,24 +54,27 @@ func attestedMesh(chains []environment.ChainSpec) (environment.Spec, environment
 	return spec, e2etest.RuntimeWithProtocolDeployer(environment.Runtime{Authorities: authorities})
 }
 
-func meshClient(chain environment.ChainID) environment.NewClient {
+func meshClient(chain environment.ChainID, attestor environment.AttestorID) environment.NewClient {
 	return environment.NewClient{
 		IBCInstance:           fixtureInstanceID(chain),
 		Authority:             e2etest.ProtocolAuthorityID,
 		MinRequiredSignatures: 1,
+		Attestors: []environment.AttestorSpec{{
+			ID: attestor, Authority: environment.AuthorityID(attestor),
+		}},
 	}
 }
 
-func meshAttestorID(connection environment.ConnectionID, end environment.ConnectionEnd) environment.AttestorID {
-	return environment.AttestorID(fmt.Sprintf("%s-%s-attestor", connection, strings.ToLower(end.String())))
+func meshAttestorID(connection environment.ConnectionID, end string) environment.AttestorID {
+	return environment.AttestorID(fmt.Sprintf("%s-%s-attestor", connection, end))
 }
 
 // meshAttestorFor returns the Attestor backing the mesh Client hosted on chain
 // and tracking counterparty, hiding that end labels follow sort order.
 func meshAttestorFor(chain, counterparty environment.ChainID) environment.AttestorID {
-	end := environment.ConnectionEndA
+	end := "a"
 	if counterparty < chain {
-		end = environment.ConnectionEndB
+		end = "b"
 	}
 	return meshAttestorID(fixtureConnectionID(chain, counterparty), end)
 }
@@ -133,29 +128,19 @@ func TestAttestedMesh(t *testing.T) {
 				IBCInstance:           "ibc-chain-a",
 				Authority:             e2etest.ProtocolAuthorityID,
 				MinRequiredSignatures: 1,
+				Attestors: []environment.AttestorSpec{{
+					ID: "conn-chain-a-chain-b-a-attestor", Authority: "conn-chain-a-chain-b-a-attestor",
+				}},
 			},
 			B: environment.NewClient{
 				IBCInstance:           "ibc-chain-b",
 				Authority:             e2etest.ProtocolAuthorityID,
 				MinRequiredSignatures: 1,
+				Attestors: []environment.AttestorSpec{{
+					ID: "conn-chain-a-chain-b-b-attestor", Authority: "conn-chain-a-chain-b-b-attestor",
+				}},
 			},
 		}},
-		Attestors: []environment.AttestorSpec{
-			{
-				ID: "conn-chain-a-chain-b-a-attestor",
-				Client: environment.IBCClientRef{
-					Connection: "conn-chain-a-chain-b", End: environment.ConnectionEndA,
-				},
-				Authority: "conn-chain-a-chain-b-a-attestor",
-			},
-			{
-				ID: "conn-chain-a-chain-b-b-attestor",
-				Client: environment.IBCClientRef{
-					Connection: "conn-chain-a-chain-b", End: environment.ConnectionEndB,
-				},
-				Authority: "conn-chain-a-chain-b-b-attestor",
-			},
-		},
 	}
 	require.Equal(t, want, spec)
 
@@ -168,7 +153,7 @@ func TestAttestedMesh(t *testing.T) {
 	for _, authority := range runtime.Authorities {
 		keys[authority.PrivateKeyHex] = struct{}{}
 	}
-	require.Len(t, keys, len(spec.Attestors)+1, "attestor keys must be distinct from each other and the deployer")
+	require.Len(t, keys, len(runtime.Authorities), "attestor keys must be distinct from each other and the deployer")
 	require.NoError(t, environment.Validate(spec, runtime))
 }
 

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -53,34 +53,20 @@ func TestIFTTransfer_MultiAttestorQuorum(t *testing.T) {
 			A: environment.NewClient{
 				IBCInstance: "quorum-ibc-a", Authority: e2etest.ProtocolAuthorityID,
 				MinRequiredSignatures: 1,
+				Attestors: []environment.AttestorSpec{{
+					ID: attestorAID, Authority: attestorAAuthority,
+				}},
 			},
 			B: environment.NewClient{
 				IBCInstance: "quorum-ibc-b", Authority: e2etest.ProtocolAuthorityID,
 				MinRequiredSignatures: 2,
+				Attestors: []environment.AttestorSpec{
+					{ID: attestorBID, Authority: attestorBAuthority},
+					{ID: attestorCID, Authority: attestorCAuthority},
+					{ID: attestorDID, Authority: attestorDAuthority},
+				},
 			},
 		}},
-		Attestors: []environment.AttestorSpec{
-			{
-				ID: attestorAID, Client: environment.IBCClientRef{
-					Connection: "quorum-connection", End: environment.ConnectionEndA,
-				}, Authority: attestorAAuthority,
-			},
-			{
-				ID: attestorBID, Client: environment.IBCClientRef{
-					Connection: "quorum-connection", End: environment.ConnectionEndB,
-				}, Authority: attestorBAuthority,
-			},
-			{
-				ID: attestorCID, Client: environment.IBCClientRef{
-					Connection: "quorum-connection", End: environment.ConnectionEndB,
-				}, Authority: attestorCAuthority,
-			},
-			{
-				ID: attestorDID, Client: environment.IBCClientRef{
-					Connection: "quorum-connection", End: environment.ConnectionEndB,
-				}, Authority: attestorDAuthority,
-			},
-		},
 	}
 	runtime := e2etest.RuntimeWithProtocolDeployer(
 		environment.Runtime{Authorities: map[environment.AuthorityID]environment.EVMAuthority{

--- a/e2e/ift_test.go
+++ b/e2e/ift_test.go
@@ -25,8 +25,6 @@ var zeroAddressReceiver = (common.Address{}).Hex()
 func TestIFTTransfer_MultiAttestorQuorum(t *testing.T) {
 	t.Parallel()
 	const (
-		clientAID          environment.ClientID    = "quorum-client-a"
-		clientBID          environment.ClientID    = "quorum-client-b"
 		attestorAID        environment.AttestorID  = "attestor-a"
 		attestorBID        environment.AttestorID  = "attestor-b"
 		attestorCID        environment.AttestorID  = "attestor-c"
@@ -53,19 +51,35 @@ func TestIFTTransfer_MultiAttestorQuorum(t *testing.T) {
 		Connections: []environment.ConnectionSpec{{
 			ID: "quorum-connection",
 			A: environment.NewClient{
-				ID: clientAID, IBCInstance: "quorum-ibc-a", Authority: e2etest.ProtocolAuthorityID,
+				IBCInstance: "quorum-ibc-a", Authority: e2etest.ProtocolAuthorityID,
 				MinRequiredSignatures: 1,
 			},
 			B: environment.NewClient{
-				ID: clientBID, IBCInstance: "quorum-ibc-b", Authority: e2etest.ProtocolAuthorityID,
+				IBCInstance: "quorum-ibc-b", Authority: e2etest.ProtocolAuthorityID,
 				MinRequiredSignatures: 2,
 			},
 		}},
 		Attestors: []environment.AttestorSpec{
-			{ID: attestorAID, Client: clientAID, Authority: attestorAAuthority},
-			{ID: attestorBID, Client: clientBID, Authority: attestorBAuthority},
-			{ID: attestorCID, Client: clientBID, Authority: attestorCAuthority},
-			{ID: attestorDID, Client: clientBID, Authority: attestorDAuthority},
+			{
+				ID: attestorAID, Client: environment.IBCClientRef{
+					Connection: "quorum-connection", End: environment.ConnectionEndA,
+				}, Authority: attestorAAuthority,
+			},
+			{
+				ID: attestorBID, Client: environment.IBCClientRef{
+					Connection: "quorum-connection", End: environment.ConnectionEndB,
+				}, Authority: attestorBAuthority,
+			},
+			{
+				ID: attestorCID, Client: environment.IBCClientRef{
+					Connection: "quorum-connection", End: environment.ConnectionEndB,
+				}, Authority: attestorCAuthority,
+			},
+			{
+				ID: attestorDID, Client: environment.IBCClientRef{
+					Connection: "quorum-connection", End: environment.ConnectionEndB,
+				}, Authority: attestorDAuthority,
+			},
 		},
 	}
 	runtime := e2etest.RuntimeWithProtocolDeployer(

--- a/e2e/internal/e2etest/matrix.go
+++ b/e2e/internal/e2etest/matrix.go
@@ -155,6 +155,7 @@ func (c *matrixCollector) emit(record *MatrixRecord) error {
 
 func summarizeSpec(spec environment.Spec) MatrixSpec {
 	counts := make(map[string]int)
+	attestors := 0
 	for _, chain := range spec.Chains {
 		switch chain.(type) {
 		case environment.ManagedAnvil:
@@ -176,10 +177,20 @@ func summarizeSpec(spec environment.Spec) MatrixSpec {
 	for _, typ := range types {
 		chains = append(chains, MatrixChain{Type: typ, Count: counts[typ]})
 	}
+	for _, connection := range spec.Connections {
+		for _, declaration := range []environment.ClientSpec{connection.A, connection.B} {
+			switch client := declaration.(type) {
+			case environment.NewClient:
+				attestors += len(client.Attestors)
+			case environment.ExistingClient:
+				attestors += len(client.Attestors)
+			}
+		}
+	}
 	return MatrixSpec{
 		Chains:       chains,
 		IBCInstances: len(spec.IBCInstances),
 		Connections:  len(spec.Connections),
-		Attestors:    len(spec.Attestors),
+		Attestors:    attestors,
 	}
 }

--- a/e2e/internal/e2etest/matrix_test.go
+++ b/e2e/internal/e2etest/matrix_test.go
@@ -36,8 +36,10 @@ func TestMatrixCollectorJoinsSelectionsAndSpec(t *testing.T) {
 			environment.AttachedEVM{ID: "b", EVMChainID: 2},
 		},
 		IBCInstances: make([]environment.IBCInstanceSpec, 2),
-		Connections:  make([]environment.ConnectionSpec, 1),
-		Attestors:    make([]environment.AttestorSpec, 3),
+		Connections: []environment.ConnectionSpec{{
+			A: environment.NewClient{Attestors: make([]environment.AttestorSpec, 1)},
+			B: environment.NewClient{Attestors: make([]environment.AttestorSpec, 2)},
+		}},
 	})
 	if err := collector.recordSpec("TestMesh/subtest", ModeProduction, summary); err != nil {
 		t.Fatal(err)

--- a/e2e/internal/e2etest/traffic.go
+++ b/e2e/internal/e2etest/traffic.go
@@ -19,7 +19,7 @@ type RouteID string
 type PacketTx struct {
 	RouteID      RouteID
 	Source       environment.ChainID
-	SourceClient string
+	SourceClient environment.IBCClientLocator
 	SourceTxHash string
 	Sequence     uint64
 }
@@ -45,7 +45,7 @@ type sendResult struct {
 func newSendResult(
 	routeID RouteID,
 	source endpoint,
-	sourceClient string,
+	sourceClient environment.IBCClientLocator,
 	receipt *types.Receipt,
 	sequence uint64,
 ) sendResult {

--- a/e2e/internal/e2etest/traffic.go
+++ b/e2e/internal/e2etest/traffic.go
@@ -17,11 +17,11 @@ type RouteID string
 // route it travels, the source transaction that emitted it, and its sequence
 // within that transaction's client. It carries no packet wire data.
 type PacketTx struct {
-	RouteID      RouteID
-	Source       environment.ChainID
-	SourceClient environment.IBCClientLocator
-	SourceTxHash string
-	Sequence     uint64
+	RouteID        RouteID
+	Source         environment.ChainID
+	SourceClientID string
+	SourceTxHash   string
+	Sequence       uint64
 }
 
 // String renders the route-scoped label used in relayer status messages.
@@ -45,17 +45,17 @@ type sendResult struct {
 func newSendResult(
 	routeID RouteID,
 	source endpoint,
-	sourceClient environment.IBCClientLocator,
+	sourceClientID string,
 	receipt *types.Receipt,
 	sequence uint64,
 ) sendResult {
 	return sendResult{
 		packetTx: PacketTx{
-			RouteID:      routeID,
-			Source:       source.chain.ID(),
-			SourceClient: sourceClient,
-			SourceTxHash: receipt.TxHash.Hex(),
-			Sequence:     sequence,
+			RouteID:        routeID,
+			Source:         source.chain.ID(),
+			SourceClientID: sourceClientID,
+			SourceTxHash:   receipt.TxHash.Hex(),
+			Sequence:       sequence,
 		},
 		receipt: receipt,
 	}

--- a/e2e/internal/e2etest/traffic_apps.go
+++ b/e2e/internal/e2etest/traffic_apps.go
@@ -25,16 +25,16 @@ func NewTransfer(
 	sourceEndpoint, destinationEndpoint, err := resolveRouteEndpoints(route.ID, source, destination)
 	require.NoError(t, err, "e2etest: resolve endpoints for Transfer on route %q", route.ID)
 	return &Transfer{
-		routeID:      route.ID,
-		source:       sourceEndpoint,
-		destination:  destinationEndpoint,
-		sender:       sender.account,
-		sourceToken:  sourceApps.Token,
-		sourceICS20:  sourceApps.ICS20Transfer,
-		sourceRouter: sourceApps.ICS26Router,
-		destICS20:    destinationApps.ICS20Transfer,
-		sourceClient: clients.SourceClient,
-		destClient:   clients.DestClient,
+		routeID:        route.ID,
+		source:         sourceEndpoint,
+		destination:    destinationEndpoint,
+		sender:         sender.account,
+		sourceToken:    sourceApps.Token,
+		sourceICS20:    sourceApps.ICS20Transfer,
+		sourceRouter:   sourceApps.ICS26Router,
+		destICS20:      destinationApps.ICS20Transfer,
+		sourceClientID: clients.SourceClientID,
+		destClientID:   clients.DestClientID,
 	}
 }
 
@@ -52,15 +52,15 @@ func NewIFT(
 	sourceEndpoint, destinationEndpoint, err := resolveRouteEndpoints(route.ID, source, destination)
 	require.NoError(t, err, "e2etest: resolve endpoints for IFT on route %q", route.ID)
 	return &IFT{
-		routeID:      route.ID,
-		source:       sourceEndpoint,
-		destination:  destinationEndpoint,
-		sender:       sender.account,
-		sourceIFT:    sourceApps.IFT,
-		destIFT:      destinationApps.IFT,
-		sourceRouter: sourceApps.ICS26Router,
-		sourceClient: clients.SourceClient,
-		batcher:      sourceApps.IFTBatchShim,
+		routeID:        route.ID,
+		source:         sourceEndpoint,
+		destination:    destinationEndpoint,
+		sender:         sender.account,
+		sourceIFT:      sourceApps.IFT,
+		destIFT:        destinationApps.IFT,
+		sourceRouter:   sourceApps.ICS26Router,
+		sourceClientID: clients.SourceClientID,
+		batcher:        sourceApps.IFTBatchShim,
 	}
 }
 
@@ -92,25 +92,25 @@ func DeployIFTTokenPair(
 
 	registerIFTBridge(
 		t, sourceEndpoint.evm, deployer, route.Source,
-		sourceIFT, clients.SourceClient, destinationIFT, sourceApps.IFTSendCallConstructor,
+		sourceIFT, clients.SourceClientID, destinationIFT, sourceApps.IFTSendCallConstructor,
 	)
 	if !route.SkipDestinationIFTBridge {
 		registerIFTBridge(
 			t, destinationEndpoint.evm, deployer, route.Destination,
-			destinationIFT, clients.DestClient, sourceIFT, destinationApps.IFTSendCallConstructor,
+			destinationIFT, clients.DestClientID, sourceIFT, destinationApps.IFTSendCallConstructor,
 		)
 	}
 
 	return &IFT{
-		routeID:      route.ID,
-		source:       sourceEndpoint,
-		destination:  destinationEndpoint,
-		sender:       deployer.account,
-		sourceIFT:    sourceIFT,
-		destIFT:      destinationIFT,
-		sourceRouter: sourceApps.ICS26Router,
-		sourceClient: clients.SourceClient,
-		batcher:      batcher,
+		routeID:        route.ID,
+		source:         sourceEndpoint,
+		destination:    destinationEndpoint,
+		sender:         deployer.account,
+		sourceIFT:      sourceIFT,
+		destIFT:        destinationIFT,
+		sourceRouter:   sourceApps.ICS26Router,
+		sourceClientID: clients.SourceClientID,
+		batcher:        batcher,
 	}
 }
 
@@ -130,18 +130,18 @@ func NewGMP(
 	defaultCall, err := mustABI(counter.CounterMetaData).Pack("increment")
 	require.NoError(t, err, "e2etest: pack Counter.increment()")
 	return &GMP{
-		routeID:      route.ID,
-		source:       sourceEndpoint,
-		destination:  destinationEndpoint,
-		sender:       sender.account,
-		sourceGMP:    sourceApps.ICS27GMP,
-		sourceRouter: sourceApps.ICS26Router,
-		counter:      destinationApps.Counter,
-		sourceClient: clients.SourceClient,
-		destClient:   clients.DestClient,
-		destGMP:      destinationApps.ICS27GMP,
-		destToken:    destinationApps.Token,
-		defaultCall:  defaultCall,
+		routeID:        route.ID,
+		source:         sourceEndpoint,
+		destination:    destinationEndpoint,
+		sender:         sender.account,
+		sourceGMP:      sourceApps.ICS27GMP,
+		sourceRouter:   sourceApps.ICS26Router,
+		counter:        destinationApps.Counter,
+		sourceClientID: clients.SourceClientID,
+		destClientID:   clients.DestClientID,
+		destGMP:        destinationApps.ICS27GMP,
+		destToken:      destinationApps.Token,
+		defaultCall:    defaultCall,
 	}
 }
 

--- a/e2e/internal/e2etest/traffic_gmp.go
+++ b/e2e/internal/e2etest/traffic_gmp.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
-	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/counter"
 )
 
@@ -30,18 +29,18 @@ type GMPRequest struct {
 // GMP drives ICS27 GMP and its default Counter and TestERC20 targets on a
 // single directed route.
 type GMP struct {
-	routeID      RouteID
-	source       endpoint
-	destination  endpoint
-	sender       evm.Account
-	sourceGMP    common.Address
-	sourceRouter common.Address
-	counter      common.Address
-	sourceClient environment.IBCClientLocator
-	destClient   environment.IBCClientLocator
-	destGMP      common.Address
-	destToken    common.Address
-	defaultCall  []byte
+	routeID        RouteID
+	source         endpoint
+	destination    endpoint
+	sender         evm.Account
+	sourceGMP      common.Address
+	sourceRouter   common.Address
+	counter        common.Address
+	sourceClientID string
+	destClientID   string
+	destGMP        common.Address
+	destToken      common.Address
+	defaultCall    []byte
 }
 
 // Token returns the destination-chain TestERC20 bound to this GMP.
@@ -74,7 +73,7 @@ func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
 		return nil, err
 	}
 	msg := ics27gmp.IICS27GMPMsgsSendCallMsg{
-		SourceClient:     string(g.sourceClient),
+		SourceClient:     g.sourceClientID,
 		Receiver:         receiver,
 		Salt:             request.Salt,
 		Payload:          payload,
@@ -97,7 +96,7 @@ func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
 		return nil, fmt.Errorf("e2etest: send GMP on route %q: %w", g.routeID, err)
 	}
 	return &GMPCall{
-		sendResult: newSendResult(g.routeID, g.source, g.sourceClient, receipt, sequence),
+		sendResult: newSendResult(g.routeID, g.source, g.sourceClientID, receipt, sequence),
 		app:        g,
 		before:     before,
 	}, nil
@@ -143,7 +142,7 @@ func (g *GMP) count(ctx context.Context) (*big.Int, error) {
 // constructs on the destination chain for a call sent by sender with salt:
 func (g *GMP) AccountIdentifier(sender common.Address, salt []byte) ics27gmp.IICS27GMPMsgsAccountIdentifier {
 	return ics27gmp.IICS27GMPMsgsAccountIdentifier{
-		ClientId: string(g.destClient),
+		ClientId: g.destClientID,
 		Sender:   sender.Hex(),
 		Salt:     salt,
 	}

--- a/e2e/internal/e2etest/traffic_gmp.go
+++ b/e2e/internal/e2etest/traffic_gmp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
+	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/counter"
 )
 
@@ -36,8 +37,8 @@ type GMP struct {
 	sourceGMP    common.Address
 	sourceRouter common.Address
 	counter      common.Address
-	sourceClient string
-	destClient   string
+	sourceClient environment.IBCClientLocator
+	destClient   environment.IBCClientLocator
 	destGMP      common.Address
 	destToken    common.Address
 	defaultCall  []byte
@@ -73,7 +74,7 @@ func (g *GMP) Call(ctx context.Context, request GMPRequest) (*GMPCall, error) {
 		return nil, err
 	}
 	msg := ics27gmp.IICS27GMPMsgsSendCallMsg{
-		SourceClient:     g.sourceClient,
+		SourceClient:     string(g.sourceClient),
 		Receiver:         receiver,
 		Salt:             request.Salt,
 		Payload:          payload,
@@ -142,7 +143,7 @@ func (g *GMP) count(ctx context.Context) (*big.Int, error) {
 // constructs on the destination chain for a call sent by sender with salt:
 func (g *GMP) AccountIdentifier(sender common.Address, salt []byte) ics27gmp.IICS27GMPMsgsAccountIdentifier {
 	return ics27gmp.IICS27GMPMsgsAccountIdentifier{
-		ClientId: g.destClient,
+		ClientId: string(g.destClient),
 		Sender:   sender.Hex(),
 		Salt:     salt,
 	}

--- a/e2e/internal/e2etest/traffic_ift.go
+++ b/e2e/internal/e2etest/traffic_ift.go
@@ -43,7 +43,7 @@ type IFT struct {
 	sourceIFT    common.Address
 	destIFT      common.Address
 	sourceRouter common.Address
-	sourceClient string
+	sourceClient environment.IBCClientLocator
 	batcher      common.Address
 }
 
@@ -85,7 +85,7 @@ func (i *IFT) Send(ctx context.Context, request IFTRequest) (*IFTSend, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := iftABI.Pack("iftTransfer", i.sourceClient, receiver.Hex(), amount, timeoutTimestamp)
+	data, err := iftABI.Pack("iftTransfer", string(i.sourceClient), receiver.Hex(), amount, timeoutTimestamp)
 	if err != nil {
 		return nil, fmt.Errorf("e2etest: pack IFT iftTransfer: %w", err)
 	}
@@ -157,7 +157,7 @@ func (i *IFT) SendBatch(ctx context.Context, requests []IFTRequest) (*IFTBatch, 
 		total.Add(total, amount)
 	}
 
-	data, err := iftBatchShimABI.Pack("batchIftTransfer", i.sourceIFT, i.sourceClient, transfers)
+	data, err := iftBatchShimABI.Pack("batchIftTransfer", i.sourceIFT, string(i.sourceClient), transfers)
 	if err != nil {
 		return nil, fmt.Errorf("e2etest: pack IFT batchIftTransfer: %w", err)
 	}
@@ -475,7 +475,7 @@ func (i *IFT) pendingTransfer(
 	ctx context.Context,
 	client *environment.EVM,
 	contract common.Address,
-	clientID string,
+	clientID environment.IBCClientLocator,
 	sequence uint64,
 ) (ift.IIFTMsgsPendingTransfer, error) {
 	var record ift.IIFTMsgsPendingTransfer
@@ -484,7 +484,7 @@ func (i *IFT) pendingTransfer(
 		if err != nil {
 			return fmt.Errorf("e2etest: bind IFT %s: %w", contract, err)
 		}
-		record, err = bound.GetPendingTransfer(&bind.CallOpts{Context: ctx}, clientID, sequence)
+		record, err = bound.GetPendingTransfer(&bind.CallOpts{Context: ctx}, string(clientID), sequence)
 		return err
 	})
 	if err != nil {

--- a/e2e/internal/e2etest/traffic_ift.go
+++ b/e2e/internal/e2etest/traffic_ift.go
@@ -36,15 +36,15 @@ type IFTRequest struct {
 
 // IFT drives the Interchain Fungible Token pair on a single directed route.
 type IFT struct {
-	routeID      RouteID
-	source       endpoint
-	destination  endpoint
-	sender       evm.Account
-	sourceIFT    common.Address
-	destIFT      common.Address
-	sourceRouter common.Address
-	sourceClient environment.IBCClientLocator
-	batcher      common.Address
+	routeID        RouteID
+	source         endpoint
+	destination    endpoint
+	sender         evm.Account
+	sourceIFT      common.Address
+	destIFT        common.Address
+	sourceRouter   common.Address
+	sourceClientID string
+	batcher        common.Address
 }
 
 // IFTSend is the result of an IFT Send: the packet it emitted plus the balance
@@ -85,7 +85,7 @@ func (i *IFT) Send(ctx context.Context, request IFTRequest) (*IFTSend, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := iftABI.Pack("iftTransfer", string(i.sourceClient), receiver.Hex(), amount, timeoutTimestamp)
+	data, err := iftABI.Pack("iftTransfer", i.sourceClientID, receiver.Hex(), amount, timeoutTimestamp)
 	if err != nil {
 		return nil, fmt.Errorf("e2etest: pack IFT iftTransfer: %w", err)
 	}
@@ -101,7 +101,7 @@ func (i *IFT) Send(ctx context.Context, request IFTRequest) (*IFTSend, error) {
 		return nil, fmt.Errorf("e2etest: send IFT on route %q: %w", i.routeID, err)
 	}
 	return &IFTSend{
-		sendResult:              newSendResult(i.routeID, i.source, i.sourceClient, receipt, sequence),
+		sendResult:              newSendResult(i.routeID, i.source, i.sourceClientID, receipt, sequence),
 		app:                     i,
 		receiver:                receiver,
 		amount:                  amount,
@@ -157,7 +157,7 @@ func (i *IFT) SendBatch(ctx context.Context, requests []IFTRequest) (*IFTBatch, 
 		total.Add(total, amount)
 	}
 
-	data, err := iftBatchShimABI.Pack("batchIftTransfer", i.sourceIFT, string(i.sourceClient), transfers)
+	data, err := iftBatchShimABI.Pack("batchIftTransfer", i.sourceIFT, i.sourceClientID, transfers)
 	if err != nil {
 		return nil, fmt.Errorf("e2etest: pack IFT batchIftTransfer: %w", err)
 	}
@@ -181,7 +181,7 @@ func (i *IFT) SendBatch(ctx context.Context, requests []IFTRequest) (*IFTBatch, 
 	sends := make([]*IFTSend, len(requests))
 	for k, sequence := range sequences {
 		sends[k] = &IFTSend{
-			sendResult:        newSendResult(i.routeID, i.source, i.sourceClient, receipt, sequence),
+			sendResult:        newSendResult(i.routeID, i.source, i.sourceClientID, receipt, sequence),
 			app:               i,
 			receiver:          common.HexToAddress(transfers[k].Receiver),
 			amount:            transfers[k].Amount,
@@ -336,7 +336,7 @@ func (p *IFTSend) awaitPendingCleared(ctx context.Context) error {
 				ctx,
 				p.app.source.evm,
 				p.app.sourceIFT,
-				p.app.sourceClient,
+				p.app.sourceClientID,
 				p.packetTx.Sequence,
 			)
 			switch {
@@ -371,7 +371,7 @@ func (p *IFTSend) VerifyPending(ctx context.Context) error {
 		ctx,
 		p.app.source.evm,
 		p.app.sourceIFT,
-		p.app.sourceClient,
+		p.app.sourceClientID,
 		p.packetTx.Sequence,
 	)
 	if err != nil {
@@ -399,7 +399,7 @@ func (p *IFTSend) VerifyPending(ctx context.Context) error {
 // VerifyPendingCleared checks that no pending-transfer record exists for
 // this packet's sequence on the source IFT contract.
 func (p *IFTSend) VerifyPendingCleared(ctx context.Context) error {
-	_, err := p.app.pendingTransfer(ctx, p.app.source.evm, p.app.sourceIFT, p.app.sourceClient, p.packetTx.Sequence)
+	_, err := p.app.pendingTransfer(ctx, p.app.source.evm, p.app.sourceIFT, p.app.sourceClientID, p.packetTx.Sequence)
 	if err == nil {
 		return fmt.Errorf(
 			"e2etest: IFT packet %s pending transfer still present, want cleared",
@@ -475,7 +475,7 @@ func (i *IFT) pendingTransfer(
 	ctx context.Context,
 	client *environment.EVM,
 	contract common.Address,
-	clientID environment.IBCClientLocator,
+	clientID string,
 	sequence uint64,
 ) (ift.IIFTMsgsPendingTransfer, error) {
 	var record ift.IIFTMsgsPendingTransfer
@@ -484,7 +484,7 @@ func (i *IFT) pendingTransfer(
 		if err != nil {
 			return fmt.Errorf("e2etest: bind IFT %s: %w", contract, err)
 		}
-		record, err = bound.GetPendingTransfer(&bind.CallOpts{Context: ctx}, string(clientID), sequence)
+		record, err = bound.GetPendingTransfer(&bind.CallOpts{Context: ctx}, clientID, sequence)
 		return err
 	})
 	if err != nil {

--- a/e2e/internal/e2etest/traffic_relayer.go
+++ b/e2e/internal/e2etest/traffic_relayer.go
@@ -241,7 +241,7 @@ func observeStatus(
 
 func statusForPacket(statuses []*relayerv2.PacketStatus, packet PacketTx) *relayerv2.PacketStatus {
 	for _, status := range statuses {
-		if status.GetSourceClientId() == packet.SourceClient && status.GetSequenceNumber() == packet.Sequence {
+		if status.GetSourceClientId() == string(packet.SourceClient) && status.GetSequenceNumber() == packet.Sequence {
 			return status
 		}
 	}

--- a/e2e/internal/e2etest/traffic_relayer.go
+++ b/e2e/internal/e2etest/traffic_relayer.go
@@ -241,7 +241,7 @@ func observeStatus(
 
 func statusForPacket(statuses []*relayerv2.PacketStatus, packet PacketTx) *relayerv2.PacketStatus {
 	for _, status := range statuses {
-		if status.GetSourceClientId() == string(packet.SourceClient) && status.GetSequenceNumber() == packet.Sequence {
+		if status.GetSourceClientId() == packet.SourceClientID && status.GetSequenceNumber() == packet.Sequence {
 			return status
 		}
 	}

--- a/e2e/internal/e2etest/traffic_setup.go
+++ b/e2e/internal/e2etest/traffic_setup.go
@@ -81,10 +81,10 @@ type ChainDeployment struct {
 	ICS26Router            common.Address
 }
 
-// RouteClients holds the realized client locators for one directed route.
+// RouteClients holds the protocol client IDs for one directed route.
 type RouteClients struct {
-	SourceClient environment.IBCClientLocator
-	DestClient   environment.IBCClientLocator
+	SourceClientID string
+	DestClientID   string
 }
 
 // Deployment is the e2e traffic-layer view of protocol apps and test tokens.
@@ -271,8 +271,8 @@ func deployApps(
 		sourceClient, destClient, err := resolveRouteClients(env, route)
 		require.NoError(t, err, "e2etest: resolve clients for route %q", route.ID)
 		deployment.routes[route.ID] = RouteClients{
-			SourceClient: sourceClient,
-			DestClient:   destClient,
+			SourceClientID: sourceClient,
+			DestClientID:   destClient,
 		}
 	}
 
@@ -294,12 +294,12 @@ func registerIFTBridges(
 		clients := deployment.routes[route.ID]
 		ends := []struct {
 			chain         environment.ChainID
-			client        environment.IBCClientLocator
+			client        string
 			counterparty  environment.ChainID
 			isDestination bool
 		}{
-			{chain: route.Source, client: clients.SourceClient, counterparty: route.Destination},
-			{chain: route.Destination, client: clients.DestClient, counterparty: route.Source, isDestination: true},
+			{chain: route.Source, client: clients.SourceClientID, counterparty: route.Destination},
+			{chain: route.Destination, client: clients.DestClientID, counterparty: route.Source, isDestination: true},
 		}
 		for _, end := range ends {
 			if end.isDestination && route.SkipDestinationIFTBridge {
@@ -326,12 +326,12 @@ func registerIFTBridge(
 	deployer Signer,
 	chain environment.ChainID,
 	iftToken common.Address,
-	client environment.IBCClientLocator,
+	client string,
 	counterpartyIFT common.Address,
 	callConstructor common.Address,
 ) {
 	t.Helper()
-	data, err := iftABI.Pack("registerIFTBridge", string(client), counterpartyIFT.Hex(), callConstructor)
+	data, err := iftABI.Pack("registerIFTBridge", client, counterpartyIFT.Hex(), callConstructor)
 	require.NoError(t, err, "e2etest: pack IFT registerIFTBridge")
 	_, err = evmAccess.BroadcastTx(t.Context(), deployer.account, &iftToken, data, nil)
 	require.NoError(t, err, "e2etest: register IFT bridge for client %q on Chain %q", client, chain)
@@ -379,7 +379,7 @@ func buildConfig(
 		require.NoError(t, err, "e2etest: resolve Attestor %q", id)
 		client := attestor.IBCClient()
 		chainID := options.ChainIDs[string(client.IBCInstance().Chain().ID())]
-		key := chainID + "/" + string(client.Locator())
+		key := chainID + "/" + client.ID()
 		set := attestorSets[key]
 		if set == nil {
 			set = &ibclink.RelayerAttestorSet{Threshold: int(client.MinRequiredSignatures())}
@@ -409,9 +409,9 @@ func buildConfig(
 		destinationChain := options.ChainIDs[string(route.Destination)]
 		connection := ibclink.RelayerConnection{
 			ChainA:  sourceChain,
-			ClientA: string(clients.SourceClient),
+			ClientA: clients.SourceClientID,
 			ChainB:  destinationChain,
-			ClientB: string(clients.DestClient),
+			ClientB: clients.DestClientID,
 		}
 		if connection.ChainB+"/"+connection.ClientB < connection.ChainA+"/"+connection.ClientA {
 			connection.ChainA, connection.ClientA, connection.ChainB, connection.ClientB = connection.ChainB, connection.ClientB, connection.ChainA, connection.ClientA
@@ -426,7 +426,7 @@ func buildConfig(
 
 		config.Routes = append(config.Routes, ibclink.RelayerRoute{
 			SourceChain:  sourceChain,
-			SourceClient: string(clients.SourceClient),
+			SourceClient: clients.SourceClientID,
 		})
 	}
 	return config, options
@@ -447,7 +447,7 @@ func routeWaitPolicy(source, destination environment.Timing) ibclink.WaitPolicy 
 func resolveRouteClients(
 	env *environment.Environment,
 	route Route,
-) (environment.IBCClientLocator, environment.IBCClientLocator, error) {
+) (string, string, error) {
 	for _, id := range env.Connections() {
 		connection, err := env.Connection(id)
 		if err != nil {
@@ -457,9 +457,9 @@ func resolveRouteClients(
 		bChain := connection.B().IBCInstance().Chain().ID()
 		switch {
 		case aChain == route.Source && bChain == route.Destination:
-			return connection.A().Locator(), connection.B().Locator(), nil
+			return connection.A().ID(), connection.B().ID(), nil
 		case bChain == route.Source && aChain == route.Destination:
-			return connection.B().Locator(), connection.A().Locator(), nil
+			return connection.B().ID(), connection.A().ID(), nil
 		}
 	}
 	return "", "", fmt.Errorf(

--- a/e2e/internal/e2etest/traffic_setup.go
+++ b/e2e/internal/e2etest/traffic_setup.go
@@ -83,8 +83,8 @@ type ChainDeployment struct {
 
 // RouteClients holds the realized client locators for one directed route.
 type RouteClients struct {
-	SourceClient string
-	DestClient   string
+	SourceClient environment.IBCClientLocator
+	DestClient   environment.IBCClientLocator
 }
 
 // Deployment is the e2e traffic-layer view of protocol apps and test tokens.
@@ -294,7 +294,7 @@ func registerIFTBridges(
 		clients := deployment.routes[route.ID]
 		ends := []struct {
 			chain         environment.ChainID
-			client        string
+			client        environment.IBCClientLocator
 			counterparty  environment.ChainID
 			isDestination bool
 		}{
@@ -326,12 +326,12 @@ func registerIFTBridge(
 	deployer Signer,
 	chain environment.ChainID,
 	iftToken common.Address,
-	client string,
+	client environment.IBCClientLocator,
 	counterpartyIFT common.Address,
 	callConstructor common.Address,
 ) {
 	t.Helper()
-	data, err := iftABI.Pack("registerIFTBridge", client, counterpartyIFT.Hex(), callConstructor)
+	data, err := iftABI.Pack("registerIFTBridge", string(client), counterpartyIFT.Hex(), callConstructor)
 	require.NoError(t, err, "e2etest: pack IFT registerIFTBridge")
 	_, err = evmAccess.BroadcastTx(t.Context(), deployer.account, &iftToken, data, nil)
 	require.NoError(t, err, "e2etest: register IFT bridge for client %q on Chain %q", client, chain)
@@ -409,9 +409,9 @@ func buildConfig(
 		destinationChain := options.ChainIDs[string(route.Destination)]
 		connection := ibclink.RelayerConnection{
 			ChainA:  sourceChain,
-			ClientA: clients.SourceClient,
+			ClientA: string(clients.SourceClient),
 			ChainB:  destinationChain,
-			ClientB: clients.DestClient,
+			ClientB: string(clients.DestClient),
 		}
 		if connection.ChainB+"/"+connection.ClientB < connection.ChainA+"/"+connection.ClientA {
 			connection.ChainA, connection.ClientA, connection.ChainB, connection.ClientB = connection.ChainB, connection.ClientB, connection.ChainA, connection.ClientA
@@ -426,7 +426,7 @@ func buildConfig(
 
 		config.Routes = append(config.Routes, ibclink.RelayerRoute{
 			SourceChain:  sourceChain,
-			SourceClient: clients.SourceClient,
+			SourceClient: string(clients.SourceClient),
 		})
 	}
 	return config, options
@@ -444,7 +444,10 @@ func routeWaitPolicy(source, destination environment.Timing) ibclink.WaitPolicy 
 	}
 }
 
-func resolveRouteClients(env *environment.Environment, route Route) (string, string, error) {
+func resolveRouteClients(
+	env *environment.Environment,
+	route Route,
+) (environment.IBCClientLocator, environment.IBCClientLocator, error) {
 	for _, id := range env.Connections() {
 		connection, err := env.Connection(id)
 		if err != nil {
@@ -454,9 +457,9 @@ func resolveRouteClients(env *environment.Environment, route Route) (string, str
 		bChain := connection.B().IBCInstance().Chain().ID()
 		switch {
 		case aChain == route.Source && bChain == route.Destination:
-			return string(connection.A().Locator()), string(connection.B().Locator()), nil
+			return connection.A().Locator(), connection.B().Locator(), nil
 		case bChain == route.Source && aChain == route.Destination:
-			return string(connection.B().Locator()), string(connection.A().Locator()), nil
+			return connection.B().Locator(), connection.A().Locator(), nil
 		}
 	}
 	return "", "", fmt.Errorf(

--- a/e2e/internal/e2etest/traffic_test.go
+++ b/e2e/internal/e2etest/traffic_test.go
@@ -89,7 +89,7 @@ func TestStatusForPacketMatchesTypedClientLocator(t *testing.T) {
 		{SourceClientId: "other", SequenceNumber: 7},
 		{SourceClientId: "client-a", SequenceNumber: 7},
 	}
-	packet := PacketTx{SourceClient: environment.IBCClientLocator("client-a"), Sequence: 7}
+	packet := PacketTx{SourceClientID: "client-a", Sequence: 7}
 
 	require.Same(t, statuses[1], statusForPacket(statuses, packet))
 }

--- a/e2e/internal/e2etest/traffic_test.go
+++ b/e2e/internal/e2etest/traffic_test.go
@@ -84,6 +84,16 @@ func TestAwaitStateRequiresRouteWaitPolicy(t *testing.T) {
 	require.EqualError(t, err, `e2etest: packet missing-7 has no wait policy for route "missing"`)
 }
 
+func TestStatusForPacketMatchesTypedClientLocator(t *testing.T) {
+	statuses := []*relayerv2.PacketStatus{
+		{SourceClientId: "other", SequenceNumber: 7},
+		{SourceClientId: "client-a", SequenceNumber: 7},
+	}
+	packet := PacketTx{SourceClient: environment.IBCClientLocator("client-a"), Sequence: 7}
+
+	require.Same(t, statuses[1], statusForPacket(statuses, packet))
+}
+
 func TestAwaitStableUsesFreshWindowAfterStateReached(t *testing.T) {
 	policy := ibclink.WaitPolicy{
 		CompletionBudget: 200 * time.Millisecond,

--- a/e2e/internal/e2etest/traffic_transfer.go
+++ b/e2e/internal/e2etest/traffic_transfer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
+	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/testerc20"
 )
 
@@ -56,8 +57,8 @@ type Transfer struct {
 	sourceICS20  common.Address
 	sourceRouter common.Address
 	destICS20    common.Address
-	sourceClient string
-	destClient   string
+	sourceClient environment.IBCClientLocator
+	destClient   environment.IBCClientLocator
 }
 
 type PreparedTransfer struct {
@@ -148,7 +149,7 @@ func (p *PreparedTransfer) Submit(ctx context.Context) (*TransferSend, error) {
 		Denom:            p.app.sourceToken,
 		Amount:           p.request.Amount,
 		Receiver:         p.request.Receiver,
-		SourceClient:     p.app.sourceClient,
+		SourceClient:     string(p.app.sourceClient),
 		DestPort:         ics20DestPort,
 		TimeoutTimestamp: p.timeoutTimestamp,
 		Memo:             "",
@@ -299,7 +300,7 @@ func destinationTimeout(
 }
 
 func (i *Transfer) voucherDenom() string {
-	return "transfer/" + i.destClient + "/" + strings.ToLower(i.sourceToken.Hex())
+	return "transfer/" + string(i.destClient) + "/" + strings.ToLower(i.sourceToken.Hex())
 }
 
 func (i *Transfer) voucherBalance(ctx context.Context, holder string) (*big.Int, error) {
@@ -354,7 +355,7 @@ func awaitPacketTimeout(
 	ctx context.Context,
 	source endpoint,
 	router common.Address,
-	sourceClient string,
+	sourceClient environment.IBCClientLocator,
 	packetTx PacketTx,
 ) error {
 	definition := ics26ABI.Events[eventTimeoutPacket]
@@ -374,7 +375,7 @@ func awaitPacketTimeout(
 		},
 		func(event *ics26router.ContractTimeoutPacket) bool {
 			return event.Packet.Sequence == packetTx.Sequence &&
-				event.Packet.SourceClient == sourceClient
+				event.Packet.SourceClient == string(sourceClient)
 		},
 	)
 	return err

--- a/e2e/internal/e2etest/traffic_transfer.go
+++ b/e2e/internal/e2etest/traffic_transfer.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/cosmos/ibc/e2e/internal/harness/chain/evm"
-	"github.com/cosmos/ibc/e2e/internal/harness/environment"
 	"github.com/cosmos/ibc/e2e/internal/harness/environment/solidityibc/testerc20"
 )
 
@@ -49,16 +48,16 @@ type TransferRequest struct {
 
 // Transfer drives ICS20 Transfer on a single directed route.
 type Transfer struct {
-	routeID      RouteID
-	source       endpoint
-	destination  endpoint
-	sender       evm.Account
-	sourceToken  common.Address
-	sourceICS20  common.Address
-	sourceRouter common.Address
-	destICS20    common.Address
-	sourceClient environment.IBCClientLocator
-	destClient   environment.IBCClientLocator
+	routeID        RouteID
+	source         endpoint
+	destination    endpoint
+	sender         evm.Account
+	sourceToken    common.Address
+	sourceICS20    common.Address
+	sourceRouter   common.Address
+	destICS20      common.Address
+	sourceClientID string
+	destClientID   string
 }
 
 type PreparedTransfer struct {
@@ -149,7 +148,7 @@ func (p *PreparedTransfer) Submit(ctx context.Context) (*TransferSend, error) {
 		Denom:            p.app.sourceToken,
 		Amount:           p.request.Amount,
 		Receiver:         p.request.Receiver,
-		SourceClient:     string(p.app.sourceClient),
+		SourceClient:     p.app.sourceClientID,
 		DestPort:         ics20DestPort,
 		TimeoutTimestamp: p.timeoutTimestamp,
 		Memo:             "",
@@ -173,7 +172,7 @@ func (p *PreparedTransfer) Submit(ctx context.Context) (*TransferSend, error) {
 		sendResult: newSendResult(
 			p.app.routeID,
 			p.app.source,
-			p.app.sourceClient,
+			p.app.sourceClientID,
 			receipt,
 			sequence,
 		),
@@ -237,7 +236,7 @@ func (t *TransferSend) VerifyNotMinted(ctx context.Context) error {
 
 // VerifyRefunded waits for the source sender balance to be restored after timeout.
 func (t *TransferSend) VerifyRefunded(ctx context.Context) error {
-	if err := awaitPacketTimeout(ctx, t.app.source, t.app.sourceRouter, t.app.sourceClient, t.packetTx); err != nil {
+	if err := awaitPacketTimeout(ctx, t.app.source, t.app.sourceRouter, t.app.sourceClientID, t.packetTx); err != nil {
 		return err
 	}
 	return awaitBalance(
@@ -300,7 +299,7 @@ func destinationTimeout(
 }
 
 func (i *Transfer) voucherDenom() string {
-	return "transfer/" + string(i.destClient) + "/" + strings.ToLower(i.sourceToken.Hex())
+	return "transfer/" + i.destClientID + "/" + strings.ToLower(i.sourceToken.Hex())
 }
 
 func (i *Transfer) voucherBalance(ctx context.Context, holder string) (*big.Int, error) {
@@ -355,7 +354,7 @@ func awaitPacketTimeout(
 	ctx context.Context,
 	source endpoint,
 	router common.Address,
-	sourceClient environment.IBCClientLocator,
+	sourceClientID string,
 	packetTx PacketTx,
 ) error {
 	definition := ics26ABI.Events[eventTimeoutPacket]
@@ -375,7 +374,7 @@ func awaitPacketTimeout(
 		},
 		func(event *ics26router.ContractTimeoutPacket) bool {
 			return event.Packet.Sequence == packetTx.Sequence &&
-				event.Packet.SourceClient == string(sourceClient)
+				event.Packet.SourceClient == sourceClientID
 		},
 	)
 	return err

--- a/e2e/internal/harness/environment/environment.go
+++ b/e2e/internal/harness/environment/environment.go
@@ -16,7 +16,7 @@ type Environment struct {
 	chains      map[ChainID]*Chain
 	instances   map[IBCInstanceID]*IBCInstance
 	connections map[ConnectionID]*Connection
-	clients     map[ClientID]*IBCClient
+	clients     map[IBCClientRef]*IBCClient
 	attestors   map[AttestorID]*Attestor
 
 	effects *effectJournal
@@ -93,10 +93,10 @@ func (e *Environment) Connections() []ConnectionID {
 	return ids
 }
 
-func (e *Environment) IBCClient(id ClientID) (*IBCClient, error) {
-	client, ok := e.clients[id]
+func (e *Environment) IBCClient(ref IBCClientRef) (*IBCClient, error) {
+	client, ok := e.clients[ref]
 	if !ok {
-		return nil, fmt.Errorf("environment: no IBC Client %q", id)
+		return nil, fmt.Errorf("environment: no IBC Client %q", ref)
 	}
 	return client, nil
 }

--- a/e2e/internal/harness/environment/environment.go
+++ b/e2e/internal/harness/environment/environment.go
@@ -16,7 +16,6 @@ type Environment struct {
 	chains      map[ChainID]*Chain
 	instances   map[IBCInstanceID]*IBCInstance
 	connections map[ConnectionID]*Connection
-	clients     map[IBCClientRef]*IBCClient
 	attestors   map[AttestorID]*Attestor
 
 	effects *effectJournal
@@ -91,14 +90,6 @@ func (e *Environment) Connections() []ConnectionID {
 	}
 	slices.Sort(ids)
 	return ids
-}
-
-func (e *Environment) IBCClient(ref IBCClientRef) (*IBCClient, error) {
-	client, ok := e.clients[ref]
-	if !ok {
-		return nil, fmt.Errorf("environment: no IBC Client %q", ref)
-	}
-	return client, nil
 }
 
 func (e *Environment) Attestor(id AttestorID) (*Attestor, error) {

--- a/e2e/internal/harness/environment/protocol.go
+++ b/e2e/internal/harness/environment/protocol.go
@@ -46,30 +46,27 @@ func (i *IBCInstance) ICS27GMPAddress() EVMAddress {
 	return i.ics27GMP
 }
 
-// IBCClient is one resolved end of an IBC Connection. Ref is its stable graph
-// identity; Locator is the actual client identifier registered in the host
-// IBC Instance.
+// IBCClient is one resolved end of an IBC Connection. ID is the protocol
+// identifier registered in the host IBC Instance.
 type IBCClient struct {
-	ref                   IBCClientRef
+	label                 string
 	instance              *IBCInstance
-	locator               IBCClientLocator
+	id                    string
 	lightClient           EVMAddress
-	counterparty          IBCClientLocator
+	counterpartyID        string
 	attestors             []EVMAddress
 	minRequiredSignatures uint8
 }
 
-func (c *IBCClient) Ref() IBCClientRef                     { return c.ref }
-func (c *IBCClient) IBCInstance() *IBCInstance             { return c.instance }
-func (c *IBCClient) Locator() IBCClientLocator             { return c.locator }
-func (c *IBCClient) LightClientAddress() EVMAddress        { return c.lightClient }
-func (c *IBCClient) CounterpartyLocator() IBCClientLocator { return c.counterparty }
-func (c *IBCClient) AttestorAddresses() []EVMAddress       { return slices.Clone(c.attestors) }
-func (c *IBCClient) MinRequiredSignatures() uint8          { return c.minRequiredSignatures }
+func (c *IBCClient) ID() string                      { return c.id }
+func (c *IBCClient) IBCInstance() *IBCInstance       { return c.instance }
+func (c *IBCClient) LightClientAddress() EVMAddress  { return c.lightClient }
+func (c *IBCClient) CounterpartyID() string          { return c.counterpartyID }
+func (c *IBCClient) AttestorAddresses() []EVMAddress { return slices.Clone(c.attestors) }
+func (c *IBCClient) MinRequiredSignatures() uint8    { return c.minRequiredSignatures }
 
 // Connection is a ready reciprocal IBC Client pair. A and B preserve the
-// authored end labels; callers can also locate either Client directly through
-// Environment.IBCClient.
+// authored end labels.
 type Connection struct {
 	id ConnectionID
 	a  *IBCClient

--- a/e2e/internal/harness/environment/protocol.go
+++ b/e2e/internal/harness/environment/protocol.go
@@ -46,11 +46,11 @@ func (i *IBCInstance) ICS27GMPAddress() EVMAddress {
 	return i.ics27GMP
 }
 
-// IBCClient is one resolved end of an IBC Connection. ID is the stable
-// authored identity; Locator is the actual client identifier registered in
-// the host IBC Instance.
+// IBCClient is one resolved end of an IBC Connection. Ref is its stable graph
+// identity; Locator is the actual client identifier registered in the host
+// IBC Instance.
 type IBCClient struct {
-	id                    ClientID
+	ref                   IBCClientRef
 	instance              *IBCInstance
 	locator               IBCClientLocator
 	lightClient           EVMAddress
@@ -59,7 +59,7 @@ type IBCClient struct {
 	minRequiredSignatures uint8
 }
 
-func (c *IBCClient) ID() ClientID                          { return c.id }
+func (c *IBCClient) Ref() IBCClientRef                     { return c.ref }
 func (c *IBCClient) IBCInstance() *IBCInstance             { return c.instance }
 func (c *IBCClient) Locator() IBCClientLocator             { return c.locator }
 func (c *IBCClient) LightClientAddress() EVMAddress        { return c.lightClient }

--- a/e2e/internal/harness/environment/protocol_start_test.go
+++ b/e2e/internal/harness/environment/protocol_start_test.go
@@ -147,7 +147,7 @@ func TestStartRealizesMixedProtocolGraphWithInjectedDrivers(t *testing.T) {
 		},
 		acquireConnection: func(_ context.Context, declaration ConnectionSpec, dependencies connectionDependencies, _ Runtime) (*Connection, error) {
 			require.EqualValues(t, 2, instancesReady.Load())
-			require.Equal(t, []AttestorSpec{spec.Attestors[0]}, dependencies.attestorSpecs["client-a"])
+			require.Equal(t, []AttestorSpec{spec.Attestors[0]}, dependencies.attestorSpecs[spec.Connections[0].ARef()])
 			connectionReady.Store(true)
 			return resolvedMixedConnection(
 				declaration.ID,
@@ -157,7 +157,7 @@ func TestStartRealizesMixedProtocolGraphWithInjectedDrivers(t *testing.T) {
 		},
 		acquireAttestor: func(_ context.Context, declaration AttestorSpec, dependencies attestorDependencies, _ Runtime, _ workspace) (attestorAcquisition, error) {
 			require.True(t, connectionReady.Load())
-			require.Equal(t, ClientID("client-a"), dependencies.client.ID())
+			require.Equal(t, spec.Connections[0].ARef(), dependencies.client.Ref())
 			require.Equal(t, IBCInstanceID("ibc-b"), dependencies.observed.ID())
 			return attestorAcquisition{
 				attestor: &Attestor{
@@ -177,7 +177,7 @@ func TestStartRealizesMixedProtocolGraphWithInjectedDrivers(t *testing.T) {
 	connection, err := env.Connection("connection-ab")
 	require.NoError(t, err)
 	require.Equal(t, IBCClientLocator("existing-client-b"), connection.A().CounterpartyLocator())
-	require.Same(t, connection.A(), mustIBCClient(t, env, "client-a"))
+	require.Same(t, connection.A(), mustIBCClient(t, env, spec.Connections[0].ARef()))
 
 	attestor, err := env.Attestor("attestor-a")
 	require.NoError(t, err)
@@ -227,9 +227,13 @@ func TestConnectionFailureStopsBeforeAttestorsAndCleansChains(t *testing.T) {
 
 func TestResolvedClientsRejectAttestorSignerReuse(t *testing.T) {
 	const signer EVMAddress = "0x1000000000000000000000000000000000000001"
-	seen := make(map[EVMAddress]ClientID)
-	require.NoError(t, recordResolvedAttestorUse(seen, &IBCClient{id: "client-a", attestors: []EVMAddress{signer}}))
-	err := recordResolvedAttestorUse(seen, &IBCClient{id: "client-b", attestors: []EVMAddress{signer}})
+	seen := make(map[EVMAddress]IBCClientRef)
+	require.NoError(t, recordResolvedAttestorUse(seen, &IBCClient{
+		ref: IBCClientRef{Connection: "one", End: ConnectionEndA}, attestors: []EVMAddress{signer},
+	}))
+	err := recordResolvedAttestorUse(seen, &IBCClient{
+		ref: IBCClientRef{Connection: "two", End: ConnectionEndA}, attestors: []EVMAddress{signer},
+	})
 	require.ErrorContains(t, err, `attestor signer 0x1000000000000000000000000000000000000001 is reused`)
 }
 
@@ -242,13 +246,33 @@ func TestExistingClientRequiresDeclaredAttestorSignerMembership(t *testing.T) {
 	require.NoError(t, err)
 	onChain := []common.Address{registered.Address()}
 
-	require.NoError(t, requireDeclaredAttestors("client-a", onChain, []AttestorSpec{{
-		ID: "attestor-a", Client: "client-a", Authority: "registered",
+	ref := IBCClientRef{Connection: "connection-ab", End: ConnectionEndA}
+	require.NoError(t, requireDeclaredAttestors(ref, onChain, []AttestorSpec{{
+		ID: "attestor-a", Client: ref, Authority: "registered",
 	}}, runtime))
-	err = requireDeclaredAttestors("client-a", onChain, []AttestorSpec{{
-		ID: "attestor-a", Client: "client-a", Authority: "absent",
+	err = requireDeclaredAttestors(ref, onChain, []AttestorSpec{{
+		ID: "attestor-a", Client: ref, Authority: "absent",
 	}}, runtime)
-	require.ErrorContains(t, err, `is not registered for existing IBC Client "client-a"`)
+	require.ErrorContains(t, err, `is not registered for existing IBC Client "connection-ab/A"`)
+}
+
+func TestClientLocatorUsesStableReference(t *testing.T) {
+	refA := IBCClientRef{Connection: "connection-ab", End: ConnectionEndA}
+	refB := IBCClientRef{Connection: "connection-ab", End: ConnectionEndB}
+	client := NewClient{IBCInstance: "ibc-a", Authority: "owner", MinRequiredSignatures: 1}
+
+	locator := clientLocator(refA, client)
+	require.Equal(
+		t,
+		IBCClientLocator("link-8b79fc938a76adf41b710b8f6a70dc97b29bef1e82ce7492840cdb8f4663512f"),
+		locator,
+	)
+	require.Equal(t, locator, clientLocator(refA, NewClient{
+		IBCInstance: "different-instance", Authority: "different-owner", MinRequiredSignatures: 2,
+	}))
+	require.NotEqual(t, locator, clientLocator(refB, client))
+	require.NotEqual(t, locator, clientLocator(IBCClientRef{Connection: "other", End: ConnectionEndA}, client))
+	require.Equal(t, IBCClientLocator("existing"), clientLocator(refA, ExistingClient{Locator: "existing"}))
 }
 
 func TestFailedAttestorStartRetainsPartialCleanup(t *testing.T) {
@@ -257,8 +281,8 @@ func TestFailedAttestorStartRetainsPartialCleanup(t *testing.T) {
 		"ibc-a": {id: "ibc-a"},
 		"ibc-b": {id: "ibc-b"},
 	}
-	clients := map[ClientID]*IBCClient{
-		"client-a": {id: "client-a", instance: instances["ibc-a"]},
+	clients := map[IBCClientRef]*IBCClient{
+		spec.Connections[0].ARef(): {ref: spec.Connections[0].ARef(), instance: instances["ibc-a"]},
 	}
 	effects := &effectJournal{}
 	var releases atomic.Int32
@@ -305,10 +329,16 @@ func mixedProtocolSpec() Spec {
 		},
 		Connections: []ConnectionSpec{{
 			ID: "connection-ab",
-			A:  NewClient{ID: "client-a", IBCInstance: "ibc-a", Authority: "client-owner", MinRequiredSignatures: 1},
-			B:  ExistingClient{ID: "client-b", IBCInstance: "ibc-b", Locator: "existing-client-b"},
+			A:  NewClient{IBCInstance: "ibc-a", Authority: "client-owner", MinRequiredSignatures: 1},
+			B:  ExistingClient{IBCInstance: "ibc-b", Locator: "existing-client-b"},
 		}},
-		Attestors: []AttestorSpec{{ID: "attestor-a", Client: "client-a", Authority: "attestor-signer"}},
+		Attestors: []AttestorSpec{
+			{
+				ID: "attestor-a", Client: IBCClientRef{
+					Connection: "connection-ab", End: ConnectionEndA,
+				}, Authority: "attestor-signer",
+			},
+		},
 	}
 }
 
@@ -331,21 +361,25 @@ func resolvedMixedConnection(
 	attestor EVMAddress,
 ) *Connection {
 	a := &IBCClient{
-		id: "client-a", instance: instances["ibc-a"], locator: "client-a-onchain",
+		ref:         IBCClientRef{Connection: id, End: ConnectionEndA},
+		instance:    instances["ibc-a"],
+		locator:     "client-a-onchain",
 		lightClient: "0x2000000000000000000000000000000000000002", counterparty: "existing-client-b",
 		attestors: []EVMAddress{attestor}, minRequiredSignatures: 1,
 	}
 	b := &IBCClient{
-		id: "client-b", instance: instances["ibc-b"], locator: "existing-client-b",
+		ref:         IBCClientRef{Connection: id, End: ConnectionEndB},
+		instance:    instances["ibc-b"],
+		locator:     "existing-client-b",
 		lightClient: "0x3000000000000000000000000000000000000003", counterparty: "client-a-onchain",
 		minRequiredSignatures: 1,
 	}
 	return &Connection{id: id, a: a, b: b}
 }
 
-func mustIBCClient(t *testing.T, env *Environment, id ClientID) *IBCClient {
+func mustIBCClient(t *testing.T, env *Environment, ref IBCClientRef) *IBCClient {
 	t.Helper()
-	client, err := env.IBCClient(id)
+	client, err := env.IBCClient(ref)
 	require.NoError(t, err)
 	return client
 }

--- a/e2e/internal/harness/environment/protocol_start_test.go
+++ b/e2e/internal/harness/environment/protocol_start_test.go
@@ -147,7 +147,6 @@ func TestStartRealizesMixedProtocolGraphWithInjectedDrivers(t *testing.T) {
 		},
 		acquireConnection: func(_ context.Context, declaration ConnectionSpec, dependencies connectionDependencies, _ Runtime) (*Connection, error) {
 			require.EqualValues(t, 2, instancesReady.Load())
-			require.Equal(t, []AttestorSpec{spec.Attestors[0]}, dependencies.attestorSpecs[spec.Connections[0].ARef()])
 			connectionReady.Store(true)
 			return resolvedMixedConnection(
 				declaration.ID,
@@ -157,7 +156,7 @@ func TestStartRealizesMixedProtocolGraphWithInjectedDrivers(t *testing.T) {
 		},
 		acquireAttestor: func(_ context.Context, declaration AttestorSpec, dependencies attestorDependencies, _ Runtime, _ workspace) (attestorAcquisition, error) {
 			require.True(t, connectionReady.Load())
-			require.Equal(t, spec.Connections[0].ARef(), dependencies.client.Ref())
+			require.Equal(t, "client-a-onchain", dependencies.client.ID())
 			require.Equal(t, IBCInstanceID("ibc-b"), dependencies.observed.ID())
 			return attestorAcquisition{
 				attestor: &Attestor{
@@ -176,8 +175,7 @@ func TestStartRealizesMixedProtocolGraphWithInjectedDrivers(t *testing.T) {
 
 	connection, err := env.Connection("connection-ab")
 	require.NoError(t, err)
-	require.Equal(t, IBCClientLocator("existing-client-b"), connection.A().CounterpartyLocator())
-	require.Same(t, connection.A(), mustIBCClient(t, env, spec.Connections[0].ARef()))
+	require.Equal(t, "existing-client-b", connection.A().CounterpartyID())
 
 	attestor, err := env.Attestor("attestor-a")
 	require.NoError(t, err)
@@ -227,14 +225,37 @@ func TestConnectionFailureStopsBeforeAttestorsAndCleansChains(t *testing.T) {
 
 func TestResolvedClientsRejectAttestorSignerReuse(t *testing.T) {
 	const signer EVMAddress = "0x1000000000000000000000000000000000000001"
-	seen := make(map[EVMAddress]IBCClientRef)
+	seen := make(map[EVMAddress]string)
 	require.NoError(t, recordResolvedAttestorUse(seen, &IBCClient{
-		ref: IBCClientRef{Connection: "one", End: ConnectionEndA}, attestors: []EVMAddress{signer},
+		label: "one/A", attestors: []EVMAddress{signer},
 	}))
 	err := recordResolvedAttestorUse(seen, &IBCClient{
-		ref: IBCClientRef{Connection: "two", End: ConnectionEndA}, attestors: []EVMAddress{signer},
+		label: "two/A", attestors: []EVMAddress{signer},
 	})
 	require.ErrorContains(t, err, `attestor signer 0x1000000000000000000000000000000000000001 is reused`)
+}
+
+func TestPreparedClientsRejectExistingSignerReuseBeforeDeployment(t *testing.T) {
+	runtime := Runtime{Authorities: map[AuthorityID]EVMAuthority{
+		"new-signer": {PrivateKeyHex: testPrimaryPrivateKeyHex},
+	}}
+	account, err := runtime.evmAccount("new-signer")
+	require.NoError(t, err)
+	spec := Spec{Connections: []ConnectionSpec{{
+		ID: "connection-ab",
+		A:  ExistingClient{ID: "existing", IBCInstance: "ibc-a"},
+		B: NewClient{
+			IBCInstance: "ibc-b", Attestors: []AttestorSpec{{ID: "new", Authority: "new-signer"}},
+		},
+	}}}
+	dependencies := connectionDependencies{existingClients: map[string]*IBCClient{
+		"connection-ab/A": {
+			label: "connection-ab/A", attestors: []EVMAddress{EVMAddress(account.Address().Hex())},
+		},
+	}}
+
+	err = validatePreparedAttestorUse(spec, dependencies, runtime)
+	require.ErrorContains(t, err, "is reused by resolved IBC Clients")
 }
 
 func TestExistingClientRequiresDeclaredAttestorSignerMembership(t *testing.T) {
@@ -246,33 +267,31 @@ func TestExistingClientRequiresDeclaredAttestorSignerMembership(t *testing.T) {
 	require.NoError(t, err)
 	onChain := []common.Address{registered.Address()}
 
-	ref := IBCClientRef{Connection: "connection-ab", End: ConnectionEndA}
-	require.NoError(t, requireDeclaredAttestors(ref, onChain, []AttestorSpec{{
-		ID: "attestor-a", Client: ref, Authority: "registered",
+	label := "connection-ab/A"
+	require.NoError(t, requireDeclaredAttestors(label, onChain, []AttestorSpec{{
+		ID: "attestor-a", Authority: "registered",
 	}}, runtime))
-	err = requireDeclaredAttestors(ref, onChain, []AttestorSpec{{
-		ID: "attestor-a", Client: ref, Authority: "absent",
+	err = requireDeclaredAttestors(label, onChain, []AttestorSpec{{
+		ID: "attestor-a", Authority: "absent",
 	}}, runtime)
 	require.ErrorContains(t, err, `is not registered for existing IBC Client "connection-ab/A"`)
 }
 
-func TestClientLocatorUsesStableReference(t *testing.T) {
-	refA := IBCClientRef{Connection: "connection-ab", End: ConnectionEndA}
-	refB := IBCClientRef{Connection: "connection-ab", End: ConnectionEndB}
+func TestClientIDUsesStableConnectionEnd(t *testing.T) {
 	client := NewClient{IBCInstance: "ibc-a", Authority: "owner", MinRequiredSignatures: 1}
 
-	locator := clientLocator(refA, client)
+	id := clientID("connection-ab", "A", client)
 	require.Equal(
 		t,
-		IBCClientLocator("link-8b79fc938a76adf41b710b8f6a70dc97b29bef1e82ce7492840cdb8f4663512f"),
-		locator,
+		"link-8b79fc938a76adf41b710b8f6a70dc97b29bef1e82ce7492840cdb8f4663512f",
+		id,
 	)
-	require.Equal(t, locator, clientLocator(refA, NewClient{
+	require.Equal(t, id, clientID("connection-ab", "A", NewClient{
 		IBCInstance: "different-instance", Authority: "different-owner", MinRequiredSignatures: 2,
 	}))
-	require.NotEqual(t, locator, clientLocator(refB, client))
-	require.NotEqual(t, locator, clientLocator(IBCClientRef{Connection: "other", End: ConnectionEndA}, client))
-	require.Equal(t, IBCClientLocator("existing"), clientLocator(refA, ExistingClient{Locator: "existing"}))
+	require.NotEqual(t, id, clientID("connection-ab", "B", client))
+	require.NotEqual(t, id, clientID("other", "A", client))
+	require.Equal(t, "existing", clientID("connection-ab", "A", ExistingClient{ID: "existing"}))
 }
 
 func TestFailedAttestorStartRetainsPartialCleanup(t *testing.T) {
@@ -281,8 +300,8 @@ func TestFailedAttestorStartRetainsPartialCleanup(t *testing.T) {
 		"ibc-a": {id: "ibc-a"},
 		"ibc-b": {id: "ibc-b"},
 	}
-	clients := map[IBCClientRef]*IBCClient{
-		spec.Connections[0].ARef(): {ref: spec.Connections[0].ARef(), instance: instances["ibc-a"]},
+	connections := map[ConnectionID]*Connection{
+		"connection-ab": resolvedMixedConnection("connection-ab", instances, "signer"),
 	}
 	effects := &effectJournal{}
 	var releases atomic.Int32
@@ -291,8 +310,7 @@ func TestFailedAttestorStartRetainsPartialCleanup(t *testing.T) {
 	_, err := acquireAttestors(
 		t.Context(),
 		spec,
-		instances,
-		clients,
+		connections,
 		mixedProtocolRuntime(),
 		workspace{privateDir: t.TempDir(), diagnosticsDir: t.TempDir()},
 		drivers{acquireAttestor: func(
@@ -329,16 +347,12 @@ func mixedProtocolSpec() Spec {
 		},
 		Connections: []ConnectionSpec{{
 			ID: "connection-ab",
-			A:  NewClient{IBCInstance: "ibc-a", Authority: "client-owner", MinRequiredSignatures: 1},
-			B:  ExistingClient{IBCInstance: "ibc-b", Locator: "existing-client-b"},
-		}},
-		Attestors: []AttestorSpec{
-			{
-				ID: "attestor-a", Client: IBCClientRef{
-					Connection: "connection-ab", End: ConnectionEndA,
-				}, Authority: "attestor-signer",
+			A: NewClient{
+				IBCInstance: "ibc-a", Authority: "client-owner", MinRequiredSignatures: 1,
+				Attestors: []AttestorSpec{{ID: "attestor-a", Authority: "attestor-signer"}},
 			},
-		},
+			B: ExistingClient{IBCInstance: "ibc-b", ID: "existing-client-b"},
+		}},
 	}
 }
 
@@ -361,25 +375,18 @@ func resolvedMixedConnection(
 	attestor EVMAddress,
 ) *Connection {
 	a := &IBCClient{
-		ref:         IBCClientRef{Connection: id, End: ConnectionEndA},
+		label:       clientLabel(id, "A"),
 		instance:    instances["ibc-a"],
-		locator:     "client-a-onchain",
-		lightClient: "0x2000000000000000000000000000000000000002", counterparty: "existing-client-b",
+		id:          "client-a-onchain",
+		lightClient: "0x2000000000000000000000000000000000000002", counterpartyID: "existing-client-b",
 		attestors: []EVMAddress{attestor}, minRequiredSignatures: 1,
 	}
 	b := &IBCClient{
-		ref:         IBCClientRef{Connection: id, End: ConnectionEndB},
+		label:       clientLabel(id, "B"),
 		instance:    instances["ibc-b"],
-		locator:     "existing-client-b",
-		lightClient: "0x3000000000000000000000000000000000000003", counterparty: "client-a-onchain",
+		id:          "existing-client-b",
+		lightClient: "0x3000000000000000000000000000000000000003", counterpartyID: "client-a-onchain",
 		minRequiredSignatures: 1,
 	}
 	return &Connection{id: id, a: a, b: b}
-}
-
-func mustIBCClient(t *testing.T, env *Environment, ref IBCClientRef) *IBCClient {
-	t.Helper()
-	client, err := env.IBCClient(ref)
-	require.NoError(t, err)
-	return client
 }

--- a/e2e/internal/harness/environment/realize_protocol.go
+++ b/e2e/internal/harness/environment/realize_protocol.go
@@ -23,9 +23,8 @@ import (
 
 type connectionDependencies struct {
 	instances       map[IBCInstanceID]*IBCInstance
-	attestorSpecs   map[IBCClientRef][]AttestorSpec
-	existingClients map[IBCClientRef]*IBCClient
-	preparedClients map[IBCClientRef]*solidityibc.PreparedClient
+	existingClients map[string]*IBCClient
+	preparedClients map[string]*solidityibc.PreparedClient
 }
 
 type attestorDependencies struct {
@@ -68,52 +67,63 @@ func acquireConnections(
 	d drivers,
 ) (
 	map[ConnectionID]*Connection,
-	map[IBCClientRef]*IBCClient,
 	error,
 ) {
 	connections := make(map[ConnectionID]*Connection, len(spec.Connections))
-	clients := make(map[IBCClientRef]*IBCClient, 2*len(spec.Connections))
-	attestorUse := make(map[EVMAddress]IBCClientRef)
-	attestorSpecsByClient := make(map[IBCClientRef][]AttestorSpec)
-	for _, declaration := range spec.Attestors {
-		attestorSpecsByClient[declaration.Client] = append(
-			attestorSpecsByClient[declaration.Client],
-			declaration,
-		)
-	}
-	dependencies := connectionDependencies{
-		instances: instances, attestorSpecs: attestorSpecsByClient,
-	}
+	attestorUse := make(map[EVMAddress]string)
+	dependencies := connectionDependencies{instances: instances}
 	if d.prepareConnections != nil {
 		prepared, err := d.prepareConnections(ctx, spec, dependencies, runtime)
 		if err != nil {
-			return nil, nil, fmt.Errorf("prepare IBC Connections failed: %w", err)
+			return nil, fmt.Errorf("prepare IBC Connections failed: %w", err)
 		}
 		dependencies = prepared
+		if err := validatePreparedAttestorUse(spec, dependencies, runtime); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, declaration := range spec.Connections {
 		connection, err := d.acquireConnection(ctx, declaration, dependencies, runtime)
 		if err != nil {
-			return nil, nil, fmt.Errorf("start IBC Connection %q failed: %w", declaration.ID, err)
+			return nil, fmt.Errorf("start IBC Connection %q failed: %w", declaration.ID, err)
 		}
 		if connection == nil || connection.a == nil || connection.b == nil {
-			return nil, nil, fmt.Errorf(
+			return nil, fmt.Errorf(
 				"environment: IBC Connection %q adapter returned an incomplete resolved value",
 				declaration.ID,
 			)
 		}
 		if err := recordResolvedAttestorUse(attestorUse, connection.a, connection.b); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		connections[declaration.ID] = connection
-		clients[connection.a.ref] = connection.a
-		clients[connection.b.ref] = connection.b
 	}
-	return connections, clients, nil
+	return connections, nil
 }
 
-func recordResolvedAttestorUse(seen map[EVMAddress]IBCClientRef, clients ...*IBCClient) error {
+func validatePreparedAttestorUse(spec Spec, dependencies connectionDependencies, runtime Runtime) error {
+	seen := make(map[EVMAddress]string)
+	for _, connection := range spec.Connections {
+		for _, end := range connection.ends() {
+			label := clientLabel(connection.ID, end.label)
+			client := dependencies.existingClients[label]
+			if client == nil {
+				client = &IBCClient{label: label}
+				for _, attestor := range end.declaration.clientAttestors() {
+					account, _ := runtime.evmAccount(attestor.Authority)
+					client.attestors = append(client.attestors, EVMAddress(account.Address().Hex()))
+				}
+			}
+			if err := recordResolvedAttestorUse(seen, client); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func recordResolvedAttestorUse(seen map[EVMAddress]string, clients ...*IBCClient) error {
 	for _, client := range clients {
 		for _, address := range client.attestors {
 			if previous, exists := seen[address]; exists {
@@ -121,10 +131,10 @@ func recordResolvedAttestorUse(seen map[EVMAddress]IBCClientRef, clients ...*IBC
 					"attestor signer %s is reused by resolved IBC Clients %q and %q",
 					address,
 					previous,
-					client.ref,
+					client.label,
 				)
 			}
-			seen[address] = client.ref
+			seen[address] = client.label
 		}
 	}
 	return nil
@@ -133,8 +143,7 @@ func recordResolvedAttestorUse(seen map[EVMAddress]IBCClientRef, clients ...*IBC
 func acquireAttestors(
 	ctx context.Context,
 	spec Spec,
-	instances map[IBCInstanceID]*IBCInstance,
-	clients map[IBCClientRef]*IBCClient,
+	connections map[ConnectionID]*Connection,
 	runtime Runtime,
 	ws workspace,
 	d drivers,
@@ -143,20 +152,37 @@ func acquireAttestors(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	acquired := make([]attestorAcquisition, len(spec.Attestors))
-	errs := make([]error, len(spec.Attestors))
+	type attestorJob struct {
+		declaration  AttestorSpec
+		dependencies attestorDependencies
+	}
+	var jobs []attestorJob
+	for _, declaration := range spec.Connections {
+		connection := connections[declaration.ID]
+		for _, attestor := range declaration.A.clientAttestors() {
+			jobs = append(jobs, attestorJob{
+				declaration: attestor,
+				dependencies: attestorDependencies{
+					client: connection.a, observed: connection.b.instance,
+				},
+			})
+		}
+		for _, attestor := range declaration.B.clientAttestors() {
+			jobs = append(jobs, attestorJob{
+				declaration: attestor,
+				dependencies: attestorDependencies{
+					client: connection.b, observed: connection.a.instance,
+				},
+			})
+		}
+	}
+
+	acquired := make([]attestorAcquisition, len(jobs))
+	errs := make([]error, len(jobs))
 	var wg sync.WaitGroup
-	for i, declaration := range spec.Attestors {
+	for i, job := range jobs {
 		wg.Go(func() {
-			observed, err := observedInstanceForClient(spec.Connections, declaration.Client, instances)
-			if err != nil {
-				errs[i] = err
-				cancel()
-				return
-			}
-			acquisition, err := d.acquireAttestor(ctx, declaration, attestorDependencies{
-				client: clients[declaration.Client], observed: observed,
-			}, runtime, ws)
+			acquisition, err := d.acquireAttestor(ctx, job.declaration, job.dependencies, runtime, ws)
 			if err != nil {
 				if acquisition.release != nil {
 					effects.append(cleanupEffect{
@@ -164,14 +190,14 @@ func acquireAttestors(
 						release:     acquisition.release,
 					})
 				}
-				errs[i] = fmt.Errorf("start Attestor %q failed: %w", declaration.ID, err)
+				errs[i] = fmt.Errorf("start Attestor %q failed: %w", job.declaration.ID, err)
 				cancel()
 				return
 			}
 			if acquisition.attestor == nil || acquisition.release == nil {
 				errs[i] = fmt.Errorf(
 					"environment: Attestor %q adapter returned an incomplete acquisition",
-					declaration.ID,
+					job.declaration.ID,
 				)
 				cancel()
 				return
@@ -190,28 +216,9 @@ func acquireAttestors(
 	}
 	attestors := make(map[AttestorID]*Attestor, len(acquired))
 	for i, acquisition := range acquired {
-		attestors[spec.Attestors[i].ID] = acquisition.attestor
+		attestors[jobs[i].declaration.ID] = acquisition.attestor
 	}
 	return attestors, nil
-}
-
-func observedInstanceForClient(
-	connections []ConnectionSpec,
-	ref IBCClientRef,
-	instances map[IBCInstanceID]*IBCInstance,
-) (*IBCInstance, error) {
-	for _, connection := range connections {
-		if connection.ID != ref.Connection {
-			continue
-		}
-		switch ref.End {
-		case ConnectionEndA:
-			return instances[clientIdentity(connection.B).IBCInstance], nil
-		case ConnectionEndB:
-			return instances[clientIdentity(connection.A).IBCInstance], nil
-		}
-	}
-	return nil, fmt.Errorf("environment: no counterparty IBC Instance for Client %q", ref)
 }
 
 func acquireIBCInstance(
@@ -271,54 +278,57 @@ func prepareConnections(
 	dependencies connectionDependencies,
 	runtime Runtime,
 ) (connectionDependencies, error) {
-	dependencies.existingClients = make(map[IBCClientRef]*IBCClient)
-	dependencies.preparedClients = make(map[IBCClientRef]*solidityibc.PreparedClient)
+	dependencies.existingClients = make(map[string]*IBCClient)
+	dependencies.preparedClients = make(map[string]*solidityibc.PreparedClient)
 
 	for _, connection := range spec.Connections {
 		ends := connection.ends()
-		locators := map[ConnectionEnd]IBCClientLocator{
-			ConnectionEndA: clientLocator(connection.ARef(), connection.A),
-			ConnectionEndB: clientLocator(connection.BRef(), connection.B),
+		clientIDs := map[string]string{
+			"A": clientID(connection.ID, "A", connection.A),
+			"B": clientID(connection.ID, "B", connection.B),
 		}
 		for index, end := range ends {
 			counterpartyEnd := ends[1-index]
-			identity := clientIdentity(end.declaration)
+			label := clientLabel(connection.ID, end.label)
+			instanceID := clientIBCInstance(end.declaration)
 			switch client := end.declaration.(type) {
 			case ExistingClient:
 				resolved, err := acquireIBCClient(
 					ctx,
-					end.ref,
+					connection.ID,
+					end.label,
 					client,
-					locators,
+					clientIDs,
 					dependencies,
 					runtime,
 				)
 				if err != nil {
 					return dependencies, fmt.Errorf(
 						"prepare existing IBC Client %q: %w",
-						end.ref,
+						label,
 						err,
 					)
 				}
-				dependencies.existingClients[end.ref] = resolved
+				dependencies.existingClients[label] = resolved
 			case NewClient:
-				instance := dependencies.instances[identity.IBCInstance]
+				instance := dependencies.instances[instanceID]
 				setup, err := solidityIBCSetup(ctx, instance.chain)
 				if err != nil {
 					return dependencies, err
 				}
 				authority, _ := runtime.evmAccount(client.Authority)
-				counterparty := clientIdentity(counterpartyEnd.declaration)
-				header, err := evmHeader(ctx, dependencies.instances[counterparty.IBCInstance].chain)
+				counterparty := clientIBCInstance(counterpartyEnd.declaration)
+				header, err := evmHeader(ctx, dependencies.instances[counterparty].chain)
 				if err != nil {
 					return dependencies, fmt.Errorf(
 						"prepare IBC Client %q counterparty header: %w",
-						end.ref,
+						label,
 						err,
 					)
 				}
-				attestors := make([]common.Address, 0, len(dependencies.attestorSpecs[end.ref]))
-				for _, declaration := range dependencies.attestorSpecs[end.ref] {
+				attestorSpecs := end.declaration.clientAttestors()
+				attestors := make([]common.Address, 0, len(attestorSpecs))
+				for _, declaration := range attestorSpecs {
 					account, _ := runtime.evmAccount(declaration.Authority)
 					attestors = append(attestors, account.Address())
 				}
@@ -327,8 +337,8 @@ func prepareConnections(
 					authority,
 					common.HexToAddress(string(instance.locator)),
 					solidityibc.AttestationClientConfig{
-						ID:                    string(locators[end.ref.End]),
-						CounterpartyClientID:  string(locators[counterpartyEnd.ref.End]),
+						ID:                    clientIDs[end.label],
+						CounterpartyClientID:  clientIDs[counterpartyEnd.label],
 						Attestors:             attestors,
 						MinRequiredSignatures: client.MinRequiredSignatures,
 						InitialHeight:         header.Number.Uint64(),
@@ -336,9 +346,9 @@ func prepareConnections(
 					},
 				)
 				if err != nil {
-					return dependencies, fmt.Errorf("prepare IBC Client %q: %w", end.ref, err)
+					return dependencies, fmt.Errorf("prepare IBC Client %q: %w", label, err)
 				}
-				dependencies.preparedClients[end.ref] = prepared
+				dependencies.preparedClients[label] = prepared
 			}
 		}
 	}
@@ -351,24 +361,24 @@ func acquireConnection(
 	dependencies connectionDependencies,
 	runtime Runtime,
 ) (*Connection, error) {
-	locators := map[ConnectionEnd]IBCClientLocator{
-		ConnectionEndA: clientLocator(declaration.ARef(), declaration.A),
-		ConnectionEndB: clientLocator(declaration.BRef(), declaration.B),
+	clientIDs := map[string]string{
+		"A": clientID(declaration.ID, "A", declaration.A),
+		"B": clientID(declaration.ID, "B", declaration.B),
 	}
 
 	a, err := acquireIBCClient(
-		ctx, declaration.ARef(), declaration.A, locators, dependencies, runtime,
+		ctx, declaration.ID, "A", declaration.A, clientIDs, dependencies, runtime,
 	)
 	if err != nil {
 		return nil, err
 	}
 	b, err := acquireIBCClient(
-		ctx, declaration.BRef(), declaration.B, locators, dependencies, runtime,
+		ctx, declaration.ID, "B", declaration.B, clientIDs, dependencies, runtime,
 	)
 	if err != nil {
 		return nil, err
 	}
-	if a.counterparty != b.locator || b.counterparty != a.locator {
+	if a.counterpartyID != b.id || b.counterpartyID != a.id {
 		return nil, fmt.Errorf("resolved IBC Clients are not reciprocal")
 	}
 	return &Connection{id: declaration.ID, a: a, b: b}, nil
@@ -376,16 +386,17 @@ func acquireConnection(
 
 func acquireIBCClient(
 	ctx context.Context,
-	ref IBCClientRef,
+	connectionID ConnectionID,
+	end string,
 	declaration ClientSpec,
-	locators map[ConnectionEnd]IBCClientLocator,
+	clientIDs map[string]string,
 	dependencies connectionDependencies,
 	runtime Runtime,
 ) (*IBCClient, error) {
-	identity := clientIdentity(declaration)
-	instance := dependencies.instances[identity.IBCInstance]
-	counterpartyLocator := locators[counterpartyEnd(ref.End)]
-	if resolved := dependencies.existingClients[ref]; resolved != nil {
+	instance := dependencies.instances[clientIBCInstance(declaration)]
+	label := clientLabel(connectionID, end)
+	counterpartyID := clientIDs[counterpartyEnd(end)]
+	if resolved := dependencies.existingClients[label]; resolved != nil {
 		return resolved, nil
 	}
 
@@ -402,31 +413,31 @@ func acquireIBCClient(
 		resolved, err = setup.AttachClient(
 			ctx,
 			common.HexToAddress(string(instance.locator)),
-			string(client.Locator),
-			string(counterpartyLocator),
+			client.ID,
+			counterpartyID,
 		)
 		if err != nil {
 			return nil, err
 		}
 		if attestorErr := requireDeclaredAttestors(
-			ref,
+			label,
 			resolved.Attestors,
-			dependencies.attestorSpecs[ref],
+			declaration.clientAttestors(),
 			runtime,
 		); attestorErr != nil {
 			return nil, attestorErr
 		}
 	case NewClient:
-		prepared := dependencies.preparedClients[ref]
+		prepared := dependencies.preparedClients[label]
 		if prepared == nil {
-			return nil, fmt.Errorf("IBC Client %q was not prepared", ref)
+			return nil, fmt.Errorf("IBC Client %q was not prepared", label)
 		}
 		authority, err := runtime.evmAccount(client.Authority)
 		if err != nil {
 			return nil, err
 		}
 		if fundingErr := ensureProtocolAuthorityFunded(ctx, instance.chain, authority); fundingErr != nil {
-			return nil, fmt.Errorf("fund IBC Client %q authority: %w", ref, fundingErr)
+			return nil, fmt.Errorf("fund IBC Client %q authority: %w", label, fundingErr)
 		}
 		resolved, err = prepared.Deploy(ctx)
 		if err != nil {
@@ -441,11 +452,11 @@ func acquireIBCClient(
 		attestors[i] = EVMAddress(address.Hex())
 	}
 	return &IBCClient{
-		ref:                   ref,
+		label:                 label,
 		instance:              instance,
-		locator:               IBCClientLocator(resolved.ID),
+		id:                    resolved.ID,
 		lightClient:           EVMAddress(resolved.Address.Hex()),
-		counterparty:          IBCClientLocator(resolved.CounterpartyClientID),
+		counterpartyID:        resolved.CounterpartyClientID,
 		attestors:             attestors,
 		minRequiredSignatures: resolved.MinRequiredSignatures,
 	}, nil
@@ -468,11 +479,11 @@ func ensureProtocolAuthorityFunded(ctx context.Context, chain *Chain, authority 
 	return funding.EnsureEOABalance(ctx, authority.Address(), minimum)
 }
 
-func counterpartyEnd(end ConnectionEnd) ConnectionEnd {
-	if end == ConnectionEndA {
-		return ConnectionEndB
+func counterpartyEnd(end string) string {
+	if end == "A" {
+		return "B"
 	}
-	return ConnectionEndA
+	return "A"
 }
 
 func acquireAttestor(
@@ -559,16 +570,16 @@ func evmHeader(ctx context.Context, chain *Chain) (*types.Header, error) {
 	return header, err
 }
 
-func clientLocator(ref IBCClientRef, declaration ClientSpec) IBCClientLocator {
+func clientID(connectionID ConnectionID, end string, declaration ClientSpec) string {
 	if existing, ok := declaration.(ExistingClient); ok {
-		return existing.Locator
+		return existing.ID
 	}
-	hash := sha256.Sum256([]byte("environment-ibc-client-v1\x00" + string(ref.Connection) + "\x00" + ref.End.String()))
-	return IBCClientLocator("link-" + hex.EncodeToString(hash[:]))
+	hash := sha256.Sum256([]byte("environment-ibc-client-v1\x00" + string(connectionID) + "\x00" + end))
+	return "link-" + hex.EncodeToString(hash[:])
 }
 
 func requireDeclaredAttestors(
-	ref IBCClientRef,
+	label string,
 	onChain []common.Address,
 	declarations []AttestorSpec,
 	runtime Runtime,
@@ -584,7 +595,7 @@ func requireDeclaredAttestors(
 				"Attestor %q signer %s is not registered for existing IBC Client %q",
 				declaration.ID,
 				account.Address(),
-				ref,
+				label,
 			)
 		}
 	}

--- a/e2e/internal/harness/environment/realize_protocol.go
+++ b/e2e/internal/harness/environment/realize_protocol.go
@@ -23,9 +23,9 @@ import (
 
 type connectionDependencies struct {
 	instances       map[IBCInstanceID]*IBCInstance
-	attestorSpecs   map[ClientID][]AttestorSpec
-	existingClients map[ClientID]*IBCClient
-	preparedClients map[ClientID]*solidityibc.PreparedClient
+	attestorSpecs   map[IBCClientRef][]AttestorSpec
+	existingClients map[IBCClientRef]*IBCClient
+	preparedClients map[IBCClientRef]*solidityibc.PreparedClient
 }
 
 type attestorDependencies struct {
@@ -68,13 +68,13 @@ func acquireConnections(
 	d drivers,
 ) (
 	map[ConnectionID]*Connection,
-	map[ClientID]*IBCClient,
+	map[IBCClientRef]*IBCClient,
 	error,
 ) {
 	connections := make(map[ConnectionID]*Connection, len(spec.Connections))
-	clients := make(map[ClientID]*IBCClient, 2*len(spec.Connections))
-	attestorUse := make(map[EVMAddress]ClientID)
-	attestorSpecsByClient := make(map[ClientID][]AttestorSpec)
+	clients := make(map[IBCClientRef]*IBCClient, 2*len(spec.Connections))
+	attestorUse := make(map[EVMAddress]IBCClientRef)
+	attestorSpecsByClient := make(map[IBCClientRef][]AttestorSpec)
 	for _, declaration := range spec.Attestors {
 		attestorSpecsByClient[declaration.Client] = append(
 			attestorSpecsByClient[declaration.Client],
@@ -107,13 +107,13 @@ func acquireConnections(
 			return nil, nil, err
 		}
 		connections[declaration.ID] = connection
-		clients[connection.a.id] = connection.a
-		clients[connection.b.id] = connection.b
+		clients[connection.a.ref] = connection.a
+		clients[connection.b.ref] = connection.b
 	}
 	return connections, clients, nil
 }
 
-func recordResolvedAttestorUse(seen map[EVMAddress]ClientID, clients ...*IBCClient) error {
+func recordResolvedAttestorUse(seen map[EVMAddress]IBCClientRef, clients ...*IBCClient) error {
 	for _, client := range clients {
 		for _, address := range client.attestors {
 			if previous, exists := seen[address]; exists {
@@ -121,10 +121,10 @@ func recordResolvedAttestorUse(seen map[EVMAddress]ClientID, clients ...*IBCClie
 					"attestor signer %s is reused by resolved IBC Clients %q and %q",
 					address,
 					previous,
-					client.id,
+					client.ref,
 				)
 			}
-			seen[address] = client.id
+			seen[address] = client.ref
 		}
 	}
 	return nil
@@ -134,7 +134,7 @@ func acquireAttestors(
 	ctx context.Context,
 	spec Spec,
 	instances map[IBCInstanceID]*IBCInstance,
-	clients map[ClientID]*IBCClient,
+	clients map[IBCClientRef]*IBCClient,
 	runtime Runtime,
 	ws workspace,
 	d drivers,
@@ -197,20 +197,21 @@ func acquireAttestors(
 
 func observedInstanceForClient(
 	connections []ConnectionSpec,
-	clientID ClientID,
+	ref IBCClientRef,
 	instances map[IBCInstanceID]*IBCInstance,
 ) (*IBCInstance, error) {
 	for _, connection := range connections {
-		a := clientIdentity(connection.A)
-		b := clientIdentity(connection.B)
-		switch clientID {
-		case a.ID:
-			return instances[b.IBCInstance], nil
-		case b.ID:
-			return instances[a.IBCInstance], nil
+		if connection.ID != ref.Connection {
+			continue
+		}
+		switch ref.End {
+		case ConnectionEndA:
+			return instances[clientIdentity(connection.B).IBCInstance], nil
+		case ConnectionEndB:
+			return instances[clientIdentity(connection.A).IBCInstance], nil
 		}
 	}
-	return nil, fmt.Errorf("environment: no counterparty IBC Instance for Client %q", clientID)
+	return nil, fmt.Errorf("environment: no counterparty IBC Instance for Client %q", ref)
 }
 
 func acquireIBCInstance(
@@ -270,29 +271,23 @@ func prepareConnections(
 	dependencies connectionDependencies,
 	runtime Runtime,
 ) (connectionDependencies, error) {
-	dependencies.existingClients = make(map[ClientID]*IBCClient)
-	dependencies.preparedClients = make(map[ClientID]*solidityibc.PreparedClient)
+	dependencies.existingClients = make(map[IBCClientRef]*IBCClient)
+	dependencies.preparedClients = make(map[IBCClientRef]*solidityibc.PreparedClient)
 
 	for _, connection := range spec.Connections {
-		ends := []struct {
-			label        string
-			declaration  ClientSpec
-			counterparty ClientSpec
-		}{
-			{label: "A", declaration: connection.A, counterparty: connection.B},
-			{label: "B", declaration: connection.B, counterparty: connection.A},
+		ends := connection.ends()
+		locators := map[ConnectionEnd]IBCClientLocator{
+			ConnectionEndA: clientLocator(connection.ARef(), connection.A),
+			ConnectionEndB: clientLocator(connection.BRef(), connection.B),
 		}
-		locators := map[string]IBCClientLocator{
-			"A": clientLocator(connection.ID, "A", connection.A),
-			"B": clientLocator(connection.ID, "B", connection.B),
-		}
-		for _, end := range ends {
+		for index, end := range ends {
+			counterpartyEnd := ends[1-index]
 			identity := clientIdentity(end.declaration)
 			switch client := end.declaration.(type) {
 			case ExistingClient:
 				resolved, err := acquireIBCClient(
 					ctx,
-					end.label,
+					end.ref,
 					client,
 					locators,
 					dependencies,
@@ -301,11 +296,11 @@ func prepareConnections(
 				if err != nil {
 					return dependencies, fmt.Errorf(
 						"prepare existing IBC Client %q: %w",
-						identity.ID,
+						end.ref,
 						err,
 					)
 				}
-				dependencies.existingClients[identity.ID] = resolved
+				dependencies.existingClients[end.ref] = resolved
 			case NewClient:
 				instance := dependencies.instances[identity.IBCInstance]
 				setup, err := solidityIBCSetup(ctx, instance.chain)
@@ -313,17 +308,17 @@ func prepareConnections(
 					return dependencies, err
 				}
 				authority, _ := runtime.evmAccount(client.Authority)
-				counterparty := clientIdentity(end.counterparty)
+				counterparty := clientIdentity(counterpartyEnd.declaration)
 				header, err := evmHeader(ctx, dependencies.instances[counterparty.IBCInstance].chain)
 				if err != nil {
 					return dependencies, fmt.Errorf(
 						"prepare IBC Client %q counterparty header: %w",
-						identity.ID,
+						end.ref,
 						err,
 					)
 				}
-				attestors := make([]common.Address, 0, len(dependencies.attestorSpecs[identity.ID]))
-				for _, declaration := range dependencies.attestorSpecs[identity.ID] {
+				attestors := make([]common.Address, 0, len(dependencies.attestorSpecs[end.ref]))
+				for _, declaration := range dependencies.attestorSpecs[end.ref] {
 					account, _ := runtime.evmAccount(declaration.Authority)
 					attestors = append(attestors, account.Address())
 				}
@@ -332,8 +327,8 @@ func prepareConnections(
 					authority,
 					common.HexToAddress(string(instance.locator)),
 					solidityibc.AttestationClientConfig{
-						ID:                    string(locators[end.label]),
-						CounterpartyClientID:  string(locators[counterpartyEnd(end.label)]),
+						ID:                    string(locators[end.ref.End]),
+						CounterpartyClientID:  string(locators[counterpartyEnd.ref.End]),
 						Attestors:             attestors,
 						MinRequiredSignatures: client.MinRequiredSignatures,
 						InitialHeight:         header.Number.Uint64(),
@@ -341,9 +336,9 @@ func prepareConnections(
 					},
 				)
 				if err != nil {
-					return dependencies, fmt.Errorf("prepare IBC Client %q: %w", identity.ID, err)
+					return dependencies, fmt.Errorf("prepare IBC Client %q: %w", end.ref, err)
 				}
-				dependencies.preparedClients[identity.ID] = prepared
+				dependencies.preparedClients[end.ref] = prepared
 			}
 		}
 	}
@@ -356,19 +351,19 @@ func acquireConnection(
 	dependencies connectionDependencies,
 	runtime Runtime,
 ) (*Connection, error) {
-	locators := map[string]IBCClientLocator{
-		"A": clientLocator(declaration.ID, "A", declaration.A),
-		"B": clientLocator(declaration.ID, "B", declaration.B),
+	locators := map[ConnectionEnd]IBCClientLocator{
+		ConnectionEndA: clientLocator(declaration.ARef(), declaration.A),
+		ConnectionEndB: clientLocator(declaration.BRef(), declaration.B),
 	}
 
 	a, err := acquireIBCClient(
-		ctx, "A", declaration.A, locators, dependencies, runtime,
+		ctx, declaration.ARef(), declaration.A, locators, dependencies, runtime,
 	)
 	if err != nil {
 		return nil, err
 	}
 	b, err := acquireIBCClient(
-		ctx, "B", declaration.B, locators, dependencies, runtime,
+		ctx, declaration.BRef(), declaration.B, locators, dependencies, runtime,
 	)
 	if err != nil {
 		return nil, err
@@ -381,17 +376,16 @@ func acquireConnection(
 
 func acquireIBCClient(
 	ctx context.Context,
-	end string,
+	ref IBCClientRef,
 	declaration ClientSpec,
-	locators map[string]IBCClientLocator,
+	locators map[ConnectionEnd]IBCClientLocator,
 	dependencies connectionDependencies,
 	runtime Runtime,
 ) (*IBCClient, error) {
 	identity := clientIdentity(declaration)
 	instance := dependencies.instances[identity.IBCInstance]
-	counterpartyEnd := counterpartyEnd(end)
-	counterpartyLocator := locators[counterpartyEnd]
-	if resolved := dependencies.existingClients[identity.ID]; resolved != nil {
+	counterpartyLocator := locators[counterpartyEnd(ref.End)]
+	if resolved := dependencies.existingClients[ref]; resolved != nil {
 		return resolved, nil
 	}
 
@@ -415,24 +409,24 @@ func acquireIBCClient(
 			return nil, err
 		}
 		if attestorErr := requireDeclaredAttestors(
-			identity.ID,
+			ref,
 			resolved.Attestors,
-			dependencies.attestorSpecs[identity.ID],
+			dependencies.attestorSpecs[ref],
 			runtime,
 		); attestorErr != nil {
 			return nil, attestorErr
 		}
 	case NewClient:
-		prepared := dependencies.preparedClients[identity.ID]
+		prepared := dependencies.preparedClients[ref]
 		if prepared == nil {
-			return nil, fmt.Errorf("IBC Client %q was not prepared", identity.ID)
+			return nil, fmt.Errorf("IBC Client %q was not prepared", ref)
 		}
 		authority, err := runtime.evmAccount(client.Authority)
 		if err != nil {
 			return nil, err
 		}
 		if fundingErr := ensureProtocolAuthorityFunded(ctx, instance.chain, authority); fundingErr != nil {
-			return nil, fmt.Errorf("fund IBC Client %q authority: %w", identity.ID, fundingErr)
+			return nil, fmt.Errorf("fund IBC Client %q authority: %w", ref, fundingErr)
 		}
 		resolved, err = prepared.Deploy(ctx)
 		if err != nil {
@@ -447,7 +441,7 @@ func acquireIBCClient(
 		attestors[i] = EVMAddress(address.Hex())
 	}
 	return &IBCClient{
-		id:                    identity.ID,
+		ref:                   ref,
 		instance:              instance,
 		locator:               IBCClientLocator(resolved.ID),
 		lightClient:           EVMAddress(resolved.Address.Hex()),
@@ -474,11 +468,11 @@ func ensureProtocolAuthorityFunded(ctx context.Context, chain *Chain, authority 
 	return funding.EnsureEOABalance(ctx, authority.Address(), minimum)
 }
 
-func counterpartyEnd(end string) string {
-	if end == "A" {
-		return "B"
+func counterpartyEnd(end ConnectionEnd) ConnectionEnd {
+	if end == ConnectionEndA {
+		return ConnectionEndB
 	}
-	return "A"
+	return ConnectionEndA
 }
 
 func acquireAttestor(
@@ -565,19 +559,16 @@ func evmHeader(ctx context.Context, chain *Chain) (*types.Header, error) {
 	return header, err
 }
 
-func clientLocator(connectionID ConnectionID, end string, declaration ClientSpec) IBCClientLocator {
+func clientLocator(ref IBCClientRef, declaration ClientSpec) IBCClientLocator {
 	if existing, ok := declaration.(ExistingClient); ok {
 		return existing.Locator
 	}
-	client := clientIdentity(declaration)
-	hash := sha256.Sum256(
-		[]byte(string(connectionID) + "\x00" + end + "\x00" + string(client.ID) + "\x00" + string(client.IBCInstance)),
-	)
+	hash := sha256.Sum256([]byte("environment-ibc-client-v1\x00" + string(ref.Connection) + "\x00" + ref.End.String()))
 	return IBCClientLocator("link-" + hex.EncodeToString(hash[:]))
 }
 
 func requireDeclaredAttestors(
-	clientID ClientID,
+	ref IBCClientRef,
 	onChain []common.Address,
 	declarations []AttestorSpec,
 	runtime Runtime,
@@ -593,7 +584,7 @@ func requireDeclaredAttestors(
 				"Attestor %q signer %s is not registered for existing IBC Client %q",
 				declaration.ID,
 				account.Address(),
-				clientID,
+				ref,
 			)
 		}
 	}

--- a/e2e/internal/harness/environment/spec.go
+++ b/e2e/internal/harness/environment/spec.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"slices"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // Graph identities are distinct types so references to different resource
@@ -24,48 +26,7 @@ type (
 	// Existing resource locators are authored identifiers whose concrete
 	// interpretation belongs to realization, not to the desired graph.
 	IBCInstanceLocator string
-	IBCClientLocator   string
 )
-
-// ConnectionEnd identifies one side of an IBC Connection.
-type ConnectionEnd uint8
-
-const (
-	ConnectionEndA ConnectionEnd = iota + 1
-	ConnectionEndB
-)
-
-func (e ConnectionEnd) String() string {
-	switch e {
-	case ConnectionEndA:
-		return "A"
-	case ConnectionEndB:
-		return "B"
-	default:
-		return fmt.Sprintf("ConnectionEnd(%d)", e)
-	}
-}
-
-// IBCClientRef is the stable graph identity of one Connection end. It is
-// derived from graph structure rather than supplied as a separate client name.
-type IBCClientRef struct {
-	Connection ConnectionID
-	End        ConnectionEnd
-}
-
-func (r IBCClientRef) String() string {
-	return fmt.Sprintf("%s/%s", r.Connection, r.End)
-}
-
-func (r IBCClientRef) validate() error {
-	if err := requireValue("IBC Client reference connection", string(r.Connection)); err != nil {
-		return err
-	}
-	if r.End != ConnectionEndA && r.End != ConnectionEndB {
-		return errorsf("IBC Client reference %q has invalid Connection end %s", r, r.End)
-	}
-	return nil
-}
 
 // Spec is the desired IBC resource graph. Typed references determine dependency
 // order; protocol declarations retain authored order while Chains start concurrently.
@@ -73,15 +34,18 @@ type Spec struct {
 	Chains       []ChainSpec
 	IBCInstances []IBCInstanceSpec
 	Connections  []ConnectionSpec
-	Attestors    []AttestorSpec
 }
 
 func (s Spec) snapshot() Spec {
 	out := Spec{
 		Chains:       slices.Clone(s.Chains),
 		IBCInstances: slices.Clone(s.IBCInstances),
-		Connections:  slices.Clone(s.Connections),
-		Attestors:    slices.Clone(s.Attestors),
+		Connections:  make([]ConnectionSpec, len(s.Connections)),
+	}
+	for i, connection := range s.Connections {
+		connection.A = snapshotClient(connection.A)
+		connection.B = snapshotClient(connection.B)
+		out.Connections[i] = connection
 	}
 	return out
 }
@@ -250,17 +214,12 @@ func (i ExistingIBCInstance) validateIBCInstance() error {
 	return requireValue(fmt.Sprintf("IBC Instance %q locator", i.ID), string(i.Locator))
 }
 
-// clientIdentityValue is the common internal identity carried by both Client
-// declaration variants.
-type clientIdentityValue struct {
-	IBCInstance IBCInstanceID
-}
-
 // ClientSpec is sealed because creating an IBC Client and using explicitly
 // identified existing state have different durability and mutation semantics.
 // A Connection may combine either variant at each end.
 type ClientSpec interface {
 	clientSpec()
+	clientAttestors() []AttestorSpec
 }
 
 // NewClient declares an attestation IBC Client to create on its host IBC
@@ -271,128 +230,137 @@ type NewClient struct {
 	IBCInstance           IBCInstanceID
 	Authority             AuthorityID
 	MinRequiredSignatures uint8
+	Attestors             []AttestorSpec
 }
 
-func (NewClient) clientSpec() {}
+func (NewClient) clientSpec()                       {}
+func (c NewClient) clientAttestors() []AttestorSpec { return c.Attestors }
 
-// ExistingClient identifies an already-created IBC Client.
+// ExistingClient identifies an already-created IBC Client by its protocol ID.
 type ExistingClient struct {
 	IBCInstance IBCInstanceID
-	Locator     IBCClientLocator
+	ID          string
+	Attestors   []AttestorSpec
 }
 
-func (ExistingClient) clientSpec() {}
+func (ExistingClient) clientSpec()                       {}
+func (c ExistingClient) clientAttestors() []AttestorSpec { return c.Attestors }
+
+func snapshotClient(spec ClientSpec) ClientSpec {
+	switch client := spec.(type) {
+	case NewClient:
+		client.Attestors = slices.Clone(client.Attestors)
+		return client
+	case ExistingClient:
+		client.Attestors = slices.Clone(client.Attestors)
+		return client
+	default:
+		return spec
+	}
+}
 
 // ConnectionSpec is a reciprocal pair of IBC Clients. Each end independently
-// declares whether the authored Client identity will be created or resolved
-// from an existing protocol locator.
+// declares whether its Client will be created or resolved from an existing
+// protocol ID.
 type ConnectionSpec struct {
 	ID ConnectionID
 	A  ClientSpec
 	B  ClientSpec
 }
 
-func (c ConnectionSpec) ARef() IBCClientRef {
-	return IBCClientRef{Connection: c.ID, End: ConnectionEndA}
-}
-
-func (c ConnectionSpec) BRef() IBCClientRef {
-	return IBCClientRef{Connection: c.ID, End: ConnectionEndB}
-}
-
 type clientEnd struct {
-	ref         IBCClientRef
+	label       string
 	declaration ClientSpec
 }
 
 func (c ConnectionSpec) ends() [2]clientEnd {
 	return [2]clientEnd{
-		{ref: c.ARef(), declaration: c.A},
-		{ref: c.BRef(), declaration: c.B},
+		{label: "A", declaration: c.A},
+		{label: "B", declaration: c.B},
 	}
+}
+
+func clientLabel(connection ConnectionID, end string) string {
+	return fmt.Sprintf("%s/%s", connection, end)
 }
 
 func (c ConnectionSpec) validate() error {
 	if err := requireValue("IBC Connection id", string(c.ID)); err != nil {
 		return err
 	}
-	a, err := validateClientSpec(c.ARef(), c.A)
+	a, err := validateClientSpec(c.ID, "A", c.A)
 	if err != nil {
 		return err
 	}
-	b, err := validateClientSpec(c.BRef(), c.B)
+	b, err := validateClientSpec(c.ID, "B", c.B)
 	if err != nil {
 		return err
 	}
-	if a.IBCInstance == b.IBCInstance {
+	if a == b {
 		return errorsf("IBC Connection %q: clients must belong to distinct IBC Instances", c.ID)
 	}
 	return nil
 }
 
-func validateClientSpec(ref IBCClientRef, spec ClientSpec) (clientIdentityValue, error) {
+func validateClientSpec(connectionID ConnectionID, end string, spec ClientSpec) (IBCInstanceID, error) {
 	var (
-		client       clientIdentityValue
+		instance     IBCInstanceID
 		variantField string
 		variantValue string
 	)
 	switch declaration := spec.(type) {
 	case NewClient:
-		client = clientIdentityValue{IBCInstance: declaration.IBCInstance}
+		instance = declaration.IBCInstance
 		variantField = "authority"
 		variantValue = string(declaration.Authority)
 		if declaration.MinRequiredSignatures == 0 {
-			return clientIdentityValue{}, errorsf(
-				"IBC Connection %q client %q minimum required signatures must be greater than zero",
-				ref.Connection,
-				ref,
+			return "", errorsf(
+				"IBC Client %q minimum required signatures must be greater than zero",
+				clientLabel(connectionID, end),
 			)
 		}
 	case ExistingClient:
-		client = clientIdentityValue{IBCInstance: declaration.IBCInstance}
-		variantField = "locator"
-		variantValue = string(declaration.Locator)
+		instance = declaration.IBCInstance
+		variantField = "id"
+		variantValue = declaration.ID
 	default:
-		return clientIdentityValue{}, errorsf(
+		return "", errorsf(
 			"IBC Connection %q end %s: unsupported declaration %T; use a concrete value",
-			ref.Connection,
-			ref.End,
+			connectionID,
+			end,
 			spec,
 		)
 	}
 
 	if err := requireValue(
-		fmt.Sprintf("IBC Client %q IBC Instance", ref),
-		string(client.IBCInstance),
+		fmt.Sprintf("IBC Client %q IBC Instance", clientLabel(connectionID, end)),
+		string(instance),
 	); err != nil {
-		return clientIdentityValue{}, err
+		return "", err
 	}
 	if err := requireValue(
-		fmt.Sprintf("IBC Client %q %s", ref, variantField),
+		fmt.Sprintf("IBC Client %q %s", clientLabel(connectionID, end), variantField),
 		variantValue,
 	); err != nil {
-		return clientIdentityValue{}, err
+		return "", err
 	}
-	return client, nil
+	return instance, nil
 }
 
-func clientIdentity(spec ClientSpec) clientIdentityValue {
+func clientIBCInstance(spec ClientSpec) IBCInstanceID {
 	switch declaration := spec.(type) {
 	case NewClient:
-		return clientIdentityValue{IBCInstance: declaration.IBCInstance}
+		return declaration.IBCInstance
 	case ExistingClient:
-		return clientIdentityValue{IBCInstance: declaration.IBCInstance}
+		return declaration.IBCInstance
 	default:
 		panic(fmt.Sprintf("environment: unsupported validated IBC Client declaration %T", spec))
 	}
 }
 
-// AttestorSpec declares an Attestor scoped to one authored IBC Client. It signs
-// that Client's attestations using a stable runtime authority binding. Its
-// observed counterparty IBC Instance is derived from the Client's Connection.
+// AttestorSpec declares an Attestor for the Client that contains it.
 type AttestorSpec struct {
 	ID        AttestorID
-	Client    IBCClientRef
 	Authority AuthorityID
 }
 
@@ -456,10 +424,14 @@ func (s Spec) validate() error {
 			)
 		}
 		if existing, ok := instance.(ExistingIBCInstance); ok {
+			locator := existing.Locator
+			if common.IsHexAddress(string(locator)) {
+				locator = IBCInstanceLocator(common.HexToAddress(string(locator)).Hex())
+			}
 			key := struct {
 				chain   ChainID
 				locator IBCInstanceLocator
-			}{chain: existing.Chain, locator: existing.Locator}
+			}{chain: existing.Chain, locator: locator}
 			if previous, exists := existingInstanceLocators[key]; exists {
 				return errorsf(
 					"existing IBC Instances %q and %q on Chain %q reference duplicate locator %q",
@@ -475,8 +447,8 @@ func (s Spec) validate() error {
 	}
 
 	connections := make(map[ConnectionID]struct{}, len(s.Connections))
-	clients := make(map[IBCClientRef]ClientSpec, 2*len(s.Connections))
-	locatorsByInstance := make(map[IBCInstanceID]map[IBCClientLocator]IBCClientRef)
+	clientIDsByInstance := make(map[IBCInstanceID]map[string]string)
+	attestors := make(map[AttestorID]struct{})
 	for _, connection := range s.Connections {
 		if err := connection.validate(); err != nil {
 			return err
@@ -485,78 +457,62 @@ func (s Spec) validate() error {
 			return errorsf("duplicate IBC Connection id %q", connection.ID)
 		}
 		for _, end := range connection.ends() {
-			client := clientIdentity(end.declaration)
-			if !contains(instances, client.IBCInstance) {
+			label := clientLabel(connection.ID, end.label)
+			instance := clientIBCInstance(end.declaration)
+			if !contains(instances, instance) {
 				return errorsf(
 					"IBC Client %q references unknown IBC Instance %q",
-					end.ref,
-					client.IBCInstance,
+					label,
+					instance,
 				)
 			}
-			if _, existing := end.declaration.(ExistingClient); existing && contains(newInstances, client.IBCInstance) {
+			if _, existing := end.declaration.(ExistingClient); existing && contains(newInstances, instance) {
 				return errorsf(
 					"existing IBC Client %q cannot belong to new IBC Instance %q",
-					end.ref,
-					client.IBCInstance,
+					label,
+					instance,
 				)
 			}
-			locator := clientLocator(end.ref, end.declaration)
-			locators := locatorsByInstance[client.IBCInstance]
-			if locators == nil {
-				locators = make(map[IBCClientLocator]IBCClientRef)
-				locatorsByInstance[client.IBCInstance] = locators
+			id := clientID(connection.ID, end.label, end.declaration)
+			ids := clientIDsByInstance[instance]
+			if ids == nil {
+				ids = make(map[string]string)
+				clientIDsByInstance[instance] = ids
 			}
-			if previous, exists := locators[locator]; exists {
+			if previous, exists := ids[id]; exists {
 				return errorsf(
-					"IBC Clients %q and %q on IBC Instance %q resolve to duplicate locator %q",
-					previous, end.ref, client.IBCInstance, locator,
+					"IBC Clients %q and %q on IBC Instance %q resolve to duplicate id %q",
+					previous, label, instance, id,
 				)
 			}
-			locators[locator] = end.ref
-			clients[end.ref] = end.declaration
-		}
-		connections[connection.ID] = struct{}{}
-	}
+			ids[id] = label
 
-	attestors := make(map[AttestorID]struct{}, len(s.Attestors))
-	attestorsByClient := make(map[IBCClientRef]int, len(s.Attestors))
-	for _, attestor := range s.Attestors {
-		if err := requireValue("Attestor id", string(attestor.ID)); err != nil {
-			return err
-		}
-		if _, exists := attestors[attestor.ID]; exists {
-			return errorsf("duplicate Attestor id %q", attestor.ID)
-		}
-		if err := attestor.Client.validate(); err != nil {
-			return err
-		}
-		if _, exists := clients[attestor.Client]; !exists {
-			return errorsf("Attestor %q references unknown IBC Client %q", attestor.ID, attestor.Client)
-		}
-		if err := requireValue(
-			fmt.Sprintf("Attestor %q authority", attestor.ID),
-			string(attestor.Authority),
-		); err != nil {
-			return err
-		}
-		attestors[attestor.ID] = struct{}{}
-		attestorsByClient[attestor.Client]++
-	}
-	for _, connection := range s.Connections {
-		for _, end := range connection.ends() {
-			client, isNew := end.declaration.(NewClient)
-			if isNew && attestorsByClient[end.ref] == 0 {
-				return errorsf("IBC Client %q must have at least one Attestor", end.ref)
+			clientAttestors := end.declaration.clientAttestors()
+			for _, attestor := range clientAttestors {
+				if err := requireValue("Attestor id", string(attestor.ID)); err != nil {
+					return err
+				}
+				if _, exists := attestors[attestor.ID]; exists {
+					return errorsf("duplicate Attestor id %q", attestor.ID)
+				}
+				if err := requireValue(
+					fmt.Sprintf("Attestor %q authority", attestor.ID),
+					string(attestor.Authority),
+				); err != nil {
+					return err
+				}
+				attestors[attestor.ID] = struct{}{}
 			}
-			if isNew && int(client.MinRequiredSignatures) > attestorsByClient[end.ref] {
+			if newClient, isNew := end.declaration.(NewClient); isNew && len(clientAttestors) == 0 {
+				return errorsf("IBC Client %q must have at least one Attestor", label)
+			} else if isNew && int(newClient.MinRequiredSignatures) > len(clientAttestors) {
 				return errorsf(
 					"IBC Client %q requires %d signatures from %d Attestors",
-					end.ref,
-					client.MinRequiredSignatures,
-					attestorsByClient[end.ref],
+					label, newClient.MinRequiredSignatures, len(clientAttestors),
 				)
 			}
 		}
+		connections[connection.ID] = struct{}{}
 	}
 
 	return nil

--- a/e2e/internal/harness/environment/spec.go
+++ b/e2e/internal/harness/environment/spec.go
@@ -15,7 +15,6 @@ type (
 	ChainID       string
 	IBCInstanceID string
 	ConnectionID  string
-	ClientID      string
 	AttestorID    string
 
 	// EndpointBindingID and AuthorityID name values supplied separately at runtime.
@@ -27,6 +26,46 @@ type (
 	IBCInstanceLocator string
 	IBCClientLocator   string
 )
+
+// ConnectionEnd identifies one side of an IBC Connection.
+type ConnectionEnd uint8
+
+const (
+	ConnectionEndA ConnectionEnd = iota + 1
+	ConnectionEndB
+)
+
+func (e ConnectionEnd) String() string {
+	switch e {
+	case ConnectionEndA:
+		return "A"
+	case ConnectionEndB:
+		return "B"
+	default:
+		return fmt.Sprintf("ConnectionEnd(%d)", e)
+	}
+}
+
+// IBCClientRef is the stable graph identity of one Connection end. It is
+// derived from graph structure rather than supplied as a separate client name.
+type IBCClientRef struct {
+	Connection ConnectionID
+	End        ConnectionEnd
+}
+
+func (r IBCClientRef) String() string {
+	return fmt.Sprintf("%s/%s", r.Connection, r.End)
+}
+
+func (r IBCClientRef) validate() error {
+	if err := requireValue("IBC Client reference connection", string(r.Connection)); err != nil {
+		return err
+	}
+	if r.End != ConnectionEndA && r.End != ConnectionEndB {
+		return errorsf("IBC Client reference %q has invalid Connection end %s", r, r.End)
+	}
+	return nil
+}
 
 // Spec is the desired IBC resource graph. Typed references determine dependency
 // order; protocol declarations retain authored order while Chains start concurrently.
@@ -214,7 +253,6 @@ func (i ExistingIBCInstance) validateIBCInstance() error {
 // clientIdentityValue is the common internal identity carried by both Client
 // declaration variants.
 type clientIdentityValue struct {
-	ID          ClientID
 	IBCInstance IBCInstanceID
 }
 
@@ -230,7 +268,6 @@ type ClientSpec interface {
 // to the same address as that Instance's Authority. The quorum is explicit
 // because no single default is safe for every attestor set.
 type NewClient struct {
-	ID                    ClientID
 	IBCInstance           IBCInstanceID
 	Authority             AuthorityID
 	MinRequiredSignatures uint8
@@ -240,7 +277,6 @@ func (NewClient) clientSpec() {}
 
 // ExistingClient identifies an already-created IBC Client.
 type ExistingClient struct {
-	ID          ClientID
 	IBCInstance IBCInstanceID
 	Locator     IBCClientLocator
 }
@@ -256,20 +292,37 @@ type ConnectionSpec struct {
 	B  ClientSpec
 }
 
+func (c ConnectionSpec) ARef() IBCClientRef {
+	return IBCClientRef{Connection: c.ID, End: ConnectionEndA}
+}
+
+func (c ConnectionSpec) BRef() IBCClientRef {
+	return IBCClientRef{Connection: c.ID, End: ConnectionEndB}
+}
+
+type clientEnd struct {
+	ref         IBCClientRef
+	declaration ClientSpec
+}
+
+func (c ConnectionSpec) ends() [2]clientEnd {
+	return [2]clientEnd{
+		{ref: c.ARef(), declaration: c.A},
+		{ref: c.BRef(), declaration: c.B},
+	}
+}
+
 func (c ConnectionSpec) validate() error {
 	if err := requireValue("IBC Connection id", string(c.ID)); err != nil {
 		return err
 	}
-	a, err := validateClientSpec(c.ID, "A", c.A)
+	a, err := validateClientSpec(c.ARef(), c.A)
 	if err != nil {
 		return err
 	}
-	b, err := validateClientSpec(c.ID, "B", c.B)
+	b, err := validateClientSpec(c.BRef(), c.B)
 	if err != nil {
 		return err
-	}
-	if a.ID == b.ID {
-		return errorsf("IBC Connection %q: clients must have distinct ids", c.ID)
 	}
 	if a.IBCInstance == b.IBCInstance {
 		return errorsf("IBC Connection %q: clients must belong to distinct IBC Instances", c.ID)
@@ -277,7 +330,7 @@ func (c ConnectionSpec) validate() error {
 	return nil
 }
 
-func validateClientSpec(connectionID ConnectionID, end string, spec ClientSpec) (clientIdentityValue, error) {
+func validateClientSpec(ref IBCClientRef, spec ClientSpec) (clientIdentityValue, error) {
 	var (
 		client       clientIdentityValue
 		variantField string
@@ -285,40 +338,37 @@ func validateClientSpec(connectionID ConnectionID, end string, spec ClientSpec) 
 	)
 	switch declaration := spec.(type) {
 	case NewClient:
-		client = clientIdentityValue{ID: declaration.ID, IBCInstance: declaration.IBCInstance}
+		client = clientIdentityValue{IBCInstance: declaration.IBCInstance}
 		variantField = "authority"
 		variantValue = string(declaration.Authority)
 		if declaration.MinRequiredSignatures == 0 {
 			return clientIdentityValue{}, errorsf(
 				"IBC Connection %q client %q minimum required signatures must be greater than zero",
-				connectionID,
-				client.ID,
+				ref.Connection,
+				ref,
 			)
 		}
 	case ExistingClient:
-		client = clientIdentityValue{ID: declaration.ID, IBCInstance: declaration.IBCInstance}
+		client = clientIdentityValue{IBCInstance: declaration.IBCInstance}
 		variantField = "locator"
 		variantValue = string(declaration.Locator)
 	default:
 		return clientIdentityValue{}, errorsf(
 			"IBC Connection %q end %s: unsupported declaration %T; use a concrete value",
-			connectionID,
-			end,
+			ref.Connection,
+			ref.End,
 			spec,
 		)
 	}
 
-	if err := requireValue(fmt.Sprintf("IBC Connection %q client id", connectionID), string(client.ID)); err != nil {
-		return clientIdentityValue{}, err
-	}
 	if err := requireValue(
-		fmt.Sprintf("IBC Connection %q client %q IBC Instance", connectionID, client.ID),
+		fmt.Sprintf("IBC Client %q IBC Instance", ref),
 		string(client.IBCInstance),
 	); err != nil {
 		return clientIdentityValue{}, err
 	}
 	if err := requireValue(
-		fmt.Sprintf("IBC Connection %q client %q %s", connectionID, client.ID, variantField),
+		fmt.Sprintf("IBC Client %q %s", ref, variantField),
 		variantValue,
 	); err != nil {
 		return clientIdentityValue{}, err
@@ -329,9 +379,9 @@ func validateClientSpec(connectionID ConnectionID, end string, spec ClientSpec) 
 func clientIdentity(spec ClientSpec) clientIdentityValue {
 	switch declaration := spec.(type) {
 	case NewClient:
-		return clientIdentityValue{ID: declaration.ID, IBCInstance: declaration.IBCInstance}
+		return clientIdentityValue{IBCInstance: declaration.IBCInstance}
 	case ExistingClient:
-		return clientIdentityValue{ID: declaration.ID, IBCInstance: declaration.IBCInstance}
+		return clientIdentityValue{IBCInstance: declaration.IBCInstance}
 	default:
 		panic(fmt.Sprintf("environment: unsupported validated IBC Client declaration %T", spec))
 	}
@@ -342,7 +392,7 @@ func clientIdentity(spec ClientSpec) clientIdentityValue {
 // observed counterparty IBC Instance is derived from the Client's Connection.
 type AttestorSpec struct {
 	ID        AttestorID
-	Client    ClientID
+	Client    IBCClientRef
 	Authority AuthorityID
 }
 
@@ -378,6 +428,10 @@ func (s Spec) validate() error {
 
 	instances := make(map[IBCInstanceID]struct{}, len(s.IBCInstances))
 	newInstances := make(map[IBCInstanceID]struct{}, len(s.IBCInstances))
+	existingInstanceLocators := make(map[struct {
+		chain   ChainID
+		locator IBCInstanceLocator
+	}]IBCInstanceID)
 	for n, instance := range s.IBCInstances {
 		switch instance.(type) {
 		case NewIBCInstance, ExistingIBCInstance:
@@ -401,6 +455,19 @@ func (s Spec) validate() error {
 				existing.Chain,
 			)
 		}
+		if existing, ok := instance.(ExistingIBCInstance); ok {
+			key := struct {
+				chain   ChainID
+				locator IBCInstanceLocator
+			}{chain: existing.Chain, locator: existing.Locator}
+			if previous, exists := existingInstanceLocators[key]; exists {
+				return errorsf(
+					"existing IBC Instances %q and %q on Chain %q reference duplicate locator %q",
+					previous, existing.ID, existing.Chain, existing.Locator,
+				)
+			}
+			existingInstanceLocators[key] = existing.ID
+		}
 		instances[id] = struct{}{}
 		if _, isNew := instance.(NewIBCInstance); isNew {
 			newInstances[id] = struct{}{}
@@ -408,7 +475,8 @@ func (s Spec) validate() error {
 	}
 
 	connections := make(map[ConnectionID]struct{}, len(s.Connections))
-	clients := make(map[ClientID]ConnectionID, 2*len(s.Connections))
+	clients := make(map[IBCClientRef]ClientSpec, 2*len(s.Connections))
+	locatorsByInstance := make(map[IBCInstanceID]map[IBCClientLocator]IBCClientRef)
 	for _, connection := range s.Connections {
 		if err := connection.validate(); err != nil {
 			return err
@@ -416,34 +484,42 @@ func (s Spec) validate() error {
 		if _, exists := connections[connection.ID]; exists {
 			return errorsf("duplicate IBC Connection id %q", connection.ID)
 		}
-		for _, declaration := range []ClientSpec{connection.A, connection.B} {
-			client := clientIdentity(declaration)
+		for _, end := range connection.ends() {
+			client := clientIdentity(end.declaration)
 			if !contains(instances, client.IBCInstance) {
 				return errorsf(
-					"IBC Connection %q client %q references unknown IBC Instance %q",
-					connection.ID,
-					client.ID,
+					"IBC Client %q references unknown IBC Instance %q",
+					end.ref,
 					client.IBCInstance,
 				)
 			}
-			if _, existing := declaration.(ExistingClient); existing && contains(newInstances, client.IBCInstance) {
+			if _, existing := end.declaration.(ExistingClient); existing && contains(newInstances, client.IBCInstance) {
 				return errorsf(
-					"IBC Connection %q existing client %q cannot belong to new IBC Instance %q",
-					connection.ID,
-					client.ID,
+					"existing IBC Client %q cannot belong to new IBC Instance %q",
+					end.ref,
 					client.IBCInstance,
 				)
 			}
-			if owner, exists := clients[client.ID]; exists {
-				return errorsf("duplicate IBC Client id %q in Connections %q and %q", client.ID, owner, connection.ID)
+			locator := clientLocator(end.ref, end.declaration)
+			locators := locatorsByInstance[client.IBCInstance]
+			if locators == nil {
+				locators = make(map[IBCClientLocator]IBCClientRef)
+				locatorsByInstance[client.IBCInstance] = locators
 			}
-			clients[client.ID] = connection.ID
+			if previous, exists := locators[locator]; exists {
+				return errorsf(
+					"IBC Clients %q and %q on IBC Instance %q resolve to duplicate locator %q",
+					previous, end.ref, client.IBCInstance, locator,
+				)
+			}
+			locators[locator] = end.ref
+			clients[end.ref] = end.declaration
 		}
 		connections[connection.ID] = struct{}{}
 	}
 
 	attestors := make(map[AttestorID]struct{}, len(s.Attestors))
-	attestorsByClient := make(map[ClientID]int, len(s.Attestors))
+	attestorsByClient := make(map[IBCClientRef]int, len(s.Attestors))
 	for _, attestor := range s.Attestors {
 		if err := requireValue("Attestor id", string(attestor.ID)); err != nil {
 			return err
@@ -451,7 +527,7 @@ func (s Spec) validate() error {
 		if _, exists := attestors[attestor.ID]; exists {
 			return errorsf("duplicate Attestor id %q", attestor.ID)
 		}
-		if err := requireValue(fmt.Sprintf("Attestor %q client", attestor.ID), string(attestor.Client)); err != nil {
+		if err := attestor.Client.validate(); err != nil {
 			return err
 		}
 		if _, exists := clients[attestor.Client]; !exists {
@@ -467,18 +543,17 @@ func (s Spec) validate() error {
 		attestorsByClient[attestor.Client]++
 	}
 	for _, connection := range s.Connections {
-		for _, declaration := range []ClientSpec{connection.A, connection.B} {
-			client, isNew := declaration.(NewClient)
-			if isNew && attestorsByClient[client.ID] == 0 {
-				return errorsf("IBC Connection %q client %q must have at least one Attestor", connection.ID, client.ID)
+		for _, end := range connection.ends() {
+			client, isNew := end.declaration.(NewClient)
+			if isNew && attestorsByClient[end.ref] == 0 {
+				return errorsf("IBC Client %q must have at least one Attestor", end.ref)
 			}
-			if isNew && int(client.MinRequiredSignatures) > attestorsByClient[client.ID] {
+			if isNew && int(client.MinRequiredSignatures) > attestorsByClient[end.ref] {
 				return errorsf(
-					"IBC Connection %q client %q requires %d signatures from %d Attestors",
-					connection.ID,
-					client.ID,
+					"IBC Client %q requires %d signatures from %d Attestors",
+					end.ref,
 					client.MinRequiredSignatures,
-					attestorsByClient[client.ID],
+					attestorsByClient[end.ref],
 				)
 			}
 		}

--- a/e2e/internal/harness/environment/spec_test.go
+++ b/e2e/internal/harness/environment/spec_test.go
@@ -14,9 +14,11 @@ func TestSpecValidateMixedGraph(t *testing.T) {
 	require.NoError(t, spec.validate())
 
 	// Multiple independently identified Attestors may serve the same Client.
-	spec.Attestors = append(spec.Attestors, AttestorSpec{
-		ID: "attestor-3", Client: spec.Connections[0].ARef(), Authority: "attest-a-2",
-	})
+	connection := spec.Connections[0]
+	client := connection.A.(NewClient)
+	client.Attestors = append(client.Attestors, AttestorSpec{ID: "attestor-3", Authority: "attest-a-2"})
+	connection.A = client
+	spec.Connections[0] = connection
 	require.NoError(t, spec.validate())
 }
 
@@ -85,20 +87,24 @@ func TestSpecValidateStrictVariants(t *testing.T) {
 			want: "minimum required signatures must be greater than zero",
 		},
 		{
-			name: "existing IBC Client locator is required",
+			name: "existing IBC Client id is required",
 			mutate: func(s *Spec) {
 				connection := existingConnectionSpec()
 				client := connection.B.(ExistingClient)
-				client.Locator = ""
+				client.ID = ""
 				connection.B = client
 				s.Connections[0] = connection
 			},
-			want: `IBC Client "connection-ab/B" locator is required`,
+			want: `IBC Client "connection-ab/B" id is required`,
 		},
 		{
 			name: "Attestor authority is required",
 			mutate: func(s *Spec) {
-				s.Attestors[0].Authority = ""
+				connection := s.Connections[0]
+				client := connection.A.(NewClient)
+				client.Attestors[0].Authority = ""
+				connection.A = client
+				s.Connections[0] = connection
 			},
 			want: "Attestor \"attestor-1\" authority is required",
 		},
@@ -115,7 +121,11 @@ func TestSpecValidateStrictVariants(t *testing.T) {
 
 func TestSpecValidateNewClientRequiresAttestor(t *testing.T) {
 	spec := validSpec()
-	spec.Attestors = spec.Attestors[:1]
+	connection := spec.Connections[0]
+	client := connection.B.(NewClient)
+	client.Attestors = nil
+	connection.B = client
+	spec.Connections[0] = connection
 	require.ErrorContains(t, spec.validate(), `IBC Client "connection-ab/B" must have at least one Attestor`)
 }
 
@@ -130,7 +140,7 @@ func TestSpecValidateNewClientQuorumDoesNotExceedAttestors(t *testing.T) {
 }
 
 func TestSpecValidateConnectionEndCombinations(t *testing.T) {
-	t.Run("both existing with Attestor reference", func(t *testing.T) {
+	t.Run("both existing", func(t *testing.T) {
 		spec := validSpec()
 		makeChainAAttached(&spec)
 		spec.IBCInstances[0] = ExistingIBCInstance{ID: "ibc-a", Chain: "chain-a", Locator: "0xibc-a"}
@@ -229,20 +239,6 @@ func TestSpecValidateIdentityAndReferences(t *testing.T) {
 			},
 			want: "references unknown IBC Instance \"missing\"",
 		},
-		{
-			name: "Attestor references known IBC Client",
-			mutate: func(s *Spec) {
-				s.Attestors[0].Client.Connection = "missing"
-			},
-			want: `Attestor "attestor-1" references unknown IBC Client "missing/A"`,
-		},
-		{
-			name: "Attestor reference end is valid",
-			mutate: func(s *Spec) {
-				s.Attestors[0].Client.End = 99
-			},
-			want: `has invalid Connection end ConnectionEnd(99)`,
-		},
 	}
 
 	for _, tc := range tests {
@@ -267,17 +263,7 @@ func TestSpecValidateConnectionPair(t *testing.T) {
 	})
 }
 
-func TestConnectionClientRefsAreStableAndDistinct(t *testing.T) {
-	connection := ConnectionSpec{ID: "connection-ab"}
-	copied := connection
-
-	require.Equal(t, IBCClientRef{Connection: "connection-ab", End: ConnectionEndA}, connection.ARef())
-	require.Equal(t, IBCClientRef{Connection: "connection-ab", End: ConnectionEndB}, connection.BRef())
-	require.Equal(t, connection.ARef(), copied.ARef())
-	require.NotEqual(t, connection.ARef(), connection.BRef())
-}
-
-func TestSpecValidateClientLocatorUniquenessIsInstanceScoped(t *testing.T) {
+func TestSpecValidateClientIDUniquenessIsInstanceScoped(t *testing.T) {
 	spec := Spec{
 		Chains: []ChainSpec{
 			AttachedEVM{ID: "chain-a", EVMChainID: 1, Endpoint: "a", Timing: testTiming()},
@@ -292,39 +278,39 @@ func TestSpecValidateClientLocatorUniquenessIsInstanceScoped(t *testing.T) {
 		Connections: []ConnectionSpec{
 			{
 				ID: "ab",
-				A:  ExistingClient{IBCInstance: "ibc-a", Locator: "shared"},
-				B:  ExistingClient{IBCInstance: "ibc-b", Locator: "b"},
+				A:  ExistingClient{IBCInstance: "ibc-a", ID: "shared"},
+				B:  ExistingClient{IBCInstance: "ibc-b", ID: "b"},
 			},
 			{
 				ID: "ac",
-				A:  ExistingClient{IBCInstance: "ibc-a", Locator: "shared"},
-				B:  ExistingClient{IBCInstance: "ibc-c", Locator: "c"},
+				A:  ExistingClient{IBCInstance: "ibc-a", ID: "shared"},
+				B:  ExistingClient{IBCInstance: "ibc-c", ID: "c"},
 			},
 		},
 	}
 	require.ErrorContains(
 		t,
 		spec.validate(),
-		`IBC Clients "ab/A" and "ac/A" on IBC Instance "ibc-a" resolve to duplicate locator "shared"`,
+		`IBC Clients "ab/A" and "ac/A" on IBC Instance "ibc-a" resolve to duplicate id "shared"`,
 	)
 
-	spec.Connections[1].A = ExistingClient{IBCInstance: "ibc-c", Locator: "shared"}
-	spec.Connections[1].B = ExistingClient{IBCInstance: "ibc-a", Locator: "a-second"}
-	require.NoError(t, spec.validate(), "the same locator is legal on distinct IBC Instances")
+	spec.Connections[1].A = ExistingClient{IBCInstance: "ibc-c", ID: "shared"}
+	spec.Connections[1].B = ExistingClient{IBCInstance: "ibc-a", ID: "a-second"}
+	require.NoError(t, spec.validate(), "the same client id is legal on distinct IBC Instances")
 }
 
 func TestSpecValidateRejectsExistingInstanceAliases(t *testing.T) {
 	spec := validSpec()
 	makeChainAAttached(&spec)
 	spec.IBCInstances = []IBCInstanceSpec{
-		ExistingIBCInstance{ID: "ibc-a", Chain: "chain-a", Locator: "0xrouter"},
+		ExistingIBCInstance{ID: "ibc-a", Chain: "chain-a", Locator: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"},
 		ExistingIBCInstance{ID: "ibc-b", Chain: "chain-b", Locator: "0xother"},
-		ExistingIBCInstance{ID: "ibc-a-alias", Chain: "chain-a", Locator: "0xrouter"},
+		ExistingIBCInstance{ID: "ibc-a-alias", Chain: "chain-a", Locator: "0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD"},
 	}
 	require.ErrorContains(
 		t,
 		spec.validate(),
-		`existing IBC Instances "ibc-a" and "ibc-a-alias" on Chain "chain-a" reference duplicate locator "0xrouter"`,
+		`existing IBC Instances "ibc-a" and "ibc-a-alias" on Chain "chain-a" reference duplicate locator "0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD"`,
 	)
 }
 
@@ -352,13 +338,18 @@ func TestSpecSnapshotOwnsCollections(t *testing.T) {
 
 	spec.Chains[0] = ManagedAnvil{ID: "changed", EVMChainID: 8}
 	spec.IBCInstances[0] = ExistingIBCInstance{ID: "changed"}
-	spec.Connections[0] = ConnectionSpec{ID: "changed"}
-	spec.Attestors[0].ID = "changed"
+	connection := spec.Connections[0]
+	connection.ID = "changed"
+	client := connection.A.(NewClient)
+	client.Attestors[0].ID = "changed"
+	connection.A = client
+	spec.Connections[0] = connection
 
 	require.Equal(t, ChainID("chain-a"), snapshot.Chains[0].chainID())
 	require.Equal(t, IBCInstanceID("ibc-a"), snapshot.IBCInstances[0].ibcInstanceID())
 	require.Equal(t, ConnectionID("connection-ab"), snapshot.Connections[0].ID)
-	require.Equal(t, AttestorID("attestor-1"), snapshot.Attestors[0].ID)
+	snapshotClient := snapshot.Connections[0].A.(NewClient)
+	require.Equal(t, AttestorID("attestor-1"), snapshotClient.Attestors[0].ID)
 }
 
 func validSpec() Spec {
@@ -385,22 +376,12 @@ func validSpec() Spec {
 				ID: "connection-ab",
 				A: NewClient{
 					IBCInstance: "ibc-a", Authority: "connect-a", MinRequiredSignatures: 1,
+					Attestors: []AttestorSpec{{ID: "attestor-1", Authority: "attest-a"}},
 				},
 				B: NewClient{
 					IBCInstance: "ibc-b", Authority: "connect-b", MinRequiredSignatures: 1,
+					Attestors: []AttestorSpec{{ID: "attestor-2", Authority: "attest-b"}},
 				},
-			},
-		},
-		Attestors: []AttestorSpec{
-			{
-				ID: "attestor-1", Client: IBCClientRef{
-					Connection: "connection-ab", End: ConnectionEndA,
-				}, Authority: "attest-a",
-			},
-			{
-				ID: "attestor-2", Client: IBCClientRef{
-					Connection: "connection-ab", End: ConnectionEndB,
-				}, Authority: "attest-b",
 			},
 		},
 	}
@@ -409,8 +390,8 @@ func validSpec() Spec {
 func existingConnectionSpec() ConnectionSpec {
 	return ConnectionSpec{
 		ID: "connection-ab",
-		A:  ExistingClient{IBCInstance: "ibc-a", Locator: "client-7"},
-		B:  ExistingClient{IBCInstance: "ibc-b", Locator: "client-9"},
+		A:  ExistingClient{IBCInstance: "ibc-a", ID: "client-7"},
+		B:  ExistingClient{IBCInstance: "ibc-b", ID: "client-9"},
 	}
 }
 

--- a/e2e/internal/harness/environment/spec_test.go
+++ b/e2e/internal/harness/environment/spec_test.go
@@ -15,7 +15,7 @@ func TestSpecValidateMixedGraph(t *testing.T) {
 
 	// Multiple independently identified Attestors may serve the same Client.
 	spec.Attestors = append(spec.Attestors, AttestorSpec{
-		ID: "attestor-3", Client: "client-a", Authority: "attest-a-2",
+		ID: "attestor-3", Client: spec.Connections[0].ARef(), Authority: "attest-a-2",
 	})
 	require.NoError(t, spec.validate())
 }
@@ -71,7 +71,7 @@ func TestSpecValidateStrictVariants(t *testing.T) {
 				connection.A = client
 				s.Connections[0] = connection
 			},
-			want: "client \"client-a\" authority is required",
+			want: `IBC Client "connection-ab/A" authority is required`,
 		},
 		{
 			name: "new IBC Client quorum is required",
@@ -93,7 +93,7 @@ func TestSpecValidateStrictVariants(t *testing.T) {
 				connection.B = client
 				s.Connections[0] = connection
 			},
-			want: "client \"client-b\" locator is required",
+			want: `IBC Client "connection-ab/B" locator is required`,
 		},
 		{
 			name: "Attestor authority is required",
@@ -116,7 +116,7 @@ func TestSpecValidateStrictVariants(t *testing.T) {
 func TestSpecValidateNewClientRequiresAttestor(t *testing.T) {
 	spec := validSpec()
 	spec.Attestors = spec.Attestors[:1]
-	require.ErrorContains(t, spec.validate(), "client \"client-b\" must have at least one Attestor")
+	require.ErrorContains(t, spec.validate(), `IBC Client "connection-ab/B" must have at least one Attestor`)
 }
 
 func TestSpecValidateNewClientQuorumDoesNotExceedAttestors(t *testing.T) {
@@ -126,7 +126,7 @@ func TestSpecValidateNewClientQuorumDoesNotExceedAttestors(t *testing.T) {
 	client.MinRequiredSignatures = 2
 	connection.A = client
 	spec.Connections[0] = connection
-	require.ErrorContains(t, spec.validate(), `client "client-a" requires 2 signatures from 1 Attestors`)
+	require.ErrorContains(t, spec.validate(), `IBC Client "connection-ab/A" requires 2 signatures from 1 Attestors`)
 }
 
 func TestSpecValidateConnectionEndCombinations(t *testing.T) {
@@ -168,7 +168,7 @@ func TestSpecValidateConnectionEndCombinations(t *testing.T) {
 		require.ErrorContains(
 			t,
 			spec.validate(),
-			`existing client "client-a" cannot belong to new IBC Instance "ibc-a"`,
+			`existing IBC Client "connection-ab/A" cannot belong to new IBC Instance "ibc-a"`,
 		)
 	})
 }
@@ -230,26 +230,18 @@ func TestSpecValidateIdentityAndReferences(t *testing.T) {
 			want: "references unknown IBC Instance \"missing\"",
 		},
 		{
-			name: "IBC Client identity is globally unique",
-			mutate: func(s *Spec) {
-				s.Connections = append(s.Connections, ConnectionSpec{
-					ID: "connection-2",
-					A: NewClient{
-						ID: "client-a", IBCInstance: "ibc-a", Authority: "connect-a", MinRequiredSignatures: 1,
-					},
-					B: ExistingClient{
-						ID: "client-c", IBCInstance: "ibc-b", Locator: "client-11",
-					},
-				})
-			},
-			want: "duplicate IBC Client id \"client-a\"",
-		},
-		{
 			name: "Attestor references known IBC Client",
 			mutate: func(s *Spec) {
-				s.Attestors[0].Client = "missing"
+				s.Attestors[0].Client.Connection = "missing"
 			},
-			want: "Attestor \"attestor-1\" references unknown IBC Client \"missing\"",
+			want: `Attestor "attestor-1" references unknown IBC Client "missing/A"`,
+		},
+		{
+			name: "Attestor reference end is valid",
+			mutate: func(s *Spec) {
+				s.Attestors[0].Client.End = 99
+			},
+			want: `has invalid Connection end ConnectionEnd(99)`,
 		},
 	}
 
@@ -263,17 +255,6 @@ func TestSpecValidateIdentityAndReferences(t *testing.T) {
 }
 
 func TestSpecValidateConnectionPair(t *testing.T) {
-	t.Run("client ids differ", func(t *testing.T) {
-		spec := validSpec()
-		connection := spec.Connections[0]
-		clientA := connection.A.(NewClient)
-		clientB := connection.B.(NewClient)
-		clientB.ID = clientA.ID
-		connection.B = clientB
-		spec.Connections[0] = connection
-		require.ErrorContains(t, spec.validate(), "clients must have distinct ids")
-	})
-
 	t.Run("IBC Instances differ", func(t *testing.T) {
 		spec := validSpec()
 		connection := spec.Connections[0]
@@ -284,6 +265,67 @@ func TestSpecValidateConnectionPair(t *testing.T) {
 		spec.Connections[0] = connection
 		require.ErrorContains(t, spec.validate(), "clients must belong to distinct IBC Instances")
 	})
+}
+
+func TestConnectionClientRefsAreStableAndDistinct(t *testing.T) {
+	connection := ConnectionSpec{ID: "connection-ab"}
+	copied := connection
+
+	require.Equal(t, IBCClientRef{Connection: "connection-ab", End: ConnectionEndA}, connection.ARef())
+	require.Equal(t, IBCClientRef{Connection: "connection-ab", End: ConnectionEndB}, connection.BRef())
+	require.Equal(t, connection.ARef(), copied.ARef())
+	require.NotEqual(t, connection.ARef(), connection.BRef())
+}
+
+func TestSpecValidateClientLocatorUniquenessIsInstanceScoped(t *testing.T) {
+	spec := Spec{
+		Chains: []ChainSpec{
+			AttachedEVM{ID: "chain-a", EVMChainID: 1, Endpoint: "a", Timing: testTiming()},
+			AttachedEVM{ID: "chain-b", EVMChainID: 2, Endpoint: "b", Timing: testTiming()},
+			AttachedEVM{ID: "chain-c", EVMChainID: 3, Endpoint: "c", Timing: testTiming()},
+		},
+		IBCInstances: []IBCInstanceSpec{
+			ExistingIBCInstance{ID: "ibc-a", Chain: "chain-a", Locator: "0x1"},
+			ExistingIBCInstance{ID: "ibc-b", Chain: "chain-b", Locator: "0x2"},
+			ExistingIBCInstance{ID: "ibc-c", Chain: "chain-c", Locator: "0x3"},
+		},
+		Connections: []ConnectionSpec{
+			{
+				ID: "ab",
+				A:  ExistingClient{IBCInstance: "ibc-a", Locator: "shared"},
+				B:  ExistingClient{IBCInstance: "ibc-b", Locator: "b"},
+			},
+			{
+				ID: "ac",
+				A:  ExistingClient{IBCInstance: "ibc-a", Locator: "shared"},
+				B:  ExistingClient{IBCInstance: "ibc-c", Locator: "c"},
+			},
+		},
+	}
+	require.ErrorContains(
+		t,
+		spec.validate(),
+		`IBC Clients "ab/A" and "ac/A" on IBC Instance "ibc-a" resolve to duplicate locator "shared"`,
+	)
+
+	spec.Connections[1].A = ExistingClient{IBCInstance: "ibc-c", Locator: "shared"}
+	spec.Connections[1].B = ExistingClient{IBCInstance: "ibc-a", Locator: "a-second"}
+	require.NoError(t, spec.validate(), "the same locator is legal on distinct IBC Instances")
+}
+
+func TestSpecValidateRejectsExistingInstanceAliases(t *testing.T) {
+	spec := validSpec()
+	makeChainAAttached(&spec)
+	spec.IBCInstances = []IBCInstanceSpec{
+		ExistingIBCInstance{ID: "ibc-a", Chain: "chain-a", Locator: "0xrouter"},
+		ExistingIBCInstance{ID: "ibc-b", Chain: "chain-b", Locator: "0xother"},
+		ExistingIBCInstance{ID: "ibc-a-alias", Chain: "chain-a", Locator: "0xrouter"},
+	}
+	require.ErrorContains(
+		t,
+		spec.validate(),
+		`existing IBC Instances "ibc-a" and "ibc-a-alias" on Chain "chain-a" reference duplicate locator "0xrouter"`,
+	)
 }
 
 func TestSpecValidateRejectsPointerClientDeclaration(t *testing.T) {
@@ -342,16 +384,24 @@ func validSpec() Spec {
 			{
 				ID: "connection-ab",
 				A: NewClient{
-					ID: "client-a", IBCInstance: "ibc-a", Authority: "connect-a", MinRequiredSignatures: 1,
+					IBCInstance: "ibc-a", Authority: "connect-a", MinRequiredSignatures: 1,
 				},
 				B: NewClient{
-					ID: "client-b", IBCInstance: "ibc-b", Authority: "connect-b", MinRequiredSignatures: 1,
+					IBCInstance: "ibc-b", Authority: "connect-b", MinRequiredSignatures: 1,
 				},
 			},
 		},
 		Attestors: []AttestorSpec{
-			{ID: "attestor-1", Client: "client-a", Authority: "attest-a"},
-			{ID: "attestor-2", Client: "client-b", Authority: "attest-b"},
+			{
+				ID: "attestor-1", Client: IBCClientRef{
+					Connection: "connection-ab", End: ConnectionEndA,
+				}, Authority: "attest-a",
+			},
+			{
+				ID: "attestor-2", Client: IBCClientRef{
+					Connection: "connection-ab", End: ConnectionEndB,
+				}, Authority: "attest-b",
+			},
 		},
 	}
 }
@@ -359,8 +409,8 @@ func validSpec() Spec {
 func existingConnectionSpec() ConnectionSpec {
 	return ConnectionSpec{
 		ID: "connection-ab",
-		A:  ExistingClient{ID: "client-a", IBCInstance: "ibc-a", Locator: "client-7"},
-		B:  ExistingClient{ID: "client-b", IBCInstance: "ibc-b", Locator: "client-9"},
+		A:  ExistingClient{IBCInstance: "ibc-a", Locator: "client-7"},
+		B:  ExistingClient{IBCInstance: "ibc-b", Locator: "client-9"},
 	}
 }
 

--- a/e2e/internal/harness/environment/start.go
+++ b/e2e/internal/harness/environment/start.go
@@ -89,12 +89,12 @@ func start(ctx context.Context, spec Spec, runtime Runtime, d drivers) (*Environ
 		return nil, abortStart(ctx, startErr, ws, effects)
 	}
 
-	connections, clients, startErr := acquireConnections(ctx, spec, instances, runtime, d)
+	connections, startErr := acquireConnections(ctx, spec, instances, runtime, d)
 	if startErr != nil {
 		return nil, abortStart(ctx, startErr, ws, effects)
 	}
 
-	attestors, startErr := acquireAttestors(ctx, spec, instances, clients, runtime, ws, d, effects)
+	attestors, startErr := acquireAttestors(ctx, spec, connections, runtime, ws, d, effects)
 	if startErr != nil {
 		return nil, abortStart(ctx, startErr, ws, effects)
 	}
@@ -106,7 +106,6 @@ func start(ctx context.Context, spec Spec, runtime Runtime, d drivers) (*Environ
 		chains:      chains,
 		instances:   instances,
 		connections: connections,
-		clients:     clients,
 		attestors:   attestors,
 		effects:     effects,
 		ws:          ws,
@@ -186,10 +185,10 @@ func validateRuntime(spec Spec, runtime Runtime) error {
 			if client, ok := declaration.(NewClient); ok {
 				requiredAuthorities[client.Authority] = struct{}{}
 			}
+			for _, attestor := range declaration.clientAttestors() {
+				requiredAuthorities[attestor.Authority] = struct{}{}
+			}
 		}
-	}
-	for _, attestor := range spec.Attestors {
-		requiredAuthorities[attestor.Authority] = struct{}{}
 	}
 	for authority := range requiredAuthorities {
 		if _, err := runtime.evmAccount(authority); err != nil {
@@ -218,7 +217,7 @@ func validateRuntime(spec Spec, runtime Runtime) error {
 			if instanceAuthority.Address() != clientAuthority.Address() {
 				return fmt.Errorf(
 					"environment: new IBC Client %q authority must resolve to the new IBC Instance %q admin address",
-					end.ref,
+					clientLabel(connection.ID, end.label),
 					instance.ID,
 				)
 			}
@@ -227,25 +226,30 @@ func validateRuntime(spec Spec, runtime Runtime) error {
 
 	type attestorUse struct {
 		id     AttestorID
-		client IBCClientRef
+		client string
 	}
 	// Solidity IBC v3 attestations do not yet include domain separation. Reusing one
 	// signer across Clients would allow the same signed bytes to be replayed in
 	// another Client context, so signer isolation is a graph-wide invariant.
-	attestorAddresses := make(map[string]attestorUse, len(spec.Attestors))
-	for _, attestor := range spec.Attestors {
-		account, _ := runtime.evmAccount(attestor.Authority)
-		address := account.Address().Hex()
-		if previous, exists := attestorAddresses[address]; exists {
-			return fmt.Errorf(
-				"environment: Attestors %q for IBC Client %q and %q for IBC Client %q resolve to the same signer address",
-				previous.id,
-				previous.client,
-				attestor.ID,
-				attestor.Client,
-			)
+	attestorAddresses := make(map[string]attestorUse)
+	for _, connection := range spec.Connections {
+		for _, end := range connection.ends() {
+			label := clientLabel(connection.ID, end.label)
+			for _, attestor := range end.declaration.clientAttestors() {
+				account, _ := runtime.evmAccount(attestor.Authority)
+				address := account.Address().Hex()
+				if previous, exists := attestorAddresses[address]; exists {
+					return fmt.Errorf(
+						"environment: Attestors %q for IBC Client %q and %q for IBC Client %q resolve to the same signer address",
+						previous.id,
+						previous.client,
+						attestor.ID,
+						label,
+					)
+				}
+				attestorAddresses[address] = attestorUse{id: attestor.ID, client: label}
+			}
 		}
-		attestorAddresses[address] = attestorUse{id: attestor.ID, client: attestor.Client}
 	}
 	return nil
 }
@@ -304,7 +308,14 @@ func productionDrivers() drivers {
 }
 
 func validateProductionPrerequisites(spec Spec, _ Runtime) error {
-	if len(spec.Attestors) == 0 {
+	hasAttestors := false
+	for _, connection := range spec.Connections {
+		if len(connection.A.clientAttestors()) != 0 || len(connection.B.clientAttestors()) != 0 {
+			hasAttestors = true
+			break
+		}
+	}
+	if !hasAttestors {
 		return nil
 	}
 	path, err := filepath.Abs(ibclink.ResolvedBin())

--- a/e2e/internal/harness/environment/start.go
+++ b/e2e/internal/harness/environment/start.go
@@ -204,8 +204,8 @@ func validateRuntime(spec Spec, runtime Runtime) error {
 		}
 	}
 	for _, connection := range spec.Connections {
-		for _, declaration := range []ClientSpec{connection.A, connection.B} {
-			client, ok := declaration.(NewClient)
+		for _, end := range connection.ends() {
+			client, ok := end.declaration.(NewClient)
 			if !ok {
 				continue
 			}
@@ -218,7 +218,7 @@ func validateRuntime(spec Spec, runtime Runtime) error {
 			if instanceAuthority.Address() != clientAuthority.Address() {
 				return fmt.Errorf(
 					"environment: new IBC Client %q authority must resolve to the new IBC Instance %q admin address",
-					client.ID,
+					end.ref,
 					instance.ID,
 				)
 			}
@@ -227,7 +227,7 @@ func validateRuntime(spec Spec, runtime Runtime) error {
 
 	type attestorUse struct {
 		id     AttestorID
-		client ClientID
+		client IBCClientRef
 	}
 	// Solidity IBC v3 attestations do not yet include domain separation. Reusing one
 	// signer across Clients would allow the same signed bytes to be replayed in

--- a/e2e/internal/harness/environment/start_integration_test.go
+++ b/e2e/internal/harness/environment/start_integration_test.go
@@ -34,8 +34,6 @@ func TestStartRealizesSolidityIBCAppStackConnectionAndAttestors(t *testing.T) {
 		instanceA    environment.IBCInstanceID = "ibc-a"
 		instanceB    environment.IBCInstanceID = "ibc-b"
 		connectionID environment.ConnectionID  = "a-b"
-		clientA      environment.ClientID      = "client-a"
-		clientB      environment.ClientID      = "client-b"
 		attestorA    environment.AttestorID    = "attestor-a"
 		attestorB    environment.AttestorID    = "attestor-b"
 		deployer     environment.AuthorityID   = "deployer"
@@ -61,21 +59,27 @@ func TestStartRealizesSolidityIBCAppStackConnectionAndAttestors(t *testing.T) {
 		Connections: []environment.ConnectionSpec{{
 			ID: connectionID,
 			A: environment.NewClient{
-				ID:                    clientA,
 				IBCInstance:           instanceA,
 				Authority:             deployer,
 				MinRequiredSignatures: 1,
 			},
 			B: environment.NewClient{
-				ID:                    clientB,
 				IBCInstance:           instanceB,
 				Authority:             deployer,
 				MinRequiredSignatures: 1,
 			},
 		}},
 		Attestors: []environment.AttestorSpec{
-			{ID: attestorA, Client: clientA, Authority: signerA},
-			{ID: attestorB, Client: clientB, Authority: signerB},
+			{
+				ID: attestorA, Client: environment.IBCClientRef{
+					Connection: connectionID, End: environment.ConnectionEndA,
+				}, Authority: signerA,
+			},
+			{
+				ID: attestorB, Client: environment.IBCClientRef{
+					Connection: connectionID, End: environment.ConnectionEndB,
+				}, Authority: signerB,
+			},
 		},
 	}
 	runtime := environment.Runtime{Authorities: map[environment.AuthorityID]environment.EVMAuthority{
@@ -107,8 +111,16 @@ func TestStartRealizesSolidityIBCAppStackConnectionAndAttestors(t *testing.T) {
 
 	connection, err := env.Connection(connectionID)
 	require.NoError(t, err)
-	require.Equal(t, clientA, connection.A().ID())
-	require.Equal(t, clientB, connection.B().ID())
+	require.Equal(
+		t,
+		environment.IBCClientRef{Connection: connectionID, End: environment.ConnectionEndA},
+		connection.A().Ref(),
+	)
+	require.Equal(
+		t,
+		environment.IBCClientRef{Connection: connectionID, End: environment.ConnectionEndB},
+		connection.B().Ref(),
+	)
 	require.NotEmpty(t, connection.A().Locator())
 	require.NotEmpty(t, connection.B().Locator())
 	require.Equal(t, connection.B().Locator(), connection.A().CounterpartyLocator())
@@ -199,15 +211,23 @@ func TestStartAttachesExistingSolidityIBCResources(t *testing.T) {
 		Connections: []environment.ConnectionSpec{{
 			ID: "created-connection",
 			A: environment.NewClient{
-				ID: "created-client-a", IBCInstance: "created-ibc-a", Authority: deployer, MinRequiredSignatures: 1,
+				IBCInstance: "created-ibc-a", Authority: deployer, MinRequiredSignatures: 1,
 			},
 			B: environment.NewClient{
-				ID: "created-client-b", IBCInstance: "created-ibc-b", Authority: deployer, MinRequiredSignatures: 1,
+				IBCInstance: "created-ibc-b", Authority: deployer, MinRequiredSignatures: 1,
 			},
 		}},
 		Attestors: []environment.AttestorSpec{
-			{ID: "created-attestor-a", Client: "created-client-a", Authority: signerA},
-			{ID: "created-attestor-b", Client: "created-client-b", Authority: signerB},
+			{
+				ID: "created-attestor-a", Client: environment.IBCClientRef{
+					Connection: "created-connection", End: environment.ConnectionEndA,
+				}, Authority: signerA,
+			},
+			{
+				ID: "created-attestor-b", Client: environment.IBCClientRef{
+					Connection: "created-connection", End: environment.ConnectionEndB,
+				}, Authority: signerB,
+			},
 		},
 	}, environment.Runtime{
 		Endpoints: endpoints,
@@ -240,15 +260,23 @@ func TestStartAttachesExistingSolidityIBCResources(t *testing.T) {
 		Connections: []environment.ConnectionSpec{{
 			ID: "attached-connection",
 			A: environment.ExistingClient{
-				ID: "attached-client-a", IBCInstance: "attached-ibc-a", Locator: createdConnection.A().Locator(),
+				IBCInstance: "attached-ibc-a", Locator: createdConnection.A().Locator(),
 			},
 			B: environment.ExistingClient{
-				ID: "attached-client-b", IBCInstance: "attached-ibc-b", Locator: createdConnection.B().Locator(),
+				IBCInstance: "attached-ibc-b", Locator: createdConnection.B().Locator(),
 			},
 		}},
 		Attestors: []environment.AttestorSpec{
-			{ID: "attached-attestor-a", Client: "attached-client-a", Authority: signerA},
-			{ID: "attached-attestor-b", Client: "attached-client-b", Authority: signerB},
+			{
+				ID: "attached-attestor-a", Client: environment.IBCClientRef{
+					Connection: "attached-connection", End: environment.ConnectionEndA,
+				}, Authority: signerA,
+			},
+			{
+				ID: "attached-attestor-b", Client: environment.IBCClientRef{
+					Connection: "attached-connection", End: environment.ConnectionEndB,
+				}, Authority: signerB,
+			},
 		},
 	}, environment.Runtime{
 		Endpoints: endpoints,
@@ -269,8 +297,8 @@ func TestStartAttachesExistingSolidityIBCResources(t *testing.T) {
 
 	require.NoError(t, attached.Close(t.Context()))
 
-	// Reuse the original A end against a fresh B router. Keeping the authored
-	// Connection, Client, and Instance identities stable reproduces the exact
+	// Reuse the original A end against a fresh B router. Keeping the Connection
+	// identity and end stable reproduces the exact
 	// reciprocal locator expected by the existing A Client on the new router.
 	mixed, err := environment.Start(t.Context(), environment.Spec{
 		Chains: chains,
@@ -285,17 +313,18 @@ func TestStartAttachesExistingSolidityIBCResources(t *testing.T) {
 		Connections: []environment.ConnectionSpec{{
 			ID: "created-connection",
 			A: environment.ExistingClient{
-				ID: "created-client-a", IBCInstance: "created-ibc-a", Locator: createdConnection.A().Locator(),
+				IBCInstance: "created-ibc-a", Locator: createdConnection.A().Locator(),
 			},
 			B: environment.NewClient{
-				ID:                    "created-client-b",
 				IBCInstance:           "created-ibc-b",
 				Authority:             deployer,
 				MinRequiredSignatures: 1,
 			},
 		}},
 		Attestors: []environment.AttestorSpec{{
-			ID: "mixed-attestor-b", Client: "created-client-b", Authority: signerC,
+			ID: "mixed-attestor-b", Client: environment.IBCClientRef{
+				Connection: "created-connection", End: environment.ConnectionEndB,
+			}, Authority: signerC,
 		}},
 	}, environment.Runtime{
 		Endpoints: endpoints,
@@ -344,15 +373,23 @@ func TestStartRealizesSolidityIBCConnectionAcrossAnvilAndBesu(t *testing.T) {
 		Connections: []environment.ConnectionSpec{{
 			ID: "anvil-besu",
 			A: environment.NewClient{
-				ID: "anvil-client", IBCInstance: "anvil-ibc", Authority: deployer, MinRequiredSignatures: 1,
+				IBCInstance: "anvil-ibc", Authority: deployer, MinRequiredSignatures: 1,
 			},
 			B: environment.NewClient{
-				ID: "besu-client", IBCInstance: "besu-ibc", Authority: deployer, MinRequiredSignatures: 1,
+				IBCInstance: "besu-ibc", Authority: deployer, MinRequiredSignatures: 1,
 			},
 		}},
 		Attestors: []environment.AttestorSpec{
-			{ID: "anvil-attestor", Client: "anvil-client", Authority: signerA},
-			{ID: "besu-attestor", Client: "besu-client", Authority: signerB},
+			{
+				ID: "anvil-attestor", Client: environment.IBCClientRef{
+					Connection: "anvil-besu", End: environment.ConnectionEndA,
+				}, Authority: signerA,
+			},
+			{
+				ID: "besu-attestor", Client: environment.IBCClientRef{
+					Connection: "anvil-besu", End: environment.ConnectionEndB,
+				}, Authority: signerB,
+			},
 		},
 	}
 

--- a/e2e/internal/harness/environment/start_integration_test.go
+++ b/e2e/internal/harness/environment/start_integration_test.go
@@ -62,25 +62,15 @@ func TestStartRealizesSolidityIBCAppStackConnectionAndAttestors(t *testing.T) {
 				IBCInstance:           instanceA,
 				Authority:             deployer,
 				MinRequiredSignatures: 1,
+				Attestors:             []environment.AttestorSpec{{ID: attestorA, Authority: signerA}},
 			},
 			B: environment.NewClient{
 				IBCInstance:           instanceB,
 				Authority:             deployer,
 				MinRequiredSignatures: 1,
+				Attestors:             []environment.AttestorSpec{{ID: attestorB, Authority: signerB}},
 			},
 		}},
-		Attestors: []environment.AttestorSpec{
-			{
-				ID: attestorA, Client: environment.IBCClientRef{
-					Connection: connectionID, End: environment.ConnectionEndA,
-				}, Authority: signerA,
-			},
-			{
-				ID: attestorB, Client: environment.IBCClientRef{
-					Connection: connectionID, End: environment.ConnectionEndB,
-				}, Authority: signerB,
-			},
-		},
 	}
 	runtime := environment.Runtime{Authorities: map[environment.AuthorityID]environment.EVMAuthority{
 		deployer: {PrivateKeyHex: testDeployerPrivateKeyHex},
@@ -111,20 +101,10 @@ func TestStartRealizesSolidityIBCAppStackConnectionAndAttestors(t *testing.T) {
 
 	connection, err := env.Connection(connectionID)
 	require.NoError(t, err)
-	require.Equal(
-		t,
-		environment.IBCClientRef{Connection: connectionID, End: environment.ConnectionEndA},
-		connection.A().Ref(),
-	)
-	require.Equal(
-		t,
-		environment.IBCClientRef{Connection: connectionID, End: environment.ConnectionEndB},
-		connection.B().Ref(),
-	)
-	require.NotEmpty(t, connection.A().Locator())
-	require.NotEmpty(t, connection.B().Locator())
-	require.Equal(t, connection.B().Locator(), connection.A().CounterpartyLocator())
-	require.Equal(t, connection.A().Locator(), connection.B().CounterpartyLocator())
+	require.NotEmpty(t, connection.A().ID())
+	require.NotEmpty(t, connection.B().ID())
+	require.Equal(t, connection.B().ID(), connection.A().CounterpartyID())
+	require.Equal(t, connection.A().ID(), connection.B().CounterpartyID())
 	require.NotEqual(t, common.Address{}, common.HexToAddress(string(connection.A().LightClientAddress())))
 	require.NotEqual(t, common.Address{}, common.HexToAddress(string(connection.B().LightClientAddress())))
 
@@ -212,23 +192,13 @@ func TestStartAttachesExistingSolidityIBCResources(t *testing.T) {
 			ID: "created-connection",
 			A: environment.NewClient{
 				IBCInstance: "created-ibc-a", Authority: deployer, MinRequiredSignatures: 1,
+				Attestors: []environment.AttestorSpec{{ID: "created-attestor-a", Authority: signerA}},
 			},
 			B: environment.NewClient{
 				IBCInstance: "created-ibc-b", Authority: deployer, MinRequiredSignatures: 1,
+				Attestors: []environment.AttestorSpec{{ID: "created-attestor-b", Authority: signerB}},
 			},
 		}},
-		Attestors: []environment.AttestorSpec{
-			{
-				ID: "created-attestor-a", Client: environment.IBCClientRef{
-					Connection: "created-connection", End: environment.ConnectionEndA,
-				}, Authority: signerA,
-			},
-			{
-				ID: "created-attestor-b", Client: environment.IBCClientRef{
-					Connection: "created-connection", End: environment.ConnectionEndB,
-				}, Authority: signerB,
-			},
-		},
 	}, environment.Runtime{
 		Endpoints: endpoints,
 		Authorities: map[environment.AuthorityID]environment.EVMAuthority{
@@ -260,24 +230,14 @@ func TestStartAttachesExistingSolidityIBCResources(t *testing.T) {
 		Connections: []environment.ConnectionSpec{{
 			ID: "attached-connection",
 			A: environment.ExistingClient{
-				IBCInstance: "attached-ibc-a", Locator: createdConnection.A().Locator(),
+				IBCInstance: "attached-ibc-a", ID: createdConnection.A().ID(),
+				Attestors: []environment.AttestorSpec{{ID: "attached-attestor-a", Authority: signerA}},
 			},
 			B: environment.ExistingClient{
-				IBCInstance: "attached-ibc-b", Locator: createdConnection.B().Locator(),
+				IBCInstance: "attached-ibc-b", ID: createdConnection.B().ID(),
+				Attestors: []environment.AttestorSpec{{ID: "attached-attestor-b", Authority: signerB}},
 			},
 		}},
-		Attestors: []environment.AttestorSpec{
-			{
-				ID: "attached-attestor-a", Client: environment.IBCClientRef{
-					Connection: "attached-connection", End: environment.ConnectionEndA,
-				}, Authority: signerA,
-			},
-			{
-				ID: "attached-attestor-b", Client: environment.IBCClientRef{
-					Connection: "attached-connection", End: environment.ConnectionEndB,
-				}, Authority: signerB,
-			},
-		},
 	}, environment.Runtime{
 		Endpoints: endpoints,
 		Authorities: map[environment.AuthorityID]environment.EVMAuthority{
@@ -290,16 +250,16 @@ func TestStartAttachesExistingSolidityIBCResources(t *testing.T) {
 
 	attachedConnection, err := attached.Connection("attached-connection")
 	require.NoError(t, err)
-	require.Equal(t, createdConnection.A().Locator(), attachedConnection.A().Locator())
-	require.Equal(t, createdConnection.B().Locator(), attachedConnection.B().Locator())
-	require.Equal(t, createdConnection.B().Locator(), attachedConnection.A().CounterpartyLocator())
-	require.Equal(t, createdConnection.A().Locator(), attachedConnection.B().CounterpartyLocator())
+	require.Equal(t, createdConnection.A().ID(), attachedConnection.A().ID())
+	require.Equal(t, createdConnection.B().ID(), attachedConnection.B().ID())
+	require.Equal(t, createdConnection.B().ID(), attachedConnection.A().CounterpartyID())
+	require.Equal(t, createdConnection.A().ID(), attachedConnection.B().CounterpartyID())
 
 	require.NoError(t, attached.Close(t.Context()))
 
 	// Reuse the original A end against a fresh B router. Keeping the Connection
 	// identity and end stable reproduces the exact
-	// reciprocal locator expected by the existing A Client on the new router.
+	// reciprocal client ID expected by the existing A Client on the new router.
 	mixed, err := environment.Start(t.Context(), environment.Spec{
 		Chains: chains,
 		IBCInstances: []environment.IBCInstanceSpec{
@@ -313,18 +273,14 @@ func TestStartAttachesExistingSolidityIBCResources(t *testing.T) {
 		Connections: []environment.ConnectionSpec{{
 			ID: "created-connection",
 			A: environment.ExistingClient{
-				IBCInstance: "created-ibc-a", Locator: createdConnection.A().Locator(),
+				IBCInstance: "created-ibc-a", ID: createdConnection.A().ID(),
 			},
 			B: environment.NewClient{
 				IBCInstance:           "created-ibc-b",
 				Authority:             deployer,
 				MinRequiredSignatures: 1,
+				Attestors:             []environment.AttestorSpec{{ID: "mixed-attestor-b", Authority: signerC}},
 			},
-		}},
-		Attestors: []environment.AttestorSpec{{
-			ID: "mixed-attestor-b", Client: environment.IBCClientRef{
-				Connection: "created-connection", End: environment.ConnectionEndB,
-			}, Authority: signerC,
 		}},
 	}, environment.Runtime{
 		Endpoints: endpoints,
@@ -337,8 +293,8 @@ func TestStartAttachesExistingSolidityIBCResources(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, mixed.Close(context.Background())) })
 	mixedConnection, err := mixed.Connection("created-connection")
 	require.NoError(t, err)
-	require.Equal(t, createdConnection.A().Locator(), mixedConnection.A().Locator())
-	require.Equal(t, createdConnection.B().Locator(), mixedConnection.B().Locator())
+	require.Equal(t, createdConnection.A().ID(), mixedConnection.A().ID())
+	require.Equal(t, createdConnection.B().ID(), mixedConnection.B().ID())
 	require.NoError(t, mixed.Close(t.Context()))
 
 	_, err = chainA.Height(t.Context())
@@ -374,23 +330,13 @@ func TestStartRealizesSolidityIBCConnectionAcrossAnvilAndBesu(t *testing.T) {
 			ID: "anvil-besu",
 			A: environment.NewClient{
 				IBCInstance: "anvil-ibc", Authority: deployer, MinRequiredSignatures: 1,
+				Attestors: []environment.AttestorSpec{{ID: "anvil-attestor", Authority: signerA}},
 			},
 			B: environment.NewClient{
 				IBCInstance: "besu-ibc", Authority: deployer, MinRequiredSignatures: 1,
+				Attestors: []environment.AttestorSpec{{ID: "besu-attestor", Authority: signerB}},
 			},
 		}},
-		Attestors: []environment.AttestorSpec{
-			{
-				ID: "anvil-attestor", Client: environment.IBCClientRef{
-					Connection: "anvil-besu", End: environment.ConnectionEndA,
-				}, Authority: signerA,
-			},
-			{
-				ID: "besu-attestor", Client: environment.IBCClientRef{
-					Connection: "anvil-besu", End: environment.ConnectionEndB,
-				}, Authority: signerB,
-			},
-		},
 	}
 
 	env, err := environment.Start(t.Context(), spec, runtime)
@@ -399,8 +345,8 @@ func TestStartRealizesSolidityIBCConnectionAcrossAnvilAndBesu(t *testing.T) {
 
 	connection, err := env.Connection("anvil-besu")
 	require.NoError(t, err)
-	require.Equal(t, connection.B().Locator(), connection.A().CounterpartyLocator())
-	require.Equal(t, connection.A().Locator(), connection.B().CounterpartyLocator())
+	require.Equal(t, connection.B().ID(), connection.A().CounterpartyID())
+	require.Equal(t, connection.A().ID(), connection.B().CounterpartyID())
 	require.NotEqual(t, common.Address{}, common.HexToAddress(string(connection.A().LightClientAddress())))
 	require.NotEqual(t, common.Address{}, common.HexToAddress(string(connection.B().LightClientAddress())))
 	require.NoError(t, env.Close(t.Context()))

--- a/e2e/internal/harness/environment/start_test.go
+++ b/e2e/internal/harness/environment/start_test.go
@@ -67,21 +67,15 @@ func TestStartRejectsAttestorSignerReuseAcrossClientsBeforeAcquisition(t *testin
 		},
 		Connections: []ConnectionSpec{{
 			ID: "connection-ab",
-			A:  ExistingClient{IBCInstance: "ibc-a", Locator: "existing-a"},
-			B:  ExistingClient{IBCInstance: "ibc-b", Locator: "existing-b"},
+			A: ExistingClient{
+				IBCInstance: "ibc-a", ID: "existing-a",
+				Attestors: []AttestorSpec{{ID: "attestor-a", Authority: "signer-a"}},
+			},
+			B: ExistingClient{
+				IBCInstance: "ibc-b", ID: "existing-b",
+				Attestors: []AttestorSpec{{ID: "attestor-b", Authority: "signer-b"}},
+			},
 		}},
-		Attestors: []AttestorSpec{
-			{
-				ID: "attestor-a", Client: IBCClientRef{
-					Connection: "connection-ab", End: ConnectionEndA,
-				}, Authority: "signer-a",
-			},
-			{
-				ID: "attestor-b", Client: IBCClientRef{
-					Connection: "connection-ab", End: ConnectionEndB,
-				}, Authority: "signer-b",
-			},
-		},
 	}
 	runtime := Runtime{
 		Endpoints: map[EndpointBindingID]EndpointBinding{
@@ -141,7 +135,9 @@ func TestValidateChecksSpecAndRuntime(t *testing.T) {
 }
 
 func TestProductionPrerequisitesRequireExecutableAttestorBinary(t *testing.T) {
-	spec := Spec{Attestors: []AttestorSpec{{ID: "attestor-a"}}}
+	spec := Spec{Connections: []ConnectionSpec{{
+		A: ExistingClient{Attestors: []AttestorSpec{{ID: "attestor-a"}}},
+	}}}
 	path := filepath.Join(t.TempDir(), "ibc")
 	t.Setenv("IBC_BIN", path)
 

--- a/e2e/internal/harness/environment/start_test.go
+++ b/e2e/internal/harness/environment/start_test.go
@@ -67,12 +67,20 @@ func TestStartRejectsAttestorSignerReuseAcrossClientsBeforeAcquisition(t *testin
 		},
 		Connections: []ConnectionSpec{{
 			ID: "connection-ab",
-			A:  ExistingClient{ID: "client-a", IBCInstance: "ibc-a", Locator: "existing-a"},
-			B:  ExistingClient{ID: "client-b", IBCInstance: "ibc-b", Locator: "existing-b"},
+			A:  ExistingClient{IBCInstance: "ibc-a", Locator: "existing-a"},
+			B:  ExistingClient{IBCInstance: "ibc-b", Locator: "existing-b"},
 		}},
 		Attestors: []AttestorSpec{
-			{ID: "attestor-a", Client: "client-a", Authority: "signer-a"},
-			{ID: "attestor-b", Client: "client-b", Authority: "signer-b"},
+			{
+				ID: "attestor-a", Client: IBCClientRef{
+					Connection: "connection-ab", End: ConnectionEndA,
+				}, Authority: "signer-a",
+			},
+			{
+				ID: "attestor-b", Client: IBCClientRef{
+					Connection: "connection-ab", End: ConnectionEndB,
+				}, Authority: "signer-b",
+			},
 		},
 	}
 	runtime := Runtime{
@@ -95,7 +103,7 @@ func TestStartRejectsAttestorSignerReuseAcrossClientsBeforeAcquisition(t *testin
 	require.ErrorContains(
 		t,
 		err,
-		`Attestors "attestor-a" for IBC Client "client-a" and "attestor-b" for IBC Client "client-b" resolve to the same signer address`,
+		`Attestors "attestor-a" for IBC Client "connection-ab/A" and "attestor-b" for IBC Client "connection-ab/B" resolve to the same signer address`,
 	)
 	require.False(t, called)
 }
@@ -115,7 +123,7 @@ func TestStartRejectsUnauthorizedNewClientBeforeAcquisition(t *testing.T) {
 	require.ErrorContains(
 		t,
 		err,
-		`new IBC Client "client-a" authority must resolve to the new IBC Instance "ibc-a" admin address`,
+		`new IBC Client "connection-ab/A" authority must resolve to the new IBC Instance "ibc-a" admin address`,
 	)
 	require.False(t, called)
 }


### PR DESCRIPTION
## Summary

- remove the separate authored client identity and use protocol client ID strings throughout resolved and traffic APIs
- nest attestor declarations under their client, eliminating client-reference plumbing and lookups
- generate new client IDs from connection position and validate protocol ID uniqueness per host instance
- preserve graph-wide preflight, signer isolation, snapshot ownership, and existing-client reattachment

## Testing

- `go test ./internal/... ./cmd/...`
- `go test . -run '^$'`\n- `go test . -run '^TestAttestedMesh'`\n- `golangci-lint run`\n- `git diff --check`\n\nThe full acceptance suite was not executable locally because Docker and `link/bin/ibc` were unavailable.\n\nLinear: FOU-1236