### PR TITLE
chore: default besu-to-besu chains to a shared account set

### DIFF
--- a/examples/besu-to-besu/README.md
+++ b/examples/besu-to-besu/README.md
@@ -6,14 +6,6 @@
 Two independent single-validator Besu QBFT chains (A and B), the substrate for a
 single IBC pair.
 
-> **DEMO KEYS — LOCAL DEVNET ONLY.** Every private key this example derives and
-> prints (to the console, the log files, and `chains/local/chains.env`) comes
-> from a publicly known BIP-39 test vector. They are worthless by design.
-> Never send real funds to any address here, never point `A_MNEMONIC`/
-> `B_MNEMONIC` at a phrase holding real funds, and never reuse these keys or
-> this key-handling approach outside this local example. See `setup.sh`'s
-> header for the full disclaimer.
-
 ## Prerequisites
 
 `docker` (with the compose v2 plugin), `curl`, `perl`.
@@ -54,17 +46,7 @@ Each invocation writes a timestamped log file to `logs/`.
 Each chain has its own mnemonic, but `B_MNEMONIC` defaults to the same phrase
 as `A_MNEMONIC`, so out of the box both chains fund the same account set:
 `FUNDED_ACCOUNTS` accounts (default 5) are funded with 1 000 000 ETH in each
-chain's genesis; index 0 is the deployer, index 1 the validator. Since the
-deployer and its nonce sequence match on both chains, identical `CREATE`
-deployments (core router, IFT tokens, ...) land at the same address on A and B.
-
-One key therefore works everywhere: import it once and reuse the same signer
-alias as deployer, relayer, and attestor signer on both chains. This is safe
-because the attestation light client this example bridges over trusts an
-explicitly configured attestor address set (`deploy client --attestors`), not
-either chain's own block-validator identity — sharing the validator carries no
-cross-chain signature-confusion risk.
-
+chain's genesis; index 0 is the deployer, index 1 the validator.
 Set `A_MNEMONIC` and `B_MNEMONIC` to different phrases if you want the chains
 to have fully independent account sets instead.
 

--- a/examples/besu-to-besu/README.md
+++ b/examples/besu-to-besu/README.md
@@ -6,6 +6,14 @@
 Two independent single-validator Besu QBFT chains (A and B), the substrate for a
 single IBC pair.
 
+> **DEMO KEYS — LOCAL DEVNET ONLY.** Every private key this example derives and
+> prints (to the console, the log files, and `chains/local/chains.env`) comes
+> from a publicly known BIP-39 test vector. They are worthless by design.
+> Never send real funds to any address here, never point `A_MNEMONIC`/
+> `B_MNEMONIC` at a phrase holding real funds, and never reuse these keys or
+> this key-handling approach outside this local example. See `setup.sh`'s
+> header for the full disclaimer.
+
 ## Prerequisites
 
 `docker` (with the compose v2 plugin), `curl`, `perl`.
@@ -38,19 +46,27 @@ Each invocation writes a timestamped log file to `logs/`.
 
 ## Chains and accounts
 
-| Chain | Chain ID | Validator source | Validator (default phrases) |
+| Chain | Chain ID | Validator source | Validator (default phrase) |
 |-------|---------:|------------------|-----------------------------|
 | A     |    41001 | `A_MNEMONIC` index 1 | `0x0D3eB21b6b21833A4939Cfff4810E9AE0758e12C` |
-| B     |    41002 | `B_MNEMONIC` index 1 | `0x45A1eF7572a5B9998b46E54AA5Dce838965acB35` |
+| B     |    41002 | `B_MNEMONIC` index 1 | `0x0D3eB21b6b21833A4939Cfff4810E9AE0758e12C` |
 
-Each chain has its own mnemonic and every account on it derives from that phrase,
-so the two chains share no accounts. `FUNDED_ACCOUNTS` accounts (default 5) are
-derived per chain and funded with 1 000 000 ETH in that chain's genesis and
-nowhere else; index 0 is that chain's deployer, index 1 its validator. Because
-the deployers differ, a contract deployed to both chains will **not** land at the
-same address — `CREATE` derives it from sender and nonce. Set `A_MNEMONIC` and
-`B_MNEMONIC` to the same value if you want shared accounts and matching contract
-addresses.
+Each chain has its own mnemonic, but `B_MNEMONIC` defaults to the same phrase
+as `A_MNEMONIC`, so out of the box both chains fund the same account set:
+`FUNDED_ACCOUNTS` accounts (default 5) are funded with 1 000 000 ETH in each
+chain's genesis; index 0 is the deployer, index 1 the validator. Since the
+deployer and its nonce sequence match on both chains, identical `CREATE`
+deployments (core router, IFT tokens, ...) land at the same address on A and B.
+
+One key therefore works everywhere: import it once and reuse the same signer
+alias as deployer, relayer, and attestor signer on both chains. This is safe
+because the attestation light client this example bridges over trusts an
+explicitly configured attestor address set (`deploy client --attestors`), not
+either chain's own block-validator identity — sharing the validator carries no
+cross-chain signature-confusion risk.
+
+Set `A_MNEMONIC` and `B_MNEMONIC` to different phrases if you want the chains
+to have fully independent account sets instead.
 
 
 ## Ports

