### PR TITLE
feat(make): improve Makefile, deduplicate commands

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,7 @@ jobs:
           bun-version: 1.3.14
       - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1
       - run: go install github.com/ethereum/go-ethereum/cmd/abigen@v1.17.4
-      - run: make -C e2e check-test-apps
+      - run: make -C e2e check-stale
 
   e2e:
     needs: changes

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,10 +65,8 @@ jobs:
           cache-dependency-path: |
             link/go.sum
             e2e/go.sum
-      - run: make build-link
       - run: docker info
-      - run: go test -count=1 ./internal/... ./cmd/...
-        working-directory: e2e
+      - run: make -C e2e test-harness
         env:
           IBC_BIN: ${{ github.workspace }}/link/bin/ibc
 
@@ -87,7 +85,7 @@ jobs:
           bun-version: 1.3.14
       - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1
       - run: go install github.com/ethereum/go-ethereum/cmd/abigen@v1.17.4
-      - run: make check-test-apps
+      - run: make -C e2e check-test-apps
 
   e2e:
     needs: changes
@@ -104,7 +102,7 @@ jobs:
             link/go.sum
             e2e/go.sum
       - run: docker info
-      - run: make test-e2e
+      - run: make -C e2e test
 
   matrix:
     runs-on: ubuntu-latest
@@ -115,4 +113,4 @@ jobs:
           go-version-file: e2e/go.mod
           cache-dependency-path: e2e/go.sum
       - run: docker info
-      - run: make check-e2e-matrix
+      - run: make -C e2e check-matrix

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -18,8 +18,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
-        with:
-          go-version-file: link/go.mod
-          cache-dependency-path: link/go.sum
-      - run: make check-license-headers
+      - uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0

--- a/Makefile
+++ b/Makefile
@@ -3,93 +3,15 @@
 help: ## List repository commands
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-E2E_FLAGS ?= -count=1
-E2E_MODE ?= fast
 LICENSE_EYE_VERSION ?= 0.8.0
 
-E2E_DIR := e2e
-HARNESS_DIR := $(E2E_DIR)/internal/harness
-CONTRACT_BINDINGS := $(addprefix $(HARNESS_DIR)/environment/solidityibc/,\
-	accessmanager escrow testerc20 counter iftsendcallconstructor iftbatchtransfershim)
+lint-license: ## Check SPDX license headers
+	go run github.com/apache/skywalking-eyes/cmd/license-eye@v$(LICENSE_EYE_VERSION) \
+		--config .licenserc.yaml header check
 
