### PR TITLE
feat: reduce manual configuration

### DIFF
--- a/link/cmd/ibc/config.go
+++ b/link/cmd/ibc/config.go
@@ -45,7 +45,46 @@ var (
 		Short: "Validate the config",
 		RunE:  configValidate,
 	}
+
+	cmdConfigAddChain = &cobra.Command{
+		Use:   "add-chain",
+		Short: "Add a chain entry to the config",
+		RunE:  configAddChain,
+	}
 )
+
+var (
+	flagConfigAddChainID       string
+	flagConfigAddChainRPC      string
+	flagConfigAddChainRouter   string
+	flagConfigAddChainDeployer string
+)
+
+func configAddChain(_ *cobra.Command, _ []string) error {
+	globalFlags.SkipConfigValidation()
+
+	cfg, err := setupHomeWithConfig()
+	if err != nil {
+		return err
+	}
+
+	if _, ok := cfg.Chain(flagConfigAddChainID); ok {
+		return errors.Errorf("chain %q already exists in config", flagConfigAddChainID)
+	}
+
+	cfg.Chains = append(cfg.Chains, config.ChainConfig{
+		ChainID:  flagConfigAddChainID,
+		EVM:      &config.EVMChainConfig{RPC: flagConfigAddChainRPC, ICS26Router: flagConfigAddChainRouter},
+		Deployer: flagConfigAddChainDeployer,
+	})
+
+	configPath, err := globalFlags.ConfigPath()
+	if err != nil {
+		return err
+	}
+
+	return cfg.StoreToFileWithComments(configPath)
+}
 
 func configNew(_ *cobra.Command, _ []string) error {
 	configPath, err := globalFlags.ConfigPath()

--- a/link/cmd/ibc/deploy.go
+++ b/link/cmd/ibc/deploy.go
@@ -457,13 +457,45 @@ func deployShow(_ *cobra.Command, args []string) error {
 	return config.PrintJSON(m)
 }
 
-// renderedDeployment is the subset of the config schema render-config emits,
-// so the output can be merged into ibc.yml without zero-valued sections.
-type renderedDeployment struct {
-	Chains  []config.ChainConfig `yaml:"chains"`
-	Relayer struct {
-		Connections []config.ConnectionConfig `yaml:"connections"`
-	} `yaml:"relayer"`
+// attestorsFromClient projects one client's on-chain attestor addresses into
+// attestors: entries watching watchedChainID -- the chain that client
+// tracks
+func attestorsFromClient(cfg config.Config, c manifest.Client, watchedChainID string) config.Attestors {
+	addresses, _ := c.Params["attestors"].([]any)
+
+	out := make(config.Attestors, 0, len(addresses))
+	for _, raw := range addresses {
+		address, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		alias, _ := signerAliasForAddress(cfg, address)
+		out = append(out, config.AttestorConfig{
+			ChainID: watchedChainID,
+			Name:    fmt.Sprintf("attestor-%s-%s", watchedChainID, address),
+			Type:    config.AttestorTypeLocal,
+			Signer:  alias,
+		})
+	}
+	return out
+}
+
+// signerAliasForAddress finds the local signer in cfg whose derived EVM
+// address matches address, case-insensitively.
+func signerAliasForAddress(cfg config.Config, address string) (string, bool) {
+	for _, sc := range cfg.Signers {
+		if sc.Type != config.SignerLocal {
+			continue
+		}
+		derived, err := signer.EVMAddressOf(sc)
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(derived, address) {
+			return sc.Alias, true
+		}
+	}
+	return "", false
 }
 
 // renderedChain copies the operated-on chain's config (if declared) and sets
@@ -488,11 +520,24 @@ func renderedClientEnd(m *manifest.Manifest, c manifest.Client) config.ClientEnd
 	}
 }
 
+// renderedDeployment is the subset of the config schema render-config emits,
+// so the output can be merged into ibc.yml without unrelated sections.
+type renderedDeployment struct {
+	Chains  []config.ChainConfig `yaml:"chains"`
+	Relayer struct {
+		Connections []config.ConnectionConfig `yaml:"connections"`
+	} `yaml:"relayer"`
+	Attestors config.Attestors `yaml:"attestors"`
+}
+
 // renderRelayConfig projects two deployment manifests into the config
 // sections needed to relay between them for every mutual client pair.
