### PR TITLE
feat(cli): attestor/relayer grpc query commands + IFT mint/send

### DIFF
--- a/link/cmd/ibc/attestor.go
+++ b/link/cmd/ibc/attestor.go
@@ -3,14 +3,22 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"net"
+	"net/http"
 
+	"connectrpc.com/connect"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	attestorv2 "github.com/cosmos/ibc/link/api/v2/attestor"
 	"github.com/cosmos/ibc/link/internal/bootstrap"
+	"github.com/cosmos/ibc/link/internal/config"
 	"github.com/cosmos/ibc/link/internal/pkg/graceful"
 )
+
+var flagAttestorHost string
 
 var (
 	cmdAttestor = &cobra.Command{
@@ -23,7 +31,30 @@ var (
 		Short: "Run the attestor",
 		RunE:  attestorRun,
 	}
+
+	cmdAttestorInfo = &cobra.Command{
+		Use:   "info [name]",
+		Short: "Query a local attestor's identity",
+		Args:  cobra.ExactArgs(1),
+		RunE:  attestorInfo,
+	}
+
+	cmdAttestorLatestHeight = &cobra.Command{
+		Use:   "latest-height [name]",
+		Short: "Query a local attestor's latest attestable height",
+		Args:  cobra.ExactArgs(1),
+		RunE:  attestorLatestHeight,
+	}
+
+	cmdAttestorStateAttestation = &cobra.Command{
+		Use:   "state-attestation [name]",
+		Short: "Query a local attestor for a state attestation at --height",
+		Args:  cobra.ExactArgs(1),
+		RunE:  attestorStateAttestation,
+	}
 )
+
+var flagAttestorHeight uint64
 
 func attestorRun(cmd *cobra.Command, _ []string) error {
 	cfg, err := setupHomeWithConfig()
@@ -55,4 +86,106 @@ func attestorRun(cmd *cobra.Command, _ []string) error {
 
 	// blocking
 	return graceful.WaitShutdown()
+}
+
+func attestorInfo(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	return attestorCall(cmd, name, attestorv2.AttestationServiceClient.Info, &attestorv2.InfoRequest{Attestor: name})
+}
+
+func attestorLatestHeight(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	return attestorCall(
+		cmd, name, attestorv2.AttestationServiceClient.LatestHeight, &attestorv2.LatestHeightRequest{Attestor: name},
+	)
+}
+
+func attestorStateAttestation(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	return attestorCall(
+		cmd,
+		name,
+		attestorv2.AttestationServiceClient.StateAttestation,
+		&attestorv2.StateAttestationRequest{
+			Attestor: name, Height: flagAttestorHeight,
+		},
+	)
+}
+
+// attestorCall resolves name's dial address, sends req via call, and prints
+// the response as JSON.
+func attestorCall[Req, Resp any](
+	cmd *cobra.Command,
+	name string,
+	call func(attestorv2.AttestationServiceClient, context.Context, *connect.Request[Req]) (*connect.Response[Resp], error),
+	req *Req,
+) error {
+	cfg, err := setupHomeWithConfig()
+	if err != nil {
+		return err
+	}
+
+	address := flagAttestorHost
+	if address == "" {
+		if err = requireLocalAttestor(cfg, name); err != nil {
+			return err
+		}
+		if cfg.Server.ListenAddress == "" {
+			return errors.New("server.listenAddr is not configured; pass --host to target a server directly")
+		}
+		address = cfg.Server.ListenAddress
+	}
+
+	client := attestorv2.NewAttestationServiceClient(
+		newGRPCHTTPClient(), "http://"+dialableAddress(address), connect.WithGRPC(),
+	)
+
+	res, err := call(client, cmd.Context(), connect.NewRequest(req))
+	if err != nil {
+		return errors.Wrap(err, cmd.Name())
+	}
+
+	return config.PrintJSON(res.Msg)
+}
+
+// requireLocalAttestor errors unless name is a locally-run attestor in cfg --
+// a remote attestor's process isn't this config's server, so dialing it here
+// would be wrong.
+func requireLocalAttestor(cfg config.Config, name string) error {
+	attestor, ok := cfg.AttestorByName(name)
+	if !ok {
+		return errors.Errorf("attestor %q not found in config", name)
+	}
+	if attestor.Type != config.AttestorTypeLocal {
+		return errors.Errorf("attestor %q is not local: pass --host to target it directly", name)
+	}
+
+	return nil
+}
+
+// dialableAddress rewrites an unspecified listen host (e.g. "0.0.0.0", the
+// config default) to "127.0.0.1" -- some platforms refuse outbound
+// connections to 0.0.0.0 even though it's a valid listen address.
+func dialableAddress(address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+		host = "127.0.0.1"
+	}
+
+	return net.JoinHostPort(host, port)
+}
+
+// https://connectrpc.com/docs/go/getting-started/#make-requests
+func newGRPCHTTPClient() *http.Client {
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetHTTP2(true)
+	protocols.SetUnencryptedHTTP2(true)
+
+	return &http.Client{
+		Transport: &http.Transport{Protocols: protocols},
+	}
 }

--- a/link/cmd/ibc/attestor.go
+++ b/link/cmd/ibc/attestor.go
@@ -18,7 +18,10 @@ import (
 	"github.com/cosmos/ibc/link/internal/pkg/graceful"
 )
 
-var flagAttestorHost string
+var (
+	flagAttestorHost   string
+	flagAttestorHeight uint64
+)
 
 var (
 	cmdAttestor = &cobra.Command{
@@ -53,8 +56,6 @@ var (
 		RunE:  attestorStateAttestation,
 	}
 )
-
-var flagAttestorHeight uint64
 
 func attestorRun(cmd *cobra.Command, _ []string) error {
 	cfg, err := setupHomeWithConfig()

--- a/link/cmd/ibc/attestor_test.go
+++ b/link/cmd/ibc/attestor_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/ibc/link/internal/config"
+)
+
+func TestRequireLocalAttestor(t *testing.T) {
+	cfg := config.Config{
+		Attestors: config.Attestors{
+			{Name: "local-attestor", Type: config.AttestorTypeLocal},
+			{Name: "remote-attestor", Type: config.AttestorTypeRemote, GRPC: "attestor.example.com:3000"},
+		},
+	}
+
+	require.NoError(t, requireLocalAttestor(cfg, "local-attestor"))
+
+	// a remote attestor's process isn't this config's own server -- fail
+	// clearly rather than silently dialing the wrong thing
+	require.ErrorContains(t, requireLocalAttestor(cfg, "remote-attestor"), `attestor "remote-attestor" is not local`)
+
+	// unknown name
+	require.ErrorContains(t, requireLocalAttestor(cfg, "nonexistent"), `attestor "nonexistent" not found`)
+}
+
+func TestDialableAddress(t *testing.T) {
+	require.Equal(t, "127.0.0.1:3000", dialableAddress("0.0.0.0:3000"))
+	require.Equal(t, "127.0.0.1:3000", dialableAddress("[::]:3000"))
+	require.Equal(t, "attestor.example.com:3000", dialableAddress("attestor.example.com:3000"))
+	require.Equal(t, "127.0.0.1:3000", dialableAddress("127.0.0.1:3000"))
+	// malformed input passes through unchanged rather than panicking
+	require.Equal(t, "not-a-host-port", dialableAddress("not-a-host-port"))
+}

--- a/link/cmd/ibc/deploy.go
+++ b/link/cmd/ibc/deploy.go
@@ -76,6 +76,13 @@ var (
 		RunE:  deployStatus,
 	}
 
+	cmdDeployShow = &cobra.Command{
+		Use:   "show [chain-id]",
+		Short: "Print the recorded deployment manifest for a chain",
+		Args:  cobra.ExactArgs(1),
+		RunE:  deployShow,
+	}
+
 	cmdDeployRenderConfig = &cobra.Command{
 		Use:   "render-config [chainA] [chainB]",
 		Short: "Project two deployment manifests into config sections for relaying between them (stdout)",
@@ -430,6 +437,23 @@ func deployStatus(cmd *cobra.Command, _ []string) error {
 		return errors.New("verification failed")
 	}
 	return nil
+}
+
+func deployShow(_ *cobra.Command, args []string) error {
+	if _, err := setupHomeWithConfig(); err != nil {
+		return err
+	}
+
+	chainID := args[0]
+	m, err := manifest.Load(flagDeployManifestDir, chainID)
+	if err != nil {
+		return err
+	}
+	if m == nil {
+		return errors.Errorf("no manifest for chain %s in %s: run `ibc deploy` against it first", chainID, flagDeployManifestDir)
+	}
+
+	return config.PrintJSON(m)
 }
 
 // renderedDeployment is the subset of the config schema render-config emits,

--- a/link/cmd/ibc/deploy.go
+++ b/link/cmd/ibc/deploy.go
@@ -90,7 +90,7 @@ var (
 	}
 
 	cmdDeployIFT = &cobra.Command{
-		Use:   "ift",
+		Use:   useIFT,
 		Short: "Deploy an IFT token on one chain",
 		RunE:  deployIFT,
 	}

--- a/link/cmd/ibc/deploy.go
+++ b/link/cmd/ibc/deploy.go
@@ -450,7 +450,8 @@ func deployShow(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if m == nil {
-		return errors.Errorf("no manifest for chain %s in %s: run `ibc deploy` against it first", chainID, flagDeployManifestDir)
+		return errors.Errorf("no manifest for chain %s in %s: run `ibc deploy` against it first",
+			chainID, flagDeployManifestDir)
 	}
 
 	return config.PrintJSON(m)

--- a/link/cmd/ibc/ift.go
+++ b/link/cmd/ibc/ift.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/ibc/link/internal/config"
+	"github.com/cosmos/ibc/link/internal/service/signer"
 )
 
 var (
@@ -62,11 +63,13 @@ func txIFTMint(cmd *cobra.Command, _ []string) error {
 	if amount == nil {
 		return errors.Errorf("invalid --amount %q", flagTxIFTAmount)
 	}
-	if !common.IsHexAddress(flagTxIFTTo) {
-		return errors.Errorf("invalid --to address %q", flagTxIFTTo)
+
+	backend, key, chainID, cfg, err := dialIFTChain(cmd.Context())
+	if err != nil {
+		return err
 	}
 
-	backend, key, chainID, err := dialIFTChain(cmd.Context())
+	to, err := resolveToAddress(cfg, flagTxIFTTo)
 	if err != nil {
 		return err
 	}
@@ -82,7 +85,7 @@ func txIFTMint(cmd *cobra.Command, _ []string) error {
 	}
 	opts.Context = cmd.Context()
 
-	tx, err := contract.Mint(opts, common.HexToAddress(flagTxIFTTo), amount)
+	tx, err := contract.Mint(opts, common.HexToAddress(to), amount)
 	if err != nil {
 		return errors.Wrap(err, "mint")
 	}
@@ -99,13 +102,18 @@ func txIFTMint(cmd *cobra.Command, _ []string) error {
 }
 
 func txIFTSend(cmd *cobra.Command, _ []string) error {
-	clientID, receiver := flagTxIFTClientID, flagTxIFTTo
+	clientID := flagTxIFTClientID
 	amount := parseIFTAmount(flagTxIFTAmount)
 	if amount == nil {
 		return errors.Errorf("invalid --amount %q", flagTxIFTAmount)
 	}
 
-	backend, key, chainID, err := dialIFTChain(cmd.Context())
+	backend, key, chainID, cfg, err := dialIFTChain(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	receiver, err := resolveToAddress(cfg, flagTxIFTTo)
 	if err != nil {
 		return err
 	}
@@ -156,38 +164,51 @@ func parseIFTAmount(s string) *big.Int {
 
 // dialIFTChain resolves --chain's RPC and --from's signer from config, and
 // dials the chain.
-func dialIFTChain(ctx context.Context) (*ethclient.Client, *ecdsa.PrivateKey, *big.Int, error) {
+func dialIFTChain(ctx context.Context) (*ethclient.Client, *ecdsa.PrivateKey, *big.Int, config.Config, error) {
 	cfg, err := setupHomeWithConfig()
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, config.Config{}, err
 	}
 
 	chain, ok := cfg.Chain(flagTxIFTChain)
 	if !ok {
-		return nil, nil, nil, errors.Errorf("chain %q not declared in config", flagTxIFTChain)
+		return nil, nil, nil, config.Config{}, errors.Errorf("chain %q not declared in config", flagTxIFTChain)
 	}
 	if chain.Type() != config.ChainTypeEVM {
-		return nil, nil, nil, errors.Errorf("chain %q is not an EVM chain", flagTxIFTChain)
+		return nil, nil, nil, config.Config{}, errors.Errorf("chain %q is not an EVM chain", flagTxIFTChain)
 	}
 
 	keyHex, err := deployerKeyHex(cfg, flagTxIFTFrom)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, config.Config{}, err
 	}
 	key, err := crypto.HexToECDSA(strings.TrimPrefix(keyHex, "0x"))
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "signer key")
+		return nil, nil, nil, config.Config{}, errors.Wrap(err, "signer key")
 	}
 
 	backend, err := ethclient.DialContext(ctx, chain.EVM.RPC)
 	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "dial %s", chain.EVM.RPC)
+		return nil, nil, nil, config.Config{}, errors.Wrapf(err, "dial %s", chain.EVM.RPC)
 	}
 
 	chainID, err := backend.ChainID(ctx)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "query chain id")
+		return nil, nil, nil, config.Config{}, errors.Wrap(err, "query chain id")
 	}
 
-	return backend, key, chainID, nil
+	return backend, key, chainID, cfg, nil
+}
+
+// resolveToAddress accepts either a raw EVM address or a config signer
+// alias, resolving the alias to its derived EVM address.
+func resolveToAddress(cfg config.Config, to string) (string, error) {
+	if common.IsHexAddress(to) {
+		return to, nil
+	}
+	sc, ok := cfg.Signer(to)
+	if !ok {
+		return "", errors.Errorf("invalid --to %q: not a hex address or a configured signer alias", to)
+	}
+	return signer.EVMAddressOf(sc)
 }

--- a/link/cmd/ibc/ift.go
+++ b/link/cmd/ibc/ift.go
@@ -25,48 +25,45 @@ var (
 	cmdTxIFT = &cobra.Command{
 		Use:   useIFT,
 		Short: "IFT transaction subcommands",
-		Long: "IFT transaction subcommands. Each takes its core transfer arguments positionally " +
-			"(e.g. to/amount, client-id/receiver/amount) and --chain/--ift/--from as flags shared " +
-			"across mint and send -- run a subcommand's --help for its exact positional order.",
 	}
 
 	cmdTxIFTMint = &cobra.Command{
-		Use:   "mint [to] [amount]",
+		Use:   "mint",
 		Short: "Mint IFT supply to an address",
-		Long:  "Mint amount of the IFT token at --ift to the to address. The --from signer must be the token's owner.",
-		Example: "  ibc tx ift mint 0xRecipient... 1000000000000000000 \\\n" +
-			"    --chain 1 --ift 0xIFTTokenAddress... --from deployer",
-		Args: cobra.ExactArgs(2),
+		Long:  "Mint --amount of the IFT token at --ift to --to. The --from signer must be the token's owner.",
+		Example: "  ibc tx ift mint --chain 1 --ift 0xIFTTokenAddress... \\\n" +
+			"    --to 0xRecipient... --amount 1000000000000000000 --from deployer",
 		RunE: txIFTMint,
 	}
 
 	cmdTxIFTSend = &cobra.Command{
-		Use:   "send [client-id] [receiver] [amount]",
+		Use:   "send",
 		Short: "Send IFT across a bridge to a counterparty chain",
-		Long: "Initiate a cross-chain transfer of amount of the IFT token at --ift, over the bridge " +
-			"registered for client-id, to receiver on the counterparty chain.",
-		Example: "  ibc tx ift send link-1-2 0xReceiver... 500000000000000000 \\\n" +
-			"    --chain 1 --ift 0xIFTTokenAddress... --from deployer",
-		Args: cobra.ExactArgs(3),
+		Long: "Initiate a cross-chain transfer of --amount of the IFT token at --ift, over the bridge " +
+			"registered for --client-id, to --to on the counterparty chain.",
+		Example: "  ibc tx ift send --chain 1 --ift 0xIFTTokenAddress... --client-id link-1-2 \\\n" +
+			"    --to 0xReceiver... --amount 500000000000000000 --from deployer",
 		RunE: txIFTSend,
 	}
 )
 
 var (
-	flagTxIFTChain   string
-	flagTxIFTAddress string
-	flagTxIFTFrom    string
-	flagTxIFTTimeout time.Duration
+	flagTxIFTChain    string
+	flagTxIFTAddress  string
+	flagTxIFTFrom     string
+	flagTxIFTTimeout  time.Duration
+	flagTxIFTTo       string
+	flagTxIFTAmount   string
+	flagTxIFTClientID string
 )
 
-func txIFTMint(cmd *cobra.Command, args []string) error {
-	to := args[0]
-	amount := parseIFTAmount(args[1])
+func txIFTMint(cmd *cobra.Command, _ []string) error {
+	amount := parseIFTAmount(flagTxIFTAmount)
 	if amount == nil {
-		return errors.Errorf("invalid amount %q", args[1])
+		return errors.Errorf("invalid --amount %q", flagTxIFTAmount)
 	}
-	if !common.IsHexAddress(to) {
-		return errors.Errorf("invalid to address %q", to)
+	if !common.IsHexAddress(flagTxIFTTo) {
+		return errors.Errorf("invalid --to address %q", flagTxIFTTo)
 	}
 
 	backend, key, chainID, err := dialIFTChain(cmd.Context())
@@ -85,7 +82,7 @@ func txIFTMint(cmd *cobra.Command, args []string) error {
 	}
 	opts.Context = cmd.Context()
 
-	tx, err := contract.Mint(opts, common.HexToAddress(to), amount)
+	tx, err := contract.Mint(opts, common.HexToAddress(flagTxIFTTo), amount)
 	if err != nil {
 		return errors.Wrap(err, "mint")
 	}
@@ -101,11 +98,11 @@ func txIFTMint(cmd *cobra.Command, args []string) error {
 	return printTxHash(tx.Hash().Hex())
 }
 
-func txIFTSend(cmd *cobra.Command, args []string) error {
-	clientID, receiver := args[0], args[1]
-	amount := parseIFTAmount(args[2])
+func txIFTSend(cmd *cobra.Command, _ []string) error {
+	clientID, receiver := flagTxIFTClientID, flagTxIFTTo
+	amount := parseIFTAmount(flagTxIFTAmount)
 	if amount == nil {
-		return errors.Errorf("invalid amount %q", args[2])
+		return errors.Errorf("invalid --amount %q", flagTxIFTAmount)
 	}
 
 	backend, key, chainID, err := dialIFTChain(cmd.Context())

--- a/link/cmd/ibc/ift.go
+++ b/link/cmd/ibc/ift.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/cosmos/solidity-ibc-eureka/packages/go-abigen/ift"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/ibc/link/internal/config"
+)
+
+var (
+	cmdTxIFT = &cobra.Command{
+		Use:   useIFT,
+		Short: "IFT transaction subcommands",
+	}
+
+	cmdTxIFTMint = &cobra.Command{
+		Use:   "mint [to] [amount]",
+		Short: "Mint IFT supply to an address",
+		Long:  "Mint amount of the IFT token at --ift to the to address. The --from signer must be the token's owner.",
+		Args:  cobra.ExactArgs(2),
+		RunE:  txIFTMint,
+	}
+
+	cmdTxIFTSend = &cobra.Command{
+		Use:   "send [client-id] [receiver] [amount]",
+		Short: "Send IFT across a bridge to a counterparty chain",
+		Long: "Initiate a cross-chain transfer of amount of the IFT token at --ift, over the bridge " +
+			"registered for client-id, to receiver on the counterparty chain.",
+		Args: cobra.ExactArgs(3),
+		RunE: txIFTSend,
+	}
+)
+
+var (
+	flagTxIFTChain   string
+	flagTxIFTAddress string
+	flagTxIFTFrom    string
+	flagTxIFTTimeout time.Duration
+)
+
+func txIFTMint(cmd *cobra.Command, args []string) error {
+	to := args[0]
+	amount := parseIFTAmount(args[1])
+	if amount == nil {
+		return errors.Errorf("invalid amount %q", args[1])
+	}
+	if !common.IsHexAddress(to) {
+		return errors.Errorf("invalid to address %q", to)
+	}
+
+	backend, key, chainID, err := dialIFTChain(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	contract, err := ift.NewContract(common.HexToAddress(flagTxIFTAddress), backend)
+	if err != nil {
+		return err
+	}
+
+	opts, err := bind.NewKeyedTransactorWithChainID(key, chainID)
+	if err != nil {
+		return err
+	}
+	opts.Context = cmd.Context()
+
+	tx, err := contract.Mint(opts, common.HexToAddress(to), amount)
+	if err != nil {
+		return errors.Wrap(err, "mint")
+	}
+
+	receipt, err := bind.WaitMined(cmd.Context(), backend, tx)
+	if err != nil {
+		return errors.Wrap(err, "mint: wait mined")
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return errors.Errorf("mint: transaction %s reverted", tx.Hash())
+	}
+
+	return printTxHash(tx.Hash().Hex())
+}
+
+func txIFTSend(cmd *cobra.Command, args []string) error {
+	clientID, receiver := args[0], args[1]
+	amount := parseIFTAmount(args[2])
+	if amount == nil {
+		return errors.Errorf("invalid amount %q", args[2])
+	}
+
+	backend, key, chainID, err := dialIFTChain(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	contract, err := ift.NewContract(common.HexToAddress(flagTxIFTAddress), backend)
+	if err != nil {
+		return err
+	}
+
+	opts, err := bind.NewKeyedTransactorWithChainID(key, chainID)
+	if err != nil {
+		return err
+	}
+	opts.Context = cmd.Context()
+
+	timeout := uint64(time.Now().Add(flagTxIFTTimeout).Unix())
+
+	tx, err := contract.IftTransfer(opts, clientID, receiver, amount, timeout)
+	if err != nil {
+		return errors.Wrapf(err, "iftTransfer %q", clientID)
+	}
+
+	receipt, err := bind.WaitMined(cmd.Context(), backend, tx)
+	if err != nil {
+		return errors.Wrapf(err, "iftTransfer %q: wait mined", clientID)
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return errors.Errorf("iftTransfer %q: transaction %s reverted", clientID, tx.Hash())
+	}
+
+	return printTxHash(tx.Hash().Hex())
+}
+
+func printTxHash(txHash string) error {
+	return config.PrintJSON(map[string]string{"txHash": txHash})
+}
+
+func parseIFTAmount(s string) *big.Int {
+	amount, ok := new(big.Int).SetString(s, 10)
+	if !ok || amount.Sign() < 0 {
+		return nil
+	}
+	return amount
+}
+
+// dialIFTChain resolves --chain's RPC and --from's signer from config, and
+// dials the chain.
+func dialIFTChain(ctx context.Context) (*ethclient.Client, *ecdsa.PrivateKey, *big.Int, error) {
+	cfg, err := setupHomeWithConfig()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	chain, ok := cfg.Chain(flagTxIFTChain)
+	if !ok {
+		return nil, nil, nil, errors.Errorf("chain %q not declared in config", flagTxIFTChain)
+	}
+
+	keyHex, err := deployerKeyHex(cfg, flagTxIFTFrom)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	key, err := crypto.HexToECDSA(strings.TrimPrefix(keyHex, "0x"))
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "signer key")
+	}
+
+	backend, err := ethclient.DialContext(ctx, chain.EVM.RPC)
+	if err != nil {
+		return nil, nil, nil, errors.Wrapf(err, "dial %s", chain.EVM.RPC)
+	}
+
+	chainID, err := backend.ChainID(ctx)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "query chain id")
+	}
+
+	return backend, key, chainID, nil
+}

--- a/link/cmd/ibc/ift.go
+++ b/link/cmd/ibc/ift.go
@@ -117,6 +117,9 @@ func txIFTSend(cmd *cobra.Command, args []string) error {
 	}
 	opts.Context = cmd.Context()
 
+	if flagTxIFTTimeout <= 0 {
+		return errors.Errorf("invalid --timeout %s: must be positive", flagTxIFTTimeout)
+	}
 	timeout := uint64(time.Now().Add(flagTxIFTTimeout).Unix())
 
 	tx, err := contract.IftTransfer(opts, clientID, receiver, amount, timeout)
@@ -158,6 +161,9 @@ func dialIFTChain(ctx context.Context) (*ethclient.Client, *ecdsa.PrivateKey, *b
 	chain, ok := cfg.Chain(flagTxIFTChain)
 	if !ok {
 		return nil, nil, nil, errors.Errorf("chain %q not declared in config", flagTxIFTChain)
+	}
+	if chain.Type() != config.ChainTypeEVM {
+		return nil, nil, nil, errors.Errorf("chain %q is not an EVM chain", flagTxIFTChain)
 	}
 
 	keyHex, err := deployerKeyHex(cfg, flagTxIFTFrom)

--- a/link/cmd/ibc/ift.go
+++ b/link/cmd/ibc/ift.go
@@ -25,14 +25,19 @@ var (
 	cmdTxIFT = &cobra.Command{
 		Use:   useIFT,
 		Short: "IFT transaction subcommands",
+		Long: "IFT transaction subcommands. Each takes its core transfer arguments positionally " +
+			"(e.g. to/amount, client-id/receiver/amount) and --chain/--ift/--from as flags shared " +
+			"across mint and send -- run a subcommand's --help for its exact positional order.",
 	}
 
 	cmdTxIFTMint = &cobra.Command{
 		Use:   "mint [to] [amount]",
 		Short: "Mint IFT supply to an address",
 		Long:  "Mint amount of the IFT token at --ift to the to address. The --from signer must be the token's owner.",
-		Args:  cobra.ExactArgs(2),
-		RunE:  txIFTMint,
+		Example: "  ibc tx ift mint 0xRecipient... 1000000000000000000 \\\n" +
+			"    --chain 1 --ift 0xIFTTokenAddress... --from deployer",
+		Args: cobra.ExactArgs(2),
+		RunE: txIFTMint,
 	}
 
 	cmdTxIFTSend = &cobra.Command{
@@ -40,6 +45,8 @@ var (
 		Short: "Send IFT across a bridge to a counterparty chain",
 		Long: "Initiate a cross-chain transfer of amount of the IFT token at --ift, over the bridge " +
 			"registered for client-id, to receiver on the counterparty chain.",
+		Example: "  ibc tx ift send link-1-2 0xReceiver... 500000000000000000 \\\n" +
+			"    --chain 1 --ift 0xIFTTokenAddress... --from deployer",
 		Args: cobra.ExactArgs(3),
 		RunE: txIFTSend,
 	}

--- a/link/cmd/ibc/ift_test.go
+++ b/link/cmd/ibc/ift_test.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIFTAmount(t *testing.T) {
+	require.Equal(t, big.NewInt(1000000), parseIFTAmount("1000000"))
+	require.Equal(t, big.NewInt(0), parseIFTAmount("0"))
+	require.Nil(t, parseIFTAmount("notanumber"))
+	require.Nil(t, parseIFTAmount(""))
+	require.Nil(t, parseIFTAmount("-1.5"))
+	require.Nil(t, parseIFTAmount("-1"))
+}

--- a/link/cmd/ibc/main.go
+++ b/link/cmd/ibc/main.go
@@ -164,6 +164,17 @@ func init() {
 	for _, req := range []string{"chain", useIFT, "from"} {
 		_ = cmdTxIFT.MarkPersistentFlagRequired(req)
 	}
+	cmdTxIFTMint.Flags().StringVar(&flagTxIFTTo, "to", "", "recipient address")
+	cmdTxIFTMint.Flags().StringVar(&flagTxIFTAmount, "amount", "", "amount to mint, in the token's base unit")
+	for _, req := range []string{"to", "amount"} {
+		_ = cmdTxIFTMint.MarkFlagRequired(req)
+	}
+	cmdTxIFTSend.Flags().StringVar(&flagTxIFTClientID, "client-id", "", "client id the bridge is registered for")
+	cmdTxIFTSend.Flags().StringVar(&flagTxIFTTo, "to", "", "receiver address on the counterparty chain")
+	cmdTxIFTSend.Flags().StringVar(&flagTxIFTAmount, "amount", "", "amount to send, in the token's base unit")
 	cmdTxIFTSend.Flags().
 		DurationVar(&flagTxIFTTimeout, "timeout", 15*time.Minute, "relative send timeout")
+	for _, req := range []string{"client-id", "to", "amount"} {
+		_ = cmdTxIFTSend.MarkFlagRequired(req)
+	}
 }

--- a/link/cmd/ibc/main.go
+++ b/link/cmd/ibc/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -22,6 +23,10 @@ var globalFlags = config.DefaultFlagSet()
 // useStatus is the shared "status" subcommand name and status-field key,
 // factored out to satisfy goconst across cmd/ibc.
 const useStatus = "status"
+
+// useIFT is the shared "ift" subcommand name, factored out to satisfy
+// goconst across cmd/ibc.
+const useIFT = "ift"
 
 var rootCmd = &cobra.Command{
 	Use:   "ibc",
@@ -58,6 +63,7 @@ func init() {
 		cmdMigrate,
 		cmdKeys,
 		cmdDeploy,
+		cmdTx,
 	)
 
 	cmdConfig.AddCommand(cmdConfigNew, cmdConfigValidate)
@@ -147,4 +153,17 @@ func init() {
 	cmdDeployIFTBridge.Flags().
 		StringVar(&flagDeployBridgeCtorB, "send-call-constructor-b", "",
 			"send call constructor address on chain B (default: deploy or reuse the EVM constructor)")
+
+	// Tx commands
+	cmdTx.AddCommand(cmdTxIFT)
+	cmdTxIFT.AddCommand(cmdTxIFTMint, cmdTxIFTSend)
+	tpf := cmdTxIFT.PersistentFlags()
+	tpf.StringVar(&flagTxIFTChain, "chain", "", "chain ID the IFT token is deployed on")
+	tpf.StringVar(&flagTxIFTAddress, "ift", "", "IFT token address")
+	tpf.StringVar(&flagTxIFTFrom, "from", "", "signer alias to submit the transaction with")
+	for _, req := range []string{"chain", useIFT, "from"} {
+		_ = cmdTxIFT.MarkPersistentFlagRequired(req)
+	}
+	cmdTxIFTSend.Flags().
+		DurationVar(&flagTxIFTTimeout, "timeout", 15*time.Minute, "relative send timeout")
 }

--- a/link/cmd/ibc/main.go
+++ b/link/cmd/ibc/main.go
@@ -104,7 +104,7 @@ func init() {
 	// Deploy commands
 	cmdDeploy.AddCommand(
 		cmdDeployCore, cmdDeployClient,
-		cmdDeployStatus, cmdDeployRenderConfig,
+		cmdDeployStatus, cmdDeployShow, cmdDeployRenderConfig,
 		cmdDeployGMP, cmdDeployIFT, cmdDeployIFTBridge,
 	)
 	dpf := cmdDeploy.PersistentFlags()
@@ -164,13 +164,14 @@ func init() {
 	for _, req := range []string{"chain", useIFT, "from"} {
 		_ = cmdTxIFT.MarkPersistentFlagRequired(req)
 	}
-	cmdTxIFTMint.Flags().StringVar(&flagTxIFTTo, "to", "", "recipient address")
+	cmdTxIFTMint.Flags().StringVar(&flagTxIFTTo, "to", "", "recipient address, or a configured signer alias")
 	cmdTxIFTMint.Flags().StringVar(&flagTxIFTAmount, "amount", "", "amount to mint, in the token's base unit")
 	for _, req := range []string{"to", "amount"} {
 		_ = cmdTxIFTMint.MarkFlagRequired(req)
 	}
 	cmdTxIFTSend.Flags().StringVar(&flagTxIFTClientID, "client-id", "", "client id the bridge is registered for")
-	cmdTxIFTSend.Flags().StringVar(&flagTxIFTTo, "to", "", "receiver address on the counterparty chain")
+	cmdTxIFTSend.Flags().
+		StringVar(&flagTxIFTTo, "to", "", "receiver address on the counterparty chain, or a configured signer alias")
 	cmdTxIFTSend.Flags().StringVar(&flagTxIFTAmount, "amount", "", "amount to send, in the token's base unit")
 	cmdTxIFTSend.Flags().
 		DurationVar(&flagTxIFTTimeout, "timeout", 15*time.Minute, "relative send timeout")

--- a/link/cmd/ibc/main.go
+++ b/link/cmd/ibc/main.go
@@ -72,11 +72,22 @@ func init() {
 	cmdKeysImport.Flags().StringVar(&flagKeysImportPrivateKey, "private-key", "", "hex-encoded private key")
 
 	// Relayer commands
-	cmdRelayer.AddCommand(cmdRelayerRun)
+	cmdRelayer.AddCommand(cmdRelayerRun, cmdRelayerRelay, cmdRelayerStatus)
 	cmdRelayerRun.Flags().BoolVarP(&flagRelayerNoMigrate, "no-migrate", "", false, "skip database migrations")
+	for _, c := range []*cobra.Command{cmdRelayerRelay, cmdRelayerStatus} {
+		c.Flags().StringVar(&flagRelayerHost, "host", "", "dial this address instead of resolving from config")
+		c.Flags().StringVar(&flagRelayerTxHash, "tx-hash", "", "source transaction hash")
+		c.Flags().StringVar(&flagRelayerSourceChainID, "chain-id", "", "source chain id")
+		_ = c.MarkFlagRequired("tx-hash")
+		_ = c.MarkFlagRequired("chain-id")
+	}
 
 	// Attestor commands
-	cmdAttestor.AddCommand(cmdAttestorRun)
+	cmdAttestor.AddCommand(cmdAttestorRun, cmdAttestorInfo, cmdAttestorLatestHeight, cmdAttestorStateAttestation)
+	for _, c := range []*cobra.Command{cmdAttestorInfo, cmdAttestorLatestHeight, cmdAttestorStateAttestation} {
+		c.Flags().StringVar(&flagAttestorHost, "host", "", "dial this address instead of resolving from config")
+	}
+	cmdAttestorStateAttestation.Flags().Uint64Var(&flagAttestorHeight, "height", 0, "height to attest")
 
 	// Query commands
 	// todo

--- a/link/cmd/ibc/relayer.go
+++ b/link/cmd/ibc/relayer.go
@@ -3,13 +3,16 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 
+	"connectrpc.com/connect"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 	"github.com/cosmos/ibc/link/internal/bootstrap"
+	"github.com/cosmos/ibc/link/internal/config"
 	"github.com/cosmos/ibc/link/internal/pkg/graceful"
 )
 
@@ -24,9 +27,26 @@ var (
 		Short: "Run the relayer",
 		RunE:  relayerRun,
 	}
+
+	cmdRelayerRelay = &cobra.Command{
+		Use:   "relay",
+		Short: "Trigger relaying of the packets emitted by a source transaction",
+		RunE:  relayerRelay,
+	}
+
+	cmdRelayerStatus = &cobra.Command{
+		Use:   useStatus,
+		Short: "Query per-packet relay status for a source transaction",
+		RunE:  relayerStatus,
+	}
 )
 
-var flagRelayerNoMigrate bool
+var (
+	flagRelayerNoMigrate     bool
+	flagRelayerHost          string
+	flagRelayerTxHash        string
+	flagRelayerSourceChainID string
+)
 
 func relayerRun(cmd *cobra.Command, _ []string) error {
 	cfg, err := setupHomeWithConfig()
@@ -88,4 +108,48 @@ func relayerRun(cmd *cobra.Command, _ []string) error {
 
 	// blocking
 	return graceful.WaitShutdown()
+}
+
+func relayerRelay(cmd *cobra.Command, _ []string) error {
+	return relayerCall(cmd, relayerv2.RelayerApiServiceClient.Relay, &relayerv2.RelayRequest{
+		TxHash: flagRelayerTxHash, SourceChainId: flagRelayerSourceChainID,
+	})
+}
+
+func relayerStatus(cmd *cobra.Command, _ []string) error {
+	return relayerCall(cmd, relayerv2.RelayerApiServiceClient.Status, &relayerv2.StatusRequest{
+		TxHash: flagRelayerTxHash, SourceChainId: flagRelayerSourceChainID,
+	})
+}
+
+// relayerCall resolves this config's relayer address, sends req via call,
+// and prints the response as JSON.
+func relayerCall[Req, Resp any](
+	cmd *cobra.Command,
+	call func(relayerv2.RelayerApiServiceClient, context.Context, *connect.Request[Req]) (*connect.Response[Resp], error),
+	req *Req,
+) error {
+	cfg, err := setupHomeWithConfig()
+	if err != nil {
+		return err
+	}
+
+	address := flagRelayerHost
+	if address == "" {
+		if cfg.Server.ListenAddress == "" {
+			return errors.New("server.listenAddr is not configured; pass --host to target a server directly")
+		}
+		address = cfg.Server.ListenAddress
+	}
+
+	client := relayerv2.NewRelayerApiServiceClient(
+		newGRPCHTTPClient(), "http://"+dialableAddress(address), connect.WithGRPC(),
+	)
+
+	res, err := call(client, cmd.Context(), connect.NewRequest(req))
+	if err != nil {
+		return errors.Wrap(err, cmd.Name())
+	}
+
+	return config.PrintJSON(res.Msg)
 }

--- a/link/cmd/ibc/relayer.go
+++ b/link/cmd/ibc/relayer.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 
 	relayerv2 "github.com/cosmos/ibc/link/api/v2/relayer"
 	"github.com/cosmos/ibc/link/internal/bootstrap"
@@ -149,6 +150,10 @@ func relayerCall[Req, Resp any](
 	res, err := call(client, cmd.Context(), connect.NewRequest(req))
 	if err != nil {
 		return errors.Wrap(err, cmd.Name())
+	}
+
+	if pm, ok := any(res.Msg).(proto.Message); ok {
+		return config.PrintProtoJSON(pm)
 	}
 
 	return config.PrintJSON(res.Msg)

--- a/link/cmd/ibc/relayer.go
+++ b/link/cmd/ibc/relayer.go
@@ -113,7 +113,9 @@ func relayerRun(cmd *cobra.Command, _ []string) error {
 
 func relayerRelay(cmd *cobra.Command, _ []string) error {
 	return relayerCall(cmd, relayerv2.RelayerApiServiceClient.Relay, &relayerv2.RelayRequest{
-		TxHash: flagRelayerTxHash, SourceChainId: flagRelayerSourceChainID,
+		TxHash:        flagRelayerTxHash,
+		SourceChainId: flagRelayerSourceChainID,
+		Selection:     &relayerv2.RelayRequest_AllPackets{AllPackets: &relayerv2.AllPackets{}},
 	})
 }
 

--- a/link/cmd/ibc/tx.go
+++ b/link/cmd/ibc/tx.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var cmdTx = &cobra.Command{
+	Use:   "tx",
+	Short: "Transaction commands",
+}

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -609,8 +609,7 @@ func PrintJSON(v any) error {
 }
 
 // PrintProtoJSON prints a protobuf message as JSON to stdout, rendering enum
-// fields by name (e.g. "PACKET_STATE_PENDING") instead of their numeric
-// value, and keeping proto_name field naming to match PrintJSON's output.
+// fields by name
 func PrintProtoJSON(msg proto.Message) error {
 	bz, err := protojson.MarshalOptions{Indent: "  ", UseProtoNames: true, EmitUnpopulated: true}.Marshal(msg)
 	if err != nil {

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/cosmos/ibc/link/internal/network"
 )
@@ -597,6 +599,20 @@ func KeyFileFallbacks(keyPath string) []string {
 // PrintJSON prints anything as JSON to stdout.
 func PrintJSON(v any) error {
 	bz, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(bz))
+
+	return nil
+}
+
+// PrintProtoJSON prints a protobuf message as JSON to stdout, rendering enum
+// fields by name (e.g. "PACKET_STATE_PENDING") instead of their numeric
+// value, and keeping proto_name field naming to match PrintJSON's output.
+func PrintProtoJSON(msg proto.Message) error {
+	bz, err := protojson.MarshalOptions{Indent: "  ", UseProtoNames: true, EmitUnpopulated: true}.Marshal(msg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds commands for interacting with the grpc api and ifts
```
ibc attestor info <name> [--host host:port]
ibc attestor latest-height <name> [--host host:port]
ibc attestor state-attestation <name> --height N [--host host:port]

ibc relayer relay --tx-hash <hash> --chain-id <id> [--host host:port]
ibc relayer status --tx-hash <hash> --chain-id <id> [--host host:port]

ibc tx ift mint --chain <id> --ift <address> --to <recipient|signer-alias> --amount <base-units> --from <signer-alias>
ibc tx ift send --chain <id> --ift <address> --client-id <id> --to <receiver|signer-alias> --amount <base-units> --from <signer-alias> [--timeout 15m]

ibc deploy show <chain-id> [--manifest-dir deployments]
```


`packet-attestation` was left out for now — constructing a valid request means hand-assembling ABI-encoded IBC packet bytes, which isn't something anyone would do by hand and it's not something people will use for the walkthrough demo