-build-link: ## Build the Link binary
-	$(MAKE) -C link build
-
-install-link: ## Install the Link binary
-	$(MAKE) -C link install
-
-doctor-e2e: ## Check the runtime dependencies used by e2e tests
-	@command -v go >/dev/null || { echo "missing go" >&2; exit 1; }
-	@command -v docker >/dev/null || { echo "missing docker; Docker is required for e2e modes and matrix generation" >&2; exit 1; }
-	@docker info >/dev/null || { echo "docker daemon is not reachable" >&2; exit 1; }
-
-doctor-e2e-tools: ## Check the generation and lint tools used by repository e2e checks
-	@command -v forge >/dev/null || { echo "missing forge; Forge is required to verify test-app artifacts" >&2; exit 1; }
-	@command -v bun >/dev/null || { echo "missing bun; bun is required to install Solidity contract dependencies" >&2; exit 1; }
-	@command -v abigen >/dev/null || { echo "missing abigen; abigen is required to generate typed contract bindings" >&2; exit 1; }
-	@command -v jq >/dev/null || { echo "missing jq; jq is required to generate typed contract bindings" >&2; exit 1; }
-	@command -v golangci-lint >/dev/null || { echo "missing golangci-lint; it is required for e2e checks" >&2; exit 1; }
-
-test-harness: build-link ## Run harness tests, including Docker-backed integrations when available
-	go -C $(E2E_DIR) test ./internal/... ./cmd/...
-
-test-e2e: build-link ## Run e2e tests (E2E_MODE=... E2E_FLAGS=...)
-	# -parallel caps concurrent Docker environments; the GOMAXPROCS default can overload a large machine.
-	E2E_MODE=$(E2E_MODE) go -C $(E2E_DIR) test . -timeout 60m -parallel 4 $(E2E_FLAGS)
-
-generate-e2e-matrix: ## Regenerate the E2E provider and topology matrix (requires Docker)
-	go -C $(E2E_DIR) run ./cmd/e2e-matrix -write test-matrix.md
-
-check-e2e-matrix: ## Check that the E2E provider and topology matrix is current (requires Docker)
-	go -C $(E2E_DIR) run ./cmd/e2e-matrix -check test-matrix.md
-
-lint: lint-link lint-e2e ## Lint all Go modules
-
-lint-fix: lint-fix-link lint-fix-e2e ## Lint all Go modules and fix errors
-
-lint-link: ## Lint the Link module
-	$(MAKE) -C link lint
-
-lint-fix-link: ## Lint the Link module and fix errors
-	$(MAKE) -C link lint-fix
-
-lint-e2e: ## Lint the e2e module, harness included
-	cd $(E2E_DIR) && golangci-lint run
-
-lint-fix-e2e: ## Lint the e2e module, harness included, and fix errors
-	cd $(E2E_DIR) && golangci-lint run --fix
-
-clean-e2e-dry-run: ## Preview e2e processes and Docker resources
-	$(E2E_DIR)/scripts/clean.sh --dry-run
-
-clean-e2e: ## Kill e2e processes and remove Docker resources
-	$(E2E_DIR)/scripts/clean.sh
-
-test-apps: ## Rebuild test-app artifacts and typed Go bindings (requires bun, forge, abigen, and jq)
-	bun install --cwd $(HARNESS_DIR)/environment/solidityibc/contracts --frozen-lockfile
-	forge build --root $(HARNESS_DIR)/environment/solidityibc/contracts
-	$(E2E_DIR)/scripts/generate-contract-bindings.sh
-
-check-test-apps: ## Fail if typed Go contract bindings are stale
-	bun install --cwd $(HARNESS_DIR)/environment/solidityibc/contracts --frozen-lockfile
-	forge build --force --root $(HARNESS_DIR)/environment/solidityibc/contracts
-	$(E2E_DIR)/scripts/generate-contract-bindings.sh
-	@status="$$(git status --porcelain --untracked-files=all -- $(CONTRACT_BINDINGS))"; \
-		test -z "$$status" || { \
-			echo "contract bindings are stale — run 'make test-apps' and commit the result" >&2; \
-			echo "$$status" >&2; \
-			exit 1; \
-		}
-
-check-license-headers: ## Check SPDX license headers
-	go run github.com/apache/skywalking-eyes/cmd/license-eye@v$(LICENSE_EYE_VERSION) --config .licenserc.yaml header check
-
-check-link: ## Run Link-local checks
+# TODO
+check: check-license-headers ## Run all repository checks
 	$(MAKE) -C link check
+	$(MAKE) -C e2e check
 
-check-e2e: doctor-e2e doctor-e2e-tools test-harness lint-e2e check-test-apps test-e2e check-e2e-matrix ## Run all repository e2e checks
-
-check: check-license-headers check-link check-e2e ## Run license, Link, and repository e2e checks
-
-.PHONY: help build-link doctor-e2e doctor-e2e-tools test-harness test-e2e generate-e2e-matrix check-e2e-matrix lint lint-fix lint-link lint-fix-link lint-e2e lint-fix-e2e \
-	clean-e2e-dry-run clean-e2e test-apps check-test-apps check-license-headers check-link check-e2e check
+.PHONY: help lint-license

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ lint-license: ## Check SPDX license headers
 	go run github.com/apache/skywalking-eyes/cmd/license-eye@v$(LICENSE_EYE_VERSION) \
 		--config .licenserc.yaml header check
 
-# TODO
-check: check-license-headers ## Run all repository checks
-	$(MAKE) -C link check
-	$(MAKE) -C e2e check
+run-all-checks: ## Run "all-in-one" code validation step.
+	$(MAKE) -C link run-all-checks
+	$(MAKE) -C e2e run-all-checks
+	$(MAKE) lint-license
 
-.PHONY: help lint-license
+.PHONY: help lint-license run-all-checks

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -7,8 +7,8 @@ This module contains one root repository-level acceptance package: linear Go tes
 Solidity IBC stack (ICS26Router, ICS20Transfer, ICS27GMP) with attestation light clients and
 managed attestors.
 
