### PR TITLE
fix(e2e): update renamed contracts dependency

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,6 +72,23 @@ jobs:
         env:
           IBC_BIN: ${{ github.workspace }}/link/bin/ibc
 
+  test-apps:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: e2e/go.mod
+          cache-dependency-path: e2e/go.sum
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1
+      - run: go install github.com/ethereum/go-ethereum/cmd/abigen@v1.17.4
+      - run: make check-test-apps
+
   e2e:
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'

--- a/e2e/internal/harness/environment/solidityibc/contracts/bun.lock
+++ b/e2e/internal/harness/environment/solidityibc/contracts/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "@ibc-link/solidity-ibc-contract-artifacts",
       "dependencies": {
-        "@cosmos/solidity-ibc-eureka": "github:cosmos/solidity-ibc-eureka#39904319467b5fbdec8c34c43b66af6f1d256dba",
+        "@cosmos/solidity-ibc-eureka": "github:cosmos/ibc-contracts#39904319467b5fbdec8c34c43b66af6f1d256dba",
         "@openzeppelin/contracts": "5.6.1",
         "@openzeppelin/contracts-upgradeable": "5.6.1",
       },
     },
   },
   "packages": {
-    "@cosmos/solidity-ibc-eureka": ["@cosmos/solidity-ibc-eureka@github:cosmos/solidity-ibc-eureka#3990431", { "dependencies": { "@openzeppelin/contracts": "^5.6.1", "@openzeppelin/contracts-upgradeable": "^5.6.1", "@uniswap/permit2": "github:Uniswap/permit2#cc56ad0f3439c502c246fc5cfcc3db92bb8b7219" } }, "cosmos-solidity-ibc-eureka-3990431", "sha512-6almWXkS5dI9PBYm8VjTcK/M6pRNvk/b5//8ts81koFIIOIkF3Uc4nlBxkXSOA9lmtmrqVaHCJHXmSMqjxB8Jg=="],
+    "@cosmos/solidity-ibc-eureka": ["@cosmos/solidity-ibc-eureka@github:cosmos/ibc-contracts#3990431", { "dependencies": { "@openzeppelin/contracts": "^5.6.1", "@openzeppelin/contracts-upgradeable": "^5.6.1", "@uniswap/permit2": "github:Uniswap/permit2#cc56ad0f3439c502c246fc5cfcc3db92bb8b7219" } }, "cosmos-ibc-contracts-3990431", "sha512-cOem1rCQyJGuc1EK1R57Lj22vbBB7ynDYUNgDAOMnOF/a/khiw1fBc37ly55yaJsL8VygLVNsTxvW5NoOTS4eA=="],
 
     "@openzeppelin/contracts": ["@openzeppelin/contracts@5.6.1", "", {}, "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w=="],
 

--- a/e2e/internal/harness/environment/solidityibc/contracts/package.json
+++ b/e2e/internal/harness/environment/solidityibc/contracts/package.json
@@ -2,7 +2,7 @@
   "name": "@ibc-link/solidity-ibc-contract-artifacts",
   "private": true,
   "dependencies": {
-    "@cosmos/solidity-ibc-eureka": "github:cosmos/solidity-ibc-eureka#39904319467b5fbdec8c34c43b66af6f1d256dba",
+    "@cosmos/solidity-ibc-eureka": "github:cosmos/ibc-contracts#39904319467b5fbdec8c34c43b66af6f1d256dba",
     "@openzeppelin/contracts": "5.6.1",
     "@openzeppelin/contracts-upgradeable": "5.6.1"
   }


### PR DESCRIPTION
## Summary

- update the Solidity test-app dependency after `cosmos/solidity-ibc-eureka` was renamed to `cosmos/ibc-contracts`
- regenerate the Bun lockfile for the renamed GitHub archive
- add a dedicated E2E CI job that runs `make check-test-apps`

## Context

GitHub source archives include the repository name in their root directory. The August 6 repository rename changed the archive bytes while preserving the pinned Git commit, so Bun correctly rejected the old lockfile integrity hash.

## Verification

- `make check-test-apps`
- `make check-license-headers`
- `actionlint .github/workflows/e2e.yml`