-func renderRelayConfig(cfg config.Config, a, b *manifest.Manifest) (renderedDeployment, error) {
-	var out renderedDeployment
-	out.Chains = []config.ChainConfig{renderedChain(cfg, a), renderedChain(cfg, b)}
+func renderRelayConfig(cfg config.Config, a, b *manifest.Manifest) (renderedDeployment, map[string]string, error) {
+	full := cfg
+	full.Chains = []config.ChainConfig{renderedChain(cfg, a), renderedChain(cfg, b)}
+	full.Relayer.Connections = nil
+	full.Attestors = nil
+
 	baseAlias := a.ChainID + "-" + b.ChainID
 	for _, ca := range a.Clients {
 		if ca.CounterpartyChainID != b.ChainID {
@@ -503,17 +548,19 @@ func renderRelayConfig(cfg config.Config, a, b *manifest.Manifest) (renderedDepl
 			continue
 		}
 		alias := baseAlias
-		if seq := len(out.Relayer.Connections); seq > 0 {
+		if seq := len(full.Relayer.Connections); seq > 0 {
 			alias = fmt.Sprintf("%s-%d", baseAlias, seq)
 		}
-		out.Relayer.Connections = append(out.Relayer.Connections, config.ConnectionConfig{
+		full.Relayer.Connections = append(full.Relayer.Connections, config.ConnectionConfig{
 			Alias:   alias,
 			ClientA: renderedClientEnd(a, ca),
 			ClientB: renderedClientEnd(b, cb),
 		})
+		full.Attestors = append(full.Attestors, attestorsFromClient(cfg, ca, b.ChainID)...)
+		full.Attestors = append(full.Attestors, attestorsFromClient(cfg, cb, a.ChainID)...)
 	}
-	if len(out.Relayer.Connections) == 0 {
-		return renderedDeployment{}, errors.Errorf(
+	if len(full.Relayer.Connections) == 0 {
+		return renderedDeployment{}, nil, errors.Errorf(
 			"no mutual client pair between chains %s and %s: run `ibc deploy client` on each chain first (chains %s and %s)",
 			a.ChainID,
 			b.ChainID,
@@ -521,25 +568,11 @@ func renderRelayConfig(cfg config.Config, a, b *manifest.Manifest) (renderedDepl
 			b.ChainID,
 		)
 	}
-	return out, nil
-}
 
-// signerPlaceholderComments annotates every rendered client end's blank
-// signer field.
-func signerPlaceholderComments(out renderedDeployment) map[string]string {
-	comments := make(map[string]string, 2*len(out.Relayer.Connections))
-	for i, conn := range out.Relayer.Connections {
-		ends := []struct {
-			field string
-			end   config.ClientEnd
-		}{{"clientA", conn.ClientA}, {"clientB", conn.ClientB}}
-		for _, e := range ends {
-			path := fmt.Sprintf("$.relayer.connections[%d].%s.signer", i, e.field)
-			comments[path] = fmt.Sprintf("TODO: signers[] alias that submits relay txs on %s", e.end.ChainID)
-		}
-	}
+	out := renderedDeployment{Chains: full.Chains, Attestors: full.Attestors}
+	out.Relayer.Connections = full.Relayer.Connections
 
-	return comments
+	return out, config.CollectComments(full), nil
 }
 
 func deployRenderConfig(_ *cobra.Command, args []string) error {
@@ -561,11 +594,11 @@ func deployRenderConfig(_ *cobra.Command, args []string) error {
 		}
 		manifests[i] = m
 	}
-	out, err := renderRelayConfig(cfg, manifests[0], manifests[1])
+	out, comments, err := renderRelayConfig(cfg, manifests[0], manifests[1])
 	if err != nil {
 		return err
 	}
-	return config.PrintYAMLWithComments(out, signerPlaceholderComments(out))
+	return config.PrintYAMLWithComments(out, comments)
 }
 
 // deployerAddress derives the deployer's EVM address, for use as the default

--- a/link/cmd/ibc/deploy.go
+++ b/link/cmd/ibc/deploy.go
@@ -475,6 +475,9 @@ func attestorsFromClient(cfg config.Config, c manifest.Client, watchedChainID st
 			Name:    fmt.Sprintf("attestor-%s-%s", watchedChainID, address),
 			Type:    config.AttestorTypeLocal,
 			Signer:  alias,
+			// 1 is a safe default for most chains; CollectComments still
+			// flags it for review since not every chain needs it.
+			FinalityOffset: 1,
 		})
 	}
 	return out

--- a/link/cmd/ibc/deploy.go
+++ b/link/cmd/ibc/deploy.go
@@ -458,8 +458,7 @@ func deployShow(_ *cobra.Command, args []string) error {
 }
 
 // attestorsFromClient projects one client's on-chain attestor addresses into
-// attestors: entries watching watchedChainID -- the chain that client
-// tracks
+// attestors
 func attestorsFromClient(cfg config.Config, c manifest.Client, watchedChainID string) config.Attestors {
 	addresses, _ := c.Params["attestors"].([]any)
 
@@ -475,12 +474,27 @@ func attestorsFromClient(cfg config.Config, c manifest.Client, watchedChainID st
 			Name:    fmt.Sprintf("attestor-%s-%s", watchedChainID, address),
 			Type:    config.AttestorTypeLocal,
 			Signer:  alias,
-			// 1 is a safe default for most chains; CollectComments still
-			// flags it for review since not every chain needs it.
+			// default to 1 so it doesn't wait for native chain finality;
+			// CollectComments still flags it for review.
 			FinalityOffset: 1,
 		})
 	}
 	return out
+}
+
+func appendUniqueAttestors(
+	existing config.Attestors,
+	seen map[string]struct{},
+	additional config.Attestors,
+) config.Attestors {
+	for _, a := range additional {
+		if _, dup := seen[a.Name]; dup {
+			continue
+		}
+		seen[a.Name] = struct{}{}
+		existing = append(existing, a)
+	}
+	return existing
 }
 
 // signerAliasForAddress finds the local signer in cfg whose derived EVM
@@ -542,6 +556,7 @@ func renderRelayConfig(cfg config.Config, a, b *manifest.Manifest) (renderedDepl
 	full.Attestors = nil
 
 	baseAlias := a.ChainID + "-" + b.ChainID
+	seenAttestors := make(map[string]struct{})
 	for _, ca := range a.Clients {
 		if ca.CounterpartyChainID != b.ChainID {
 			continue
@@ -559,8 +574,8 @@ func renderRelayConfig(cfg config.Config, a, b *manifest.Manifest) (renderedDepl
 			ClientA: renderedClientEnd(a, ca),
 			ClientB: renderedClientEnd(b, cb),
 		})
-		full.Attestors = append(full.Attestors, attestorsFromClient(cfg, ca, b.ChainID)...)
-		full.Attestors = append(full.Attestors, attestorsFromClient(cfg, cb, a.ChainID)...)
+		full.Attestors = appendUniqueAttestors(full.Attestors, seenAttestors, attestorsFromClient(cfg, ca, b.ChainID))
+		full.Attestors = appendUniqueAttestors(full.Attestors, seenAttestors, attestorsFromClient(cfg, cb, a.ChainID))
 	}
 	if len(full.Relayer.Connections) == 0 {
 		return renderedDeployment{}, nil, errors.Errorf(

--- a/link/cmd/ibc/deploy_test.go
+++ b/link/cmd/ibc/deploy_test.go
@@ -5,13 +5,34 @@ package main
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/ibc/link/internal/config"
 	"github.com/cosmos/ibc/link/internal/deploy/manifest"
+	"github.com/cosmos/ibc/link/internal/service/signer"
 )
+
+// newLocalSignerConfig generates a real local secp256k1 key, stores it to a
+// temp keyfile, and returns both the config entry referencing it and its
+// derived EVM address -- attestor resolution derives addresses the same way,
+// so tests need a real key to exercise it end to end.
+func newLocalSignerConfig(t *testing.T, alias string) (config.SignerConfig, string) {
+	t.Helper()
+
+	key, err := signer.GenerateLocalSecp256k1Signer()
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), alias+".json")
+	require.NoError(t, key.StoreToFile(path))
+
+	address, err := signer.PublicKeyToEVMAddress(key.PublicKey())
+	require.NoError(t, err)
+
+	return config.SignerConfig{Alias: alias, Type: config.SignerLocal, File: path}, address
+}
 
 func TestResolveDeployerAlias(t *testing.T) {
 	chain := config.ChainConfig{ChainID: "1", Deployer: "cfg-alias"}
@@ -45,6 +66,8 @@ func TestStatusChains(t *testing.T) {
 }
 
 func TestRenderRelayConfig(t *testing.T) {
+	watcherSigner, watcherAddress := newLocalSignerConfig(t, "attestor-watching-2")
+
 	// client ids follow defaultClientID's real convention: both ends of a
 	// connection share the same sorted "link-<a>-<b>" name.
 	a := manifest.New("1", "evm")
@@ -52,7 +75,10 @@ func TestRenderRelayConfig(t *testing.T) {
 	a.UpsertClient(manifest.Client{
 		ClientID: "link-1-2", Type: "attestation", Address: "0xca",
 		CounterpartyChainID: "2", CounterpartyClientID: "link-1-2",
-		Params: map[string]any{"threshold": float64(2)},
+		Params: map[string]any{
+			"threshold": float64(2),
+			"attestors": []any{watcherAddress, "0xUnresolvedAddress"},
+		},
 	})
 	// stray client tracking another chain must not pair
 	a.UpsertClient(manifest.Client{
@@ -76,13 +102,18 @@ func TestRenderRelayConfig(t *testing.T) {
 	b.UpsertClient(manifest.Client{
 		ClientID: "custom-b", Type: "attestation", Address: "0xcb2",
 		CounterpartyChainID: "1", CounterpartyClientID: "custom-a",
+		// no configured attestors: must not surface as an attestors: entry
 		Params: map[string]any{"threshold": float64(2)},
 	})
 
-	cfg := config.Config{Chains: []config.ChainConfig{
-		{ChainID: "1", EVM: &config.EVMChainConfig{RPC: "http://a", ICS26Router: "0xstale"}},
-	}}
-	out, err := renderRelayConfig(cfg, a, b)
+	unreferencedSigner, _ := newLocalSignerConfig(t, "unused-signer")
+	cfg := config.Config{
+		Chains: []config.ChainConfig{
+			{ChainID: "1", EVM: &config.EVMChainConfig{RPC: "http://a", ICS26Router: "0xstale"}},
+		},
+		Signers: config.Signers{watcherSigner, unreferencedSigner},
+	}
+	out, _, err := renderRelayConfig(cfg, a, b)
 	require.NoError(t, err)
 
 	// chain 1 is declared: its config is copied, router updated, rpc kept
@@ -109,10 +140,22 @@ func TestRenderRelayConfig(t *testing.T) {
 	require.Equal(t, "custom-a", conn2.ClientA.ClientID)
 	require.Equal(t, "custom-b", conn2.ClientB.ClientID)
 
+	// A's first client has two attestor addresses: one resolves to a
+	// configured signer, one doesn't -- both still get an entry, watching
+	// chain 2 (the chain that client tracks); every other client has no
+	// configured attestors at all to project
+	require.Len(t, out.Attestors, 2)
+	require.Equal(t, "2", out.Attestors[0].ChainID)
+	require.Equal(t, "attestor-2-"+watcherAddress, out.Attestors[0].Name)
+	require.Equal(t, "attestor-watching-2", out.Attestors[0].Signer)
+	require.Equal(t, config.AttestorTypeLocal, out.Attestors[0].Type)
+	require.Equal(t, "attestor-2-0xUnresolvedAddress", out.Attestors[1].Name)
+	require.Empty(t, out.Attestors[1].Signer)
+
 	// no mutual pair: B has no client tracking A back
 	empty := manifest.New("2", "evm")
 	empty.Core.Router = "0xrouterB"
-	_, err = renderRelayConfig(cfg, a, empty)
+	_, _, err = renderRelayConfig(cfg, a, empty)
 	require.ErrorContains(t, err, "no mutual client pair")
 
 	// mismatched back-reference: B's client points at a different A client
@@ -122,60 +165,41 @@ func TestRenderRelayConfig(t *testing.T) {
 		ClientID: "link-1", Type: "attestation",
 		CounterpartyChainID: "1", CounterpartyClientID: "link-other",
 	})
-	_, err = renderRelayConfig(cfg, a, mismatched)
+	_, _, err = renderRelayConfig(cfg, a, mismatched)
 	require.ErrorContains(t, err, "no mutual client pair")
-}
-
-func TestSignerPlaceholderComments(t *testing.T) {
-	out := renderedDeployment{}
-	out.Relayer.Connections = []config.ConnectionConfig{
-		{
-			Alias:   "1-2",
-			ClientA: config.ClientEnd{ChainID: "1", ClientID: "link-1-2"},
-			ClientB: config.ClientEnd{ChainID: "2", ClientID: "link-1-2"},
-		},
-		{
-			Alias:   "1-2-1",
-			ClientA: config.ClientEnd{ChainID: "1", ClientID: "custom-a"},
-			ClientB: config.ClientEnd{ChainID: "2", ClientID: "custom-b"},
-		},
-	}
-
-	// every end of every connection is annotated, naming the chain whose
-	// transactions that signer pays for
-	require.Equal(t, map[string]string{
-		"$.relayer.connections[0].clientA.signer": "TODO: signers[] alias that submits relay txs on 1",
-		"$.relayer.connections[0].clientB.signer": "TODO: signers[] alias that submits relay txs on 2",
-		"$.relayer.connections[1].clientA.signer": "TODO: signers[] alias that submits relay txs on 1",
-		"$.relayer.connections[1].clientB.signer": "TODO: signers[] alias that submits relay txs on 2",
-	}, signerPlaceholderComments(out))
 }
 
 // goccy silently drops comments whose path doesn't resolve, so assert the
 // paths agree with the emitted document rather than just with each other.
-func TestRenderConfigEmitsSignerPlaceholders(t *testing.T) {
+// CollectComments' own logic is unit-tested directly in internal/config.
+func TestRenderConfigEmitsComments(t *testing.T) {
 	a := manifest.New("1", "evm")
 	a.Core.Router = "0xrouterA"
 	a.UpsertClient(manifest.Client{
 		ClientID: "link-1-2", Type: "attestation",
 		CounterpartyChainID: "2", CounterpartyClientID: "link-1-2",
+		// unresolvable address: exercises the attestor signer TODO
+		Params: map[string]any{"attestors": []any{"0xUnresolvedAddress"}},
 	})
 	b := manifest.New("2", "evm")
-	b.Core.Router = "0xrouterB"
+	// chain 2's router is left blank on purpose: exercises the ics26Router
+	// TODO alongside the signer TODOs in the same render
 	b.UpsertClient(manifest.Client{
 		ClientID: "link-1-2", Type: "attestation",
 		CounterpartyChainID: "1", CounterpartyClientID: "link-1-2",
 	})
 
-	out, err := renderRelayConfig(config.Config{}, a, b)
+	out, comments, err := renderRelayConfig(config.Config{}, a, b)
 	require.NoError(t, err)
 
 	rendered := captureStdout(t, func() {
-		require.NoError(t, config.PrintYAMLWithComments(out, signerPlaceholderComments(out)))
+		require.NoError(t, config.PrintYAMLWithComments(out, comments))
 	})
 
-	require.Contains(t, rendered, `signer: "" # TODO: signers[] alias that submits relay txs on 1`)
-	require.Contains(t, rendered, `signer: "" # TODO: signers[] alias that submits relay txs on 2`)
+	require.Contains(t, rendered, `signer: "" # TODO: signers[] alias that submits relay txs on chainA`)
+	require.Contains(t, rendered, `signer: "" # TODO: signers[] alias that submits relay txs on chainB`)
+	require.Contains(t, rendered, `ics26Router: "" # TODO: fill in`)
+	require.Contains(t, rendered, `signer: "" # TODO: signers[] alias backing this attestor's key`)
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/link/cmd/ibc/deploy_test.go
+++ b/link/cmd/ibc/deploy_test.go
@@ -149,8 +149,10 @@ func TestRenderRelayConfig(t *testing.T) {
 	require.Equal(t, "attestor-2-"+watcherAddress, out.Attestors[0].Name)
 	require.Equal(t, "attestor-watching-2", out.Attestors[0].Signer)
 	require.Equal(t, config.AttestorTypeLocal, out.Attestors[0].Type)
+	require.EqualValues(t, 1, out.Attestors[0].FinalityOffset)
 	require.Equal(t, "attestor-2-0xUnresolvedAddress", out.Attestors[1].Name)
 	require.Empty(t, out.Attestors[1].Signer)
+	require.EqualValues(t, 1, out.Attestors[1].FinalityOffset)
 
 	// no mutual pair: B has no client tracking A back
 	empty := manifest.New("2", "evm")

--- a/link/cmd/ibc/deploy_test.go
+++ b/link/cmd/ibc/deploy_test.go
@@ -86,11 +86,15 @@ func TestRenderRelayConfig(t *testing.T) {
 		CounterpartyChainID: "9", CounterpartyClientID: "link-1-9",
 	})
 	// a second, custom-named connection between the same chain pair --
-	// exercises the alias seqno suffix.
+	// exercises the alias seqno suffix, and reuses the same attestor address
+	// watching chain 2 to exercise cross-connection attestor deduplication.
 	a.UpsertClient(manifest.Client{
 		ClientID: "custom-a", Type: "attestation", Address: "0xca2",
 		CounterpartyChainID: "2", CounterpartyClientID: "custom-b",
-		Params: map[string]any{"threshold": float64(2)},
+		Params: map[string]any{
+			"threshold": float64(2),
+			"attestors": []any{watcherAddress},
+		},
 	})
 	b := manifest.New("2", "evm")
 	b.Core.Router = "0xrouterB"
@@ -142,8 +146,8 @@ func TestRenderRelayConfig(t *testing.T) {
 
 	// A's first client has two attestor addresses: one resolves to a
 	// configured signer, one doesn't -- both still get an entry, watching
-	// chain 2 (the chain that client tracks); every other client has no
-	// configured attestors at all to project
+	// chain 2 (the chain that client tracks). A's second client (custom-a)
+	// reuses watcherAddress and must not produce a duplicate entry.
 	require.Len(t, out.Attestors, 2)
 	require.Equal(t, "2", out.Attestors[0].ChainID)
 	require.Equal(t, "attestor-2-"+watcherAddress, out.Attestors[0].Name)

--- a/link/cmd/ibc/keys.go
+++ b/link/cmd/ibc/keys.go
@@ -19,6 +19,7 @@ import (
 var (
 	flagKeysShowPrivate      bool
 	flagKeysImportPrivateKey string
+	flagKeysPopulateConfig   bool
 )
 
 var (
@@ -63,7 +64,7 @@ var (
 func keysNew(_ *cobra.Command, args []string) error {
 	globalFlags.SkipConfigValidation()
 
-	_, err := setupHomeWithConfig()
+	cfg, err := setupHomeWithConfig()
 	if err != nil {
 		return err
 	}
@@ -81,6 +82,10 @@ func keysNew(_ *cobra.Command, args []string) error {
 	saveKey := len(args) > 1
 
 	if !saveKey {
+		if flagKeysPopulateConfig {
+			return fmt.Errorf("--populate-config requires a key name")
+		}
+
 		// for ephemeral keys we print the key to stdout including the private key
 		return printKey(key, true, nil)
 	}
@@ -91,7 +96,25 @@ func keysNew(_ *cobra.Command, args []string) error {
 	}
 
 	if err := key.StoreToFile(keyPath); err != nil {
-		return err
+		switch {
+		case !os.IsExist(err):
+			return err
+		case !flagKeysPopulateConfig:
+			return fmt.Errorf("key already exists: %s", keyPath)
+		}
+
+		// --populate-config: an already-existing key is fine, load what's
+		// actually on disk instead of erroring
+		key, err = signer.LocalKeyFromFile(keyPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	if flagKeysPopulateConfig {
+		if err := addSignerToConfig(cfg, args[1]); err != nil {
+			return err
+		}
 	}
 
 	// note that we don't print the private key here to avoid leaking it to the user
@@ -157,7 +180,8 @@ func keysList(_ *cobra.Command, _ []string) error {
 func keysImport(_ *cobra.Command, args []string) error {
 	globalFlags.SkipConfigValidation()
 
-	if _, err := setupHomeWithConfig(); err != nil {
+	cfg, err := setupHomeWithConfig()
+	if err != nil {
 		return err
 	}
 
@@ -176,8 +200,21 @@ func keysImport(_ *cobra.Command, args []string) error {
 
 	_, err = os.Stat(keyPath)
 	switch {
-	case err == nil:
+	case err == nil && !flagKeysPopulateConfig:
 		return fmt.Errorf("key already exists: %s", keyPath)
+	case err == nil:
+		// --populate-config: reuse the existing keystore entry instead of
+		// erroring, no need to re-supply --private-key for it
+		key, loadErr := signer.LocalKeyFromFile(keyPath)
+		if loadErr != nil {
+			return loadErr
+		}
+		if configErr := addSignerToConfig(cfg, args[1]); configErr != nil {
+			return configErr
+		}
+		return printKey(key, false, map[string]any{
+			"path": keyPath,
+		})
 	case !os.IsNotExist(err):
 		return err
 	}
@@ -203,9 +240,41 @@ func keysImport(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	if flagKeysPopulateConfig {
+		if err := addSignerToConfig(cfg, args[1]); err != nil {
+			return err
+		}
+	}
+
 	return printKey(key, false, map[string]any{
 		"path": keyPath,
 	})
+}
+
+// addSignerToConfig appends a local signer entry for the given key to the
+// config file, so a freshly created/imported key is immediately usable as a
+// `signers:` alias without a manual edit. File is stored as the short-form
+// key name (not an absolute path) -- KeyFileFallbacks resolves that back to
+// <home>/keys/<name>.json, so the config stays portable across homes.
+// A no-op if the alias is already configured, so callers can populate the
+// config for a preexisting key without erroring.
+func addSignerToConfig(cfg config.Config, alias string) error {
+	if _, ok := cfg.Signer(alias); ok {
+		return nil
+	}
+
+	cfg.Signers = append(cfg.Signers, config.SignerConfig{
+		Alias: alias,
+		Type:  config.SignerLocal,
+		File:  alias,
+	})
+
+	configPath, err := globalFlags.ConfigPath()
+	if err != nil {
+		return err
+	}
+
+	return cfg.StoreToFileWithComments(configPath)
 }
 
 func printKey(key signer.LocalKey, showPrivate bool, extra map[string]any) error {

--- a/link/cmd/ibc/keys.go
+++ b/link/cmd/ibc/keys.go
@@ -253,11 +253,7 @@ func keysImport(_ *cobra.Command, args []string) error {
 
 // addSignerToConfig appends a local signer entry for the given key to the
 // config file, so a freshly created/imported key is immediately usable as a
-// `signers:` alias without a manual edit. File is stored as the short-form
-// key name (not an absolute path) -- KeyFileFallbacks resolves that back to
-// <home>/keys/<name>.json, so the config stays portable across homes.
-// A no-op if the alias is already configured, so callers can populate the
-// config for a preexisting key without erroring.
+// `signers:` alias without a manual edit.
 func addSignerToConfig(cfg config.Config, alias string) error {
 	if _, ok := cfg.Signer(alias); ok {
 		return nil

--- a/link/cmd/ibc/main.go
+++ b/link/cmd/ibc/main.go
@@ -66,16 +66,29 @@ func init() {
 		cmdTx,
 	)
 
-	cmdConfig.AddCommand(cmdConfigNew, cmdConfigValidate)
+	cmdConfig.AddCommand(cmdConfigNew, cmdConfigValidate, cmdConfigAddChain)
 	cmdConfigNew.Flags().BoolVar(&flagConfigNewOut, "out", false, "output the config to stdout")
 	cmdConfigValidate.Flags().BoolVar(&flagConfigValidateLive, "live", false, "extra validation checks")
 	cmdConfigValidate.Flags().
 		BoolVar(&flagConfigValidateStrict, "strict", false, "fail on unknown fields in the config file")
+	cmdConfigAddChain.Flags().StringVar(&flagConfigAddChainID, "chain-id", "", "chain ID")
+	cmdConfigAddChain.Flags().StringVar(&flagConfigAddChainRPC, "rpc", "", "chain RPC URL")
+	cmdConfigAddChain.Flags().
+		StringVar(&flagConfigAddChainRouter, "router", "", "ics26Router address (default: left blank, fill in via render-config)")
+	cmdConfigAddChain.Flags().
+		StringVar(&flagConfigAddChainDeployer, "deployer", "", "signer alias used by ibc deploy for this chain")
+	for _, req := range []string{"chain-id", "rpc"} {
+		_ = cmdConfigAddChain.MarkFlagRequired(req)
+	}
 
 	// Keys commands
 	cmdKeys.AddCommand(cmdKeysNew, cmdKeysShow, cmdKeysImport, cmdKeysList)
 	cmdKeysShow.Flags().BoolVarP(&flagKeysShowPrivate, "private", "", false, "show private key")
 	cmdKeysImport.Flags().StringVar(&flagKeysImportPrivateKey, "private-key", "", "hex-encoded private key")
+	for _, c := range []*cobra.Command{cmdKeysNew, cmdKeysImport} {
+		c.Flags().
+			BoolVar(&flagKeysPopulateConfig, "populate-config", false, "append the resulting key as a signers entry in the config file")
+	}
 
 	// Relayer commands
 	cmdRelayer.AddCommand(cmdRelayerRun, cmdRelayerRelay, cmdRelayerStatus)

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -673,7 +673,7 @@ func PrintYAMLWithComments(v any, comments map[string]string) error {
 // finalityOffsetTODO is attached to every local attestor's finalityOffset,
 // unconditionally: zero is both the default and a legitimate value, so
 // there's no "blank" state to detect the way there is for signer/router.
-const finalityOffsetTODO = `TODO: verify -- chains without a live "finalized" tag (e.g. Besu QBFT) need this set to 1+`
+const finalityOffsetTODO = `TODO: set appropriately. 0 defaults to chain finality`
 
 // CollectComments builds TODO comments for every field in cfg that's left
 // for the operator to fill in by hand, keyed by YAML path for

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -71,13 +71,11 @@ type AttestorConfig struct {
 	Type AttestorType `yaml:"type"`
 
 	// Signer required for type: local only -- the signer used to sign
-	// attestations. Not omitempty: a blank local signer needs to render so
-	// CollectComments' TODO on it actually shows up.
+	// attestations.
 	Signer string `yaml:"signer"`
 
 	// FinalityOffset local only. Zero attests up to the chain's "finalized"
-	// tag; n > 0 attests up to "latest" - n instead. Not omitempty: zero is
-	// also the un-set value, and CollectComments' TODO needs it to render.
+	// tag; n > 0 attests up to "latest" - n instead.
 	FinalityOffset uint `yaml:"finalityOffset"`
 
 	// GRPC required for type: remote only. Bare host:port.
@@ -629,8 +627,7 @@ func PrintJSON(v any) error {
 }
 
 // PrintProtoJSON prints a protobuf message as JSON to stdout, rendering enum
-// fields by name (e.g. "PACKET_STATE_PENDING") instead of their numeric
-// value, and keeping proto_name field naming to match PrintJSON's output.
+// fields by name
 func PrintProtoJSON(msg proto.Message) error {
 	bz, err := protojson.MarshalOptions{Indent: "  ", UseProtoNames: true, EmitUnpopulated: true}.Marshal(msg)
 	if err != nil {
@@ -656,9 +653,7 @@ func PrintYAML(v any) error {
 
 // PrintYAMLWithComments prints v as YAML to stdout, attaching a line comment
 // to every field addressed by a YAML path in comments, keyed as
-// "$.relayer.connections[0].clientA.signer". v need not be a Config -- e.g.
-// render-config prints a smaller projection than the Config comments were
-// collected against, as long as the two share the same field paths.
+// "$.relayer.connections[0].clientA.signer".
 func PrintYAMLWithComments(v any, comments map[string]string) error {
 	bz, err := yaml.MarshalWithOptions(v, yaml.WithComment(toCommentMap(comments)))
 	if err != nil {
@@ -670,17 +665,11 @@ func PrintYAMLWithComments(v any, comments map[string]string) error {
 	return nil
 }
 
-// finalityOffsetTODO is attached to every local attestor's finalityOffset,
-// unconditionally: zero is both the default and a legitimate value, so
-// there's no "blank" state to detect the way there is for signer/router.
 const finalityOffsetTODO = `TODO: set appropriately. 0 defaults to chain finality`
 
 // CollectComments builds TODO comments for every field in cfg that's left
 // for the operator to fill in by hand, keyed by YAML path for
-// PrintYAMLWithComments/StoreToFileWithComments. Kept as one explicit
-// function (not a generic path-walker) so a test can pin the exact set of
-// paths and messages and fail immediately if the config schema or these
-// paths drift.
+// PrintYAMLWithComments/StoreToFileWithComments.
 func CollectComments(cfg Config) map[string]string {
 	comments := map[string]string{}
 

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -70,12 +70,15 @@ type AttestorConfig struct {
 
 	Type AttestorType `yaml:"type"`
 
-	// Signer required for type: local only -- the signer used to sign attestations.
-	Signer string `yaml:"signer,omitempty"`
+	// Signer required for type: local only -- the signer used to sign
+	// attestations. Not omitempty: a blank local signer needs to render so
+	// CollectComments' TODO on it actually shows up.
+	Signer string `yaml:"signer"`
 
 	// FinalityOffset local only. Zero attests up to the chain's "finalized"
-	// tag; n > 0 attests up to "latest" - n instead.
-	FinalityOffset uint `yaml:"finalityOffset,omitempty"`
+	// tag; n > 0 attests up to "latest" - n instead. Not omitempty: zero is
+	// also the un-set value, and CollectComments' TODO needs it to render.
+	FinalityOffset uint `yaml:"finalityOffset"`
 
 	// GRPC required for type: remote only. Bare host:port.
 	GRPC string `yaml:"grpc,omitempty"`
@@ -93,13 +96,13 @@ type SignerConfig struct {
 	Type string `yaml:"type"`
 
 	// File key file path for a local signer
-	File string `yaml:"file"`
+	File string `yaml:"file,omitempty"`
 
 	// GRPC address for a remote signer
-	GRPC string `yaml:"grpc"`
+	GRPC string `yaml:"grpc,omitempty"`
 
 	// RemoteKeyID KMS key ID for a remote signer
-	RemoteKeyID string `yaml:"remoteKeyId"`
+	RemoteKeyID string `yaml:"remoteKeyId,omitempty"`
 }
 
 // ChainType the execution environment of a chain.
@@ -391,20 +394,37 @@ func (c ChainConfig) Validate() error {
 }
 
 func (c Config) StoreToFile(path string) error {
+	return c.store(path, nil)
+}
+
+// StoreToFileWithComments writes c to path as YAML, with a TODO comment
+// attached to every field CollectComments flags as left for the operator to
+// fill in.
+func (c Config) StoreToFileWithComments(path string) error {
+	return c.store(path, CollectComments(c))
+}
+
+func (c Config) store(path string, comments map[string]string) error {
 	if err := EnsureDirectory(path); err != nil {
 		return err
 	}
 
-	bz, err := yaml.Marshal(c)
+	bz, err := yaml.MarshalWithOptions(c, yaml.WithComment(toCommentMap(comments)))
 	if err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(path, bz, 0o644); err != nil {
-		return err
-	}
+	return os.WriteFile(path, bz, 0o644)
+}
 
-	return nil
+// toCommentMap converts comments (YAML path -> text) into a yaml.CommentMap
+// of line comments, as PrintYAMLWithComments/store both need.
+func toCommentMap(comments map[string]string) yaml.CommentMap {
+	cm := make(yaml.CommentMap, len(comments))
+	for path, text := range comments {
+		cm[path] = []*yaml.Comment{yaml.LineComment(" " + text)}
+	}
+	return cm
 }
 
 func (c ServerConfig) Validate() error {
@@ -609,7 +629,8 @@ func PrintJSON(v any) error {
 }
 
 // PrintProtoJSON prints a protobuf message as JSON to stdout, rendering enum
-// fields by name
+// fields by name (e.g. "PACKET_STATE_PENDING") instead of their numeric
+// value, and keeping proto_name field naming to match PrintJSON's output.
 func PrintProtoJSON(msg proto.Message) error {
 	bz, err := protojson.MarshalOptions{Indent: "  ", UseProtoNames: true, EmitUnpopulated: true}.Marshal(msg)
 	if err != nil {
@@ -633,16 +654,13 @@ func PrintYAML(v any) error {
 	return nil
 }
 
-// PrintYAMLWithComments prints anything as YAML to stdout, attaching a line
-// comment to every field addressed by a YAML path in comments, keyed as
-// "$.relayer.connections[0].clientA.signer".
+// PrintYAMLWithComments prints v as YAML to stdout, attaching a line comment
+// to every field addressed by a YAML path in comments, keyed as
+// "$.relayer.connections[0].clientA.signer". v need not be a Config -- e.g.
+// render-config prints a smaller projection than the Config comments were
+// collected against, as long as the two share the same field paths.
 func PrintYAMLWithComments(v any, comments map[string]string) error {
-	cm := make(yaml.CommentMap, len(comments))
-	for path, text := range comments {
-		cm[path] = []*yaml.Comment{yaml.LineComment(" " + text)}
-	}
-
-	bz, err := yaml.MarshalWithOptions(v, yaml.WithComment(cm))
+	bz, err := yaml.MarshalWithOptions(v, yaml.WithComment(toCommentMap(comments)))
 	if err != nil {
 		return err
 	}
@@ -650,6 +668,53 @@ func PrintYAMLWithComments(v any, comments map[string]string) error {
 	fmt.Println(string(bz))
 
 	return nil
+}
+
+// finalityOffsetTODO is attached to every local attestor's finalityOffset,
+// unconditionally: zero is both the default and a legitimate value, so
+// there's no "blank" state to detect the way there is for signer/router.
+const finalityOffsetTODO = `TODO: verify -- chains without a live "finalized" tag (e.g. Besu QBFT) need this set to 1+`
+
+// CollectComments builds TODO comments for every field in cfg that's left
+// for the operator to fill in by hand, keyed by YAML path for
+// PrintYAMLWithComments/StoreToFileWithComments. Kept as one explicit
+// function (not a generic path-walker) so a test can pin the exact set of
+// paths and messages and fail immediately if the config schema or these
+// paths drift.
+func CollectComments(cfg Config) map[string]string {
+	comments := map[string]string{}
+
+	for i, chain := range cfg.Chains {
+		if chain.EVM != nil && chain.EVM.ICS26Router == "" {
+			path := fmt.Sprintf("$.chains[%d].evm.ics26Router", i)
+			comments[path] = "TODO: fill in"
+		}
+	}
+
+	for i, conn := range cfg.Relayer.Connections {
+		if conn.ClientA.Signer == "" {
+			path := fmt.Sprintf("$.relayer.connections[%d].clientA.signer", i)
+			comments[path] = "TODO: signers[] alias that submits relay txs on chainA"
+		}
+		if conn.ClientB.Signer == "" {
+			path := fmt.Sprintf("$.relayer.connections[%d].clientB.signer", i)
+			comments[path] = "TODO: signers[] alias that submits relay txs on chainB"
+		}
+	}
+
+	for i, attestor := range cfg.Attestors {
+		if attestor.Type != AttestorTypeLocal {
+			continue
+		}
+		if attestor.Signer == "" {
+			path := fmt.Sprintf("$.attestors[%d].signer", i)
+			comments[path] = "TODO: signers[] alias backing this attestor's key"
+		}
+		path := fmt.Sprintf("$.attestors[%d].finalityOffset", i)
+		comments[path] = finalityOffsetTODO
+	}
+
+	return comments
 }
 
 func dbTypeFromURL(raw string) string {

--- a/link/internal/config/config_test.go
+++ b/link/internal/config/config_test.go
@@ -630,3 +630,39 @@ func TestConfigAccessors(t *testing.T) {
 	require.Equal(t, "a3", forChain[1].Name)
 	require.Empty(t, cfg.AttestorsForChain("9"))
 }
+
+func TestCollectComments(t *testing.T) {
+	cfg := Config{
+		Chains: []ChainConfig{
+			{ChainID: "1", EVM: &EVMChainConfig{ICS26Router: ""}},
+			{ChainID: "2", EVM: &EVMChainConfig{ICS26Router: "0xabc"}},
+		},
+		Relayer: RelayerConfig{Connections: []ConnectionConfig{
+			{ClientA: ClientEnd{ChainID: "1"}, ClientB: ClientEnd{ChainID: "2", Signer: "relayer-key"}},
+		}},
+		Attestors: Attestors{
+			{ChainID: "2", Name: "attestor-2-0xabc", Type: AttestorTypeLocal},
+			{ChainID: "1", Name: "attestor-1-0xdef", Type: AttestorTypeLocal, Signer: "watcher"},
+			{Name: "remote", Type: AttestorTypeRemote, GRPC: "attestor.example.com:3000"},
+		},
+	}
+
+	require.Equal(t, map[string]string{
+		"$.chains[0].evm.ics26Router":             "TODO: fill in",
+		"$.relayer.connections[0].clientA.signer": "TODO: signers[] alias that submits relay txs on chainA",
+		"$.attestors[0].signer":                   "TODO: signers[] alias backing this attestor's key",
+		"$.attestors[0].finalityOffset":           finalityOffsetTODO,
+		"$.attestors[1].finalityOffset":           finalityOffsetTODO,
+	}, CollectComments(cfg))
+
+	// nothing left blank -> only the always-on finalityOffset reminder remains
+	require.Equal(t, map[string]string{
+		"$.attestors[0].finalityOffset": finalityOffsetTODO,
+	}, CollectComments(Config{
+		Chains: []ChainConfig{{ChainID: "1", EVM: &EVMChainConfig{ICS26Router: "0xabc"}}},
+		Relayer: RelayerConfig{Connections: []ConnectionConfig{
+			{ClientA: ClientEnd{ChainID: "1", Signer: "a"}, ClientB: ClientEnd{ChainID: "2", Signer: "b"}},
+		}},
+		Attestors: Attestors{{ChainID: "1", Name: "a", Type: AttestorTypeLocal, Signer: "watcher"}},
+	}))
+}

--- a/link/internal/config/relayer_test.go
+++ b/link/internal/config/relayer_test.go
@@ -170,6 +170,12 @@ func TestRelayerConfig(t *testing.T) {
 				errContains: ".txSubmissionDelay must not be negative",
 			},
 			{
+				name: "missing router contract is allowed -- it's a deploy output, not operator input",
+				patch: func(c *Config) {
+					c.Chains[0].EVM.ICS26Router = ""
+				},
+			},
+			{
 				name: "zero gas multiplier",
 				patch: func(c *Config) {
 					zero := 0.0


### PR DESCRIPTION
### Changes

- `ibc config add-chain`
- extend render-config to render attestors as well. resolves attestor signers by address: on-chain attestor addresses recorded in a client's deployment manifest are matched against locally configured signers
- Some rendered configs have unset required config values. They get annotated with an explicit # TODO comment via a new config.CollectComments
- Rendered attestors default finalityOffset: 1 instead of leaving it at 0 — the safe default for most chains — with a short reminder comment (0 defaults to chain finality) since some chains do want 0.
- `ibc keys new/ibc keys import --populate-config`


The flow starting from zero is:

- `ibc config new`
- create and import signers with `--populate-config`
- add chains with `ibc config add-chain`
- `ibc deploy` to deploy everything
- `render-config` and copy chains, relayer, and attestor configs
- fill in relayer signer references