-- Run from the repository root: `make test-e2e` uses fast mode;
-  `make test-e2e E2E_MODE=complete|production` selects another mode, and
+- Run from the repository root: `make -C e2e test` uses fast mode;
+  `make -C e2e test E2E_MODE=complete|production` selects another mode, and
   `E2E_FLAGS='-run TestTransfer_AutoRelay -count=1'` focuses a run. `-e2e.mode` in `E2E_FLAGS`
   overrides `E2E_MODE`.
 - Tests declare portable EVM, controlled-mining, or node-lifecycle requirements. Fast mode may
@@ -25,6 +25,6 @@ managed attestors.
   paused and resumed it is interval-only, so transaction inclusion may take one second.
 - `Environment` cleans up managed resources only. Attached chains remain caller-owned and expose no
   harness mining or node-lifecycle controls.
-- Run `make generate-e2e-matrix` after changing requirements or topology, and
-  `make check-e2e-matrix` to check the committed matrix. Both require Docker.
-- After a hard crash: `make clean-e2e-dry-run`, then `make clean-e2e` from the repository root.
+- Run `make -C e2e generate-matrix` after changing requirements or topology, and
+  `make -C e2e check-matrix` to check the committed matrix. Both require Docker.
+- After a hard crash: `make -C e2e clean-dry-run`, then `make -C e2e clean` from the repository root.

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -11,7 +11,6 @@ help: ## List e2e commands
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 doctor: ## Check the runtime dependencies used by e2e tests
-	@command -v go >/dev/null || { echo "missing go" >&2; exit 1; }
 	@command -v docker >/dev/null || { echo "missing docker; Docker is required for e2e modes and matrix generation" >&2; exit 1; }
 	@docker info >/dev/null || { echo "docker daemon is not reachable" >&2; exit 1; }
 
@@ -21,6 +20,12 @@ doctor-tools: ## Check the generation and lint tools used by e2e checks
 	@command -v abigen >/dev/null || { echo "missing abigen; abigen is required to generate typed contract bindings" >&2; exit 1; }
 	@command -v jq >/dev/null || { echo "missing jq; jq is required to generate typed contract bindings" >&2; exit 1; }
 	@command -v golangci-lint >/dev/null || { echo "missing golangci-lint; it is required for e2e checks" >&2; exit 1; }
+
+lint: ## Lint code
+	golangci-lint run
+
+lint-fix: ## Lint & fix code
+	golangci-lint run --fix
 
 test-harness: _build-link ## Run tests for e2e harness itself
 	go test ./internal/... ./cmd/... -count=1
@@ -40,22 +45,15 @@ generate-matrix: ## Regenerate the E2E provider and topology matrix
 check-matrix: ## Check that the generated E2E matrix is current
 	go run ./cmd/e2e-matrix -check test-matrix.md
 
-lint: ## Lint code
-	golangci-lint run
-
-lint-fix: ## Lint & fix code
-	golangci-lint run --fix
+clean: ## Kill e2e processes and remove Docker resources
+	./scripts/clean.sh
 
 clean-dry-run: ## Preview e2e processes and Docker resources
 	./scripts/clean.sh --dry-run
 
-clean: ## Kill e2e processes and remove Docker resources
-	./scripts/clean.sh
-
-check-test-apps: ## Fail if typed Go contract bindings are stale
-	bun install --cwd $(HARNESS_DIR)/environment/solidityibc/contracts --frozen-lockfile
-	forge build --force --root $(HARNESS_DIR)/environment/solidityibc/contracts
-	./scripts/generate-contract-bindings.sh
+check-stale: ## Run all checks for stale code
+	@echo "Checking for stale ABI Go bindings..."
+	$(MAKE) test-apps
 	@status="$$(git -C .. status --porcelain --untracked-files=all -- $(addprefix e2e/,$(CONTRACT_BINDINGS)))"; \
 		test -z "$$status" || { \
 			echo "contract bindings are stale — run 'make test-apps' and commit the result" >&2; \
@@ -63,7 +61,21 @@ check-test-apps: ## Fail if typed Go contract bindings are stale
 			exit 1; \
 		}
 