--- a/examples/besu-to-besu/setup.sh
+++ b/examples/besu-to-besu/setup.sh
@@ -92,11 +92,7 @@ export FOUNDRY_IMAGE="${FOUNDRY_IMAGE:-ghcr.io/foundry-rs/foundry:latest}"
 
 # Key material. One mnemonic per chain, independently overridable, but
 # defaulted to the same phrase so out of the box both chains fund the same
-# account set -- deployer, relayer, attestor signer, and validator alike -- and
-# one key works everywhere. Sharing the validator carries no cross-chain risk:
-# the attestation light client this example bridges over trusts an explicitly
-# configured attestor address set (`deploy client --attestors`), not either
-# chain's own block-validator identity.
+# account set.
 #
 # The default below is a standard BIP-39 test vector, published in the spec
 # itself — demo material, safe to commit precisely because it protects nothing.

--- a/examples/besu-to-besu/setup.sh
+++ b/examples/besu-to-besu/setup.sh
@@ -51,8 +51,9 @@
 # Environment (optional):
 #   A_MNEMONIC           BIP-39 phrase every chain A account derives from
 #   B_MNEMONIC           BIP-39 phrase every chain B account derives from
-#                        (each chain has its own phrase, distinct from the
-#                        other's, so the chains share no accounts)
+#                        (defaults to the same phrase as A_MNEMONIC, so both
+#                        chains share the same account set, including the
+#                        validator; override independently for separate sets)
 #   A_VALIDATOR_INDEX    index of chain A's validator within A_MNEMONIC (1)
 #   B_VALIDATOR_INDEX    index of chain B's validator within B_MNEMONIC (1)
 #                        Index 0 of each phrase is that chain's deployer and is
@@ -89,25 +90,23 @@ export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(basename "$SCRIPT_DIR")}"
 export BESU_IMAGE="${BESU_IMAGE:-hyperledger/besu:25.4.0}"
 export FOUNDRY_IMAGE="${FOUNDRY_IMAGE:-ghcr.io/foundry-rs/foundry:latest}"
 
-# Key material. One mnemonic per chain, both publicly known devnet phrases.
-# Every account on a chain — deployer, validator, and the rest of the pre-funded
-# set — derives from that chain's phrase, so the two chains share no accounts.
+# Key material. One mnemonic per chain, independently overridable, but
+# defaulted to the same phrase so out of the box both chains fund the same
+# account set -- deployer, relayer, attestor signer, and validator alike -- and
+# one key works everywhere. Sharing the validator carries no cross-chain risk:
+# the attestation light client this example bridges over trusts an explicitly
+# configured attestor address set (`deploy client --attestors`), not either
+# chain's own block-validator identity.
 #
-# The phrases are deliberately distinct rather than two indices of one mnemonic.
-# A QBFT light client trusts the counterparty's validator set by address, so if
-# A and B shared a validator, a header signed for one chain would be
-# signature-valid against the other's client. Distinct phrases make that
-# impossible by construction.
-#
-# Both defaults below are standard BIP-39 test vectors, published in the spec
-# itself — demo material, safe to commit precisely because they protect nothing.
+# The default below is a standard BIP-39 test vector, published in the spec
+# itself — demo material, safe to commit precisely because it protects nothing.
 #
 # Never point either of these at a mnemonic holding real funds, on any network.
 # Everything derived from them is written to chains/local/<chain>/ unencrypted
 # for Besu to read, and their addresses are printed to the console and the log
 # file on every run.
 export A_MNEMONIC="${A_MNEMONIC:-legal winner thank year wave sausage worth useful legal winner thank yellow}"
-export B_MNEMONIC="${B_MNEMONIC:-letter advice cage absurd amount doctor acoustic avoid letter advice cage above}"
+export B_MNEMONIC="${B_MNEMONIC:-$A_MNEMONIC}"
 # Index 0 is the deployer on both chains and index 1 is the validator on both,
 # so no chain's block proposer is also the account sending txs. A validator is
 # its chain's coinbase and pockets the priority fee, which would otherwise make


### PR DESCRIPTION
Sets the mnemonic the funded accounts are derived from to be the same by default for the chains. This poses no security risk since it's local demo example and it is a QoL improvement for people running the demo to be able to do `ibc keys import relayer --private key 0x...` and use the same signer for the relayer on multiple chains.