-check: doctor doctor-tools test-harness lint check-test-apps test check-matrix ## Run all e2e checks
+run-all-checks: doctor doctor-tools ## Run "all-in-one" code validation step.
+	@echo "==== 1. Linting ===="
+	$(MAKE) lint
+
+	@echo "==== 2. Checking for stale code ===="
+	$(MAKE) check-stale
+
+	@echo "==== 3. Testing harness ===="
+	$(MAKE) test-harness
+
+	@echo "==== 4. Running E2E ===="
+	$(MAKE) test
+
+	@echo "==== 5. Checking matrix ===="
+	$(MAKE) check-matrix
 
 # Hidden commands
 _build-link:
@@ -72,5 +84,5 @@ _build-link:
 .PHONY: help doctor doctor-tools lint lint-fix
 .PHONY: test-harness test-apps test
 .PHONY: generate-matrix check-matrix
-.PHONY:	clean-dry-run clean check-test-apps check
+.PHONY:	clean clean-dry-run check-stale run-all-checks
 .PHONY: _build-link

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+
+E2E_FLAGS ?= -count=1
+E2E_MODE ?= fast
+
+HARNESS_DIR := internal/harness
+CONTRACT_BINDINGS := $(addprefix $(HARNESS_DIR)/environment/solidityibc/,\
+	accessmanager escrow testerc20 counter iftsendcallconstructor iftbatchtransfershim)
+
+help: ## List e2e commands
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+doctor: ## Check the runtime dependencies used by e2e tests
+	@command -v go >/dev/null || { echo "missing go" >&2; exit 1; }
+	@command -v docker >/dev/null || { echo "missing docker; Docker is required for e2e modes and matrix generation" >&2; exit 1; }
+	@docker info >/dev/null || { echo "docker daemon is not reachable" >&2; exit 1; }
+
+doctor-tools: ## Check the generation and lint tools used by e2e checks
+	@command -v forge >/dev/null || { echo "missing forge; Forge is required to verify test-app artifacts" >&2; exit 1; }
+	@command -v bun >/dev/null || { echo "missing bun; bun is required to install Solidity contract dependencies" >&2; exit 1; }
+	@command -v abigen >/dev/null || { echo "missing abigen; abigen is required to generate typed contract bindings" >&2; exit 1; }
+	@command -v jq >/dev/null || { echo "missing jq; jq is required to generate typed contract bindings" >&2; exit 1; }
+	@command -v golangci-lint >/dev/null || { echo "missing golangci-lint; it is required for e2e checks" >&2; exit 1; }
+
+test-harness: _build-link ## Run tests for e2e harness itself
+	go test ./internal/... ./cmd/... -count=1
+
+test-apps: ## Rebuild test-app artifacts and typed Go bindings (requires bun, forge, abigen, and jq)
+	bun install --cwd $(HARNESS_DIR)/environment/solidityibc/contracts --frozen-lockfile
+	forge build --root $(HARNESS_DIR)/environment/solidityibc/contracts
+	./scripts/generate-contract-bindings.sh
+
+test: _build-link ## Run e2e tests (E2E_MODE=... E2E_FLAGS=...)
+	# -parallel caps concurrent Docker environments; the GOMAXPROCS default can overload a large machine.
+	E2E_MODE=$(E2E_MODE) go test . -timeout 60m -parallel 4 $(E2E_FLAGS)
+
+generate-matrix: ## Regenerate the E2E provider and topology matrix
+	go run ./cmd/e2e-matrix -write test-matrix.md
+
+check-matrix: ## Check that the generated E2E matrix is current
+	go run ./cmd/e2e-matrix -check test-matrix.md
+
+lint: ## Lint code
+	golangci-lint run
+
+lint-fix: ## Lint & fix code
+	golangci-lint run --fix
+
+clean-dry-run: ## Preview e2e processes and Docker resources
+	./scripts/clean.sh --dry-run
+
+clean: ## Kill e2e processes and remove Docker resources
+	./scripts/clean.sh
+
+check-test-apps: ## Fail if typed Go contract bindings are stale
+	bun install --cwd $(HARNESS_DIR)/environment/solidityibc/contracts --frozen-lockfile
+	forge build --force --root $(HARNESS_DIR)/environment/solidityibc/contracts
+	./scripts/generate-contract-bindings.sh
+	@status="$$(git -C .. status --porcelain --untracked-files=all -- $(addprefix e2e/,$(CONTRACT_BINDINGS)))"; \
+		test -z "$$status" || { \
+			echo "contract bindings are stale — run 'make test-apps' and commit the result" >&2; \
+			echo "$$status" >&2; \
+			exit 1; \
+		}
+
+check: doctor doctor-tools test-harness lint check-test-apps test check-matrix ## Run all e2e checks
+
+# Hidden commands
+_build-link:
+	$(MAKE) -C ../link build
+
+.PHONY: help doctor doctor-tools lint lint-fix
+.PHONY: test-harness test-apps test
+.PHONY: generate-matrix check-matrix
+.PHONY:	clean-dry-run clean check-test-apps check

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -2,6 +2,7 @@
 
 E2E_FLAGS ?= -count=1
 E2E_MODE ?= fast
+FORGE_BUILD_FLAGS ?=
 
 HARNESS_DIR := internal/harness
 CONTRACT_BINDINGS := $(addprefix $(HARNESS_DIR)/environment/solidityibc/,\
@@ -11,6 +12,7 @@ help: ## List e2e commands
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 doctor: ## Check the runtime dependencies used by e2e tests
+	@command -v go >/dev/null || { echo "missing go" >&2; exit 1; }
 	@command -v docker >/dev/null || { echo "missing docker; Docker is required for e2e modes and matrix generation" >&2; exit 1; }
 	@docker info >/dev/null || { echo "docker daemon is not reachable" >&2; exit 1; }
 
@@ -32,7 +34,7 @@ test-harness: _build-link ## Run tests for e2e harness itself
 
 test-apps: ## Rebuild test-app artifacts and typed Go bindings (requires bun, forge, abigen, and jq)
 	bun install --cwd $(HARNESS_DIR)/environment/solidityibc/contracts --frozen-lockfile
-	forge build --root $(HARNESS_DIR)/environment/solidityibc/contracts
+	forge build $(FORGE_BUILD_FLAGS) --root $(HARNESS_DIR)/environment/solidityibc/contracts
 	./scripts/generate-contract-bindings.sh
 
 test: _build-link ## Run e2e tests (E2E_MODE=... E2E_FLAGS=...)
@@ -53,10 +55,10 @@ clean-dry-run: ## Preview e2e processes and Docker resources
 
 check-stale: ## Run all checks for stale code
 	@echo "Checking for stale ABI Go bindings..."
-	$(MAKE) test-apps
-	@status="$$(git -C .. status --porcelain --untracked-files=all -- $(addprefix e2e/,$(CONTRACT_BINDINGS)))"; \
+	$(MAKE) test-apps FORGE_BUILD_FLAGS=--force
+	@status="$$(git status --porcelain --untracked-files=all -- $(CONTRACT_BINDINGS))"; \
 		test -z "$$status" || { \
-			echo "contract bindings are stale — run 'make test-apps' and commit the result" >&2; \
+			echo "contract bindings are stale — run 'make -C e2e test-apps' and commit the result" >&2; \
 			echo "$$status" >&2; \
 			exit 1; \
 		}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -73,3 +73,4 @@ _build-link:
 .PHONY: test-harness test-apps test
 .PHONY: generate-matrix check-matrix
 .PHONY:	clean-dry-run clean check-test-apps check
+.PHONY: _build-link

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,11 +16,10 @@ Run targets from the repository root:
 
 ```sh
 make -C e2e doctor
-make build-link
 make -C e2e test
 ```
 
-`make build-link` produces `link/bin/ibc`; `IBC_BIN` overrides that path. The real Link Relayer collects attestor signatures and submits recv, ack, and timeout transactions with attestation proofs, which the attestation light clients verify.
+The test target builds `link/bin/ibc`; `IBC_BIN` overrides that path. The real Link Relayer collects attestor signatures and submits recv, ack, and timeout transactions with attestation proofs, which the attestation light clients verify.
 
 Execution modes choose providers from each test's declared requirements:
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,9 +15,9 @@ The root package covers ICS20 transfer, ICS27 GMP, IFT (burn/mint on top of GMP)
 Run targets from the repository root:
 
 ```sh
-make doctor-e2e
+make -C e2e doctor
 make build-link
-make test-e2e
+make -C e2e test
 ```
 
 `make build-link` produces `link/bin/ibc`; `IBC_BIN` overrides that path. The real Link Relayer collects attestor signatures and submits recv, ack, and timeout transactions with attestation proofs, which the attestation light clients verify.
@@ -36,15 +36,15 @@ provide those harness controls. `complete` runs each test once with the fastest 
 it does not run every provider permutation.
 
 ```sh
-make test-e2e
-make test-e2e E2E_MODE=complete
-make test-e2e E2E_MODE=production
-make test-e2e E2E_FLAGS='-run TestIFTTransfer_AutoRelay -count=1'
-make test-e2e E2E_MODE=production E2E_FLAGS='-run TestCrossRoute -parallel 1 -count=1'
+make -C e2e test
+make -C e2e test E2E_MODE=complete
+make -C e2e test E2E_MODE=production
+make -C e2e test E2E_FLAGS='-run TestIFTTransfer_AutoRelay -count=1'
+make -C e2e test E2E_MODE=production E2E_FLAGS='-run TestCrossRoute -parallel 1 -count=1'
 ```
 
 `-e2e.mode` in `E2E_FLAGS` overrides `E2E_MODE`. After a hard crash, use
-`make clean-e2e-dry-run` and then `make clean-e2e`.
+`make -C e2e clean-dry-run` and then `make -C e2e clean`.
 
 Every environment-backed test calls `t.Parallel()` and boots its own environment; the Makefile caps concurrency at four environments. Pass `E2E_FLAGS='-parallel 1 -count=1'` to serialize when debugging.
 
@@ -113,8 +113,8 @@ specs for all three modes. Generation starts the caller-owned Anvil used by the 
 so Docker is required.
 
 ```sh
-make generate-e2e-matrix
-make check-e2e-matrix
+make -C e2e generate-matrix
+make -C e2e check-matrix
 ```
 
 Regenerate the matrix after changing test requirements or topology. The check compares generated

--- a/e2e/internal/harness/AGENTS.md
+++ b/e2e/internal/harness/AGENTS.md
@@ -17,5 +17,5 @@ corroborates outcomes by reading chain state with its own clients.
   with `--entrypoint anvil` (PID 1, so `docker stop`'s SIGTERM reaches it and shutdown is prompt
   instead of waiting out the kill grace). Don't reintroduce a shell-wrapped entrypoint.
   StopNode/StartNode fault injection is docker pause/unpause; chain state stays in memory.
-- Lint with `make lint-e2e` from the repository root; the shared root `.golangci.yml` covers the
+- Lint with `make -C e2e lint` from the repository root; the shared root `.golangci.yml` covers the
   harness and excludes exported-doc mandates for this internal test surface.

--- a/link/AGENTS.md
+++ b/link/AGENTS.md
@@ -7,4 +7,4 @@
 - Repository-wide black-box e2e lives in `../e2e`, with its harness in
   `../e2e/internal/harness` as a separate Go module. The real Link relayer submits packets through
   ICS26Router with attestation proofs signed by harness-managed attestors. Keep
-  `make test-e2e` green when changing that transport contract.
+  `make -C e2e test` green when changing that transport contract.

--- a/link/Makefile
+++ b/link/Makefile
@@ -35,7 +35,7 @@ lint-fix: ## Lint the code and fix errors
 	golangci-lint run --fix
 
 test: ## Run tests
-	go test ./... 
+	go test ./... -v
 
 codegen: codegen-sql codegen-proto codegen-abi codegen-mocks ## Generate code
 
@@ -46,7 +46,7 @@ codegen-proto: ## Generate Go proto bindings
 	cd ../proto && $(BUF) generate
 
 codegen-mocks: ## Generate mocks for the code
-	go run github.com/vektra/mockery/v3@v3.7.1 --log-level ERROR	
+	go run github.com/vektra/mockery/v3@v3.7.1 --log-level ERROR
 
 # todo: replace the copied ABI files and this target with the contracts' own build
 # outputs and go-abigen bindings once they are migrated from solidity-ibc-eureka

--- a/link/Makefile
+++ b/link/Makefile
@@ -34,6 +34,9 @@ lint: ## Lint the code
 lint-fix: ## Lint the code and fix errors
 	golangci-lint run --fix
 
+test: ## Run tests
+	go test ./... 
+
 codegen: codegen-sql codegen-proto codegen-abi codegen-mocks ## Generate code
 
 codegen-sql: ## Generate Go code based on migrations and queries
@@ -42,19 +45,8 @@ codegen-sql: ## Generate Go code based on migrations and queries
 codegen-proto: ## Generate Go proto bindings
 	cd ../proto && $(BUF) generate
 
-check-proto: ## Fail if Link's generated API is stale or the removed API module returns
-	@command -v buf >/dev/null || { echo "missing buf; buf is required to verify Link's generated API" >&2; exit 1; }
-	cd ../proto && buf generate
-	@status="$$(git -C .. status --porcelain --untracked-files=all -- \
-		':(glob)link/api/v2/**/*.pb.go' \
-		':(glob)link/api/v2/**/*.connect.go')"; \
-		test -z "$$status" || { echo "Link API bindings are stale — run 'make codegen-proto' and commit the result" >&2; echo "$$status" >&2; exit 1; }
-	@test ! -e ../api || { echo "the removed standalone API module still exists" >&2; exit 1; }
-	@old_api='github.com/cosmos/ibc/'api; \
-		! git -C .. grep -n -F "$$old_api" -- . || { echo "the removed API module is still referenced" >&2; exit 1; }
-
 codegen-mocks: ## Generate mocks for the code
-	go run github.com/vektra/mockery/v3@v3.7.1 --log-level ERROR
+	go run github.com/vektra/mockery/v3@v3.7.1 --log-level ERROR	
 
 # todo: replace the copied ABI files and this target with the contracts' own build
 # outputs and go-abigen bindings once they are migrated from solidity-ibc-eureka
@@ -72,9 +64,30 @@ codegen-abi: ## Generate Go bindings for EVM contract ABIs
 		--type Contract \
 		--out internal/chains/evm/contracts/attestation/attestation.go
 
-test: ## Run tests
-	go test ./... -v
+check-stale: ## Run all checks for stale code
+	@echo "Checking for stale proto bindings..."
+	$(MAKE) codegen-proto
+	@status="$$(git -C .. status --porcelain --untracked-files=all -- \
+		':(glob)link/api/v2/**/*.pb.go' \
+		':(glob)link/api/v2/**/*.connect.go')"; \
+		test -z "$$status" || { echo "Link API bindings are stale — run 'make codegen-proto' and commit the result" >&2; echo "$$status" >&2; exit 1; }
+	@test ! -e ../api || { echo "the removed standalone API module still exists" >&2; exit 1; }
+	@old_api='github.com/cosmos/ibc/'api; \
+		! git --no-pager -C .. grep -n -F "$$old_api" -- . || { echo "the removed API module is still referenced" >&2; exit 1; }
 
-check: build test lint check-proto ## Run Link build, tests, lint, and generation freshness
+run-all-checks: ## Run "all-in-one" code validation step.
+	@echo "==== 1. Linting ===="
+	$(MAKE) lint
 
-.PHONY: help build install docker-build lint lint-fix test codegen codegen-sql codegen-proto codegen-abi codegen-mocks check-proto check
+	@echo "==== 2. Checking for stale code ===="
+	$(MAKE) check-stale
+
+	@echo "==== 3. Building ===="
+	$(MAKE) build
+
+	@echo "==== 4. Testing ===="
+	$(MAKE) test
+
+.PHONY: help build install docker-build lint lint-fix test
+.PHONY: codegen codegen-sql codegen-proto codegen-abi codegen-mocks
+.PHONY: check-stale run-all-checks

--- a/link/README.md
+++ b/link/README.md
@@ -42,6 +42,6 @@ worked example.
 
 Repository-wide black-box tests live in [`../e2e/`](../e2e/README.md), with the harness in
 `../e2e/internal/harness` as a separate Go module. From the repository root,
-`make doctor-e2e && make test-e2e` runs the Link smoke suite.
+`make -C e2e doctor && make -C e2e test` runs the Link smoke suite.
 
 The accepted target for the harness is documented in [IBC Environment Architecture](HARNESS-ARCHITECTURE-DESIGN.md).


### PR DESCRIPTION
- [x] Streamline and simplify e2e's `make` commands 
- [x] Move e2e's `make` commands to e2e/Makefile
- [x] Fix CI `make` references
- [x] Rename some `make` commands (e.g. `make check` → `make run-all-checks`)


Closes FOU-1411