### PR TITLE
docs: address GMP review comments (FOU-1386, FOU-1392)

### DIFF
--- a/docs/3-applications/gmp.md
+++ b/docs/3-applications/gmp.md
@@ -92,7 +92,7 @@ Once the packet reaches the destination chain, the router hands it to that chain
 
 If one of those checks fails, the call never runs, and the acknowledgement carries an error instead. Either way the call runs at most once, because the [receive step](/how-ibc-works/packet-lifecycle) records a receipt for the packet on the destination chain and the same packet cannot be received twice.
 
-A relayer delivers the packet and pays for it. The destination call runs on whatever gas remains in the relayer's transaction, and neither the send message nor the packet carries a gas field, so gas budgeting belongs to the relayer. An attempt that reverts before the packet is received leaves the packet in flight, and a relayer can deliver it again with more gas until the packet's timeout.
+A relayer delivers the packet and pays for it. The destination call runs on whatever gas remains in the relayer's transaction, and neither the send message nor the packet carries a gas field, so gas budgeting belongs to the relayer. A delivery that reverts before the destination chain records the packet's receipt leaves the packet in flight, so a relayer can submit it again, with more gas if that was the problem, until the timeout passes. Once the receipt is written the packet is consumed, and the outcome comes back as an acknowledgement whether the call succeeded or not.
 
 ## Acknowledgements and callbacks
 

--- a/docs/3-applications/gmp.md
+++ b/docs/3-applications/gmp.md
@@ -35,7 +35,7 @@ struct SendCallMsg {
 - `sourceClient`: the local client identifier to send over.
 - `receiver`: the target contract's address, as a string.
 - `salt`: bytes that pick which of the sender's destination accounts makes the call.
-- `payload`: the call data for the target.
+- `payload`: the call data for the target, encoded the way the destination chain's GMP implementation expects.
 - `timeoutTimestamp`: an absolute time, in unix seconds. The timeout must be in the future.
 - `memo`: an optional string carried with the call.
 
@@ -43,7 +43,9 @@ The sender declares where the call goes, and GMP supplies who is calling. It sta
 
 The salt picks which of the sender's accounts makes the call. GMP mixes it into the account derivation along with the client and the sender, so the same sender arrives from a different address under a different salt. Leaving it empty gives the sender one account.
 
-The payload is the call data the target will run, and GMP passes it through without interpreting it. In IBC-solidity the packet data is ABI-encoded, and every GMP packet uses the same port, version, and encoding.
+The payload is opaque to GMP. GMP carries it to the destination chain and hands it to the target without interpreting it, so encoding it in the form the destination chain's GMP implementation can execute is the sender's job. In IBC-solidity that form is an ABI-encoded Solidity call: a four-byte function selector followed by its ABI-encoded arguments, which the destination account passes to the target verbatim.
+
+That is separate from how the packet itself is encoded. Every GMP packet uses the same port, version, and encoding, and in IBC-solidity the packet data is ABI-encoded under the encoding string `application/x-solidity-abi`.
 
 ## The destination account
 
@@ -79,7 +81,7 @@ flowchart LR
 
 ## Executing the call on the destination
 
-A relayer delivers the packet to the destination chain, where the router verifies its proof with the light client. The router then hands the packet to that chain's GMP application, which turns it into a call:
+Once the packet reaches the destination chain, the router hands it to that chain's GMP application, which turns it into a call:
 
 1. Checks the packet's version, encoding, and both port identifiers against its own constants.
 2. Confirms the payload carries call data.
@@ -88,9 +90,9 @@ A relayer delivers the packet to the destination chain, where the router verifie
 5. Asks the account to call the target with the payload as call data.
 6. Wraps whatever the target returned as the acknowledgement.
 
-The router then commits the acknowledgement and emits it for a relayer to carry home. If one of those checks fails, the call never runs, and the acknowledgement carries an error instead.
+If one of those checks fails, the call never runs, and the acknowledgement carries an error instead. Either way the call runs at most once, because the [receive step](/how-ibc-works/packet-lifecycle) records a receipt for the packet on the destination chain and the same packet cannot be received twice.
 
-A call executes only once. The [receive step](/how-ibc-works/packet-lifecycle) records a receipt for the packet on the destination chain, so the same packet cannot be executed again.
+A relayer delivers the packet and pays for it. The destination call runs on whatever gas remains in the relayer's transaction, and neither the send message nor the packet carries a gas field, so gas budgeting belongs to the relayer. An attempt that reverts before the packet is received leaves the packet in flight, and a relayer can deliver it again with more gas until the packet's timeout.
 
 ## Acknowledgements and callbacks
 
@@ -132,8 +134,6 @@ bytes internal constant UNIVERSAL_ERROR_ACK =
 ```
 
 The acknowledgement reports that the call failed. The destination chain's router emits the revert reason as an `IBCAppRecvPacketCallbackError` event, so finding out why means reading that chain's logs.
-
-The destination call runs on whatever gas remains in the relayer's transaction, and neither the send message nor the packet carries a gas field, so gas budgeting belongs to the relayer.
 
 The account forwards the destination call through `Address.functionCall`, which turns an empty revert into a `FailedCall` error. A target that runs out of gas reverts with a four-byte `FailedCall`, so the router writes the error acknowledgement and the packet is consumed. Empty revert data reaches the router only when the callback frame itself dies, and that is the case the router rejects outright, leaving the packet in flight. A relayer can then retry that packet with more gas.
 

--- a/docs/5-ibc-solidity-contracts/ics27-gmp-and-accounts.md
+++ b/docs/5-ibc-solidity-contracts/ics27-gmp-and-accounts.md
@@ -20,44 +20,37 @@ Interacts with: [ICS26Router](/ibc-solidity-contracts/ics26-router) for sends an
 | ICS27Lib | Library, compiled into ICS27GMP | Supplies the GMP constants, the acknowledgement encoding, and the account beacon-proxy bytecode used for CREATE2 | [ICS27Lib.sol](https://github.com/cosmos/ibc-contracts/blob/main/ibc-solidity/contracts/utils/ICS27Lib.sol) |
 | IBCSenderCallbacksLib | Library, compiled into ICS27GMP | Checks a sender's ERC165 support and makes the acknowledgement or timeout callback | [IBCSenderCallbacksLib.sol](https://github.com/cosmos/ibc-contracts/blob/main/ibc-solidity/contracts/utils/IBCSenderCallbacksLib.sol) |
 
-```mermaid
-flowchart LR
-  Router[ICS26Router]
-  GMP[ICS27GMP]
-  subgraph accounts["One ICS27Account per (clientId, sender, salt)"]
-    Acct1[ICS27Account]
-    Acct2[ICS27Account]
-  end
-  Target[Target contract]
-  Router <-- packets --> GMP
-  GMP -- deploys and drives --> Acct1
-  GMP -- deploys and drives --> Acct2
-  Acct1 -- call data --> Target
-```
-
 One ICS27Account exists per `(clientId, sender, salt)` triple, so a chain holds one account for every distinct triple that has received a call.
 
 ## How a call moves through the contracts
 
-A sender starts a call with `sendCall`, which builds the packet data and hands the packet to the router, which commits a record of it. It is then relayed to the destination chain's router.
-
-Once on the destination chain, the router verifies the packet with the light client and then calls `onRecvPacket`. ICS27GMP checks the payload's identity fields, finds or deploys the sender's account, and asks that account to call the receiver. The target's return data goes back to the router as the acknowledgement.
-
-Back on the source chain the router calls `onAcknowledgementPacket` when that acknowledgement arrives, or `onTimeoutPacket` when the deadline passes without receipt. Either handler recovers the original sender from the packet data and forwards the outcome to that sender's callback.
+A sender starts a call with `sendCall`, which builds the packet data and hands the packet to the router, which commits a record of it.
 
 ```mermaid
 sequenceDiagram
-    participant S as Sender contract<br/>chain A
-    participant G1 as ICS27GMP<br/>chain A
-    participant R1 as ICS26Router<br/>chain A
-    participant Rel as Relayer
-    participant R2 as ICS26Router<br/>chain B
-    participant G2 as ICS27GMP<br/>chain B
-    participant Ac as ICS27Account<br/>chain B
-    participant T as Target contract<br/>chain B
-
+    box Chain A
+        participant S as Sender contract
+        participant G1 as ICS27GMP
+        participant R1 as ICS26Router
+    end
     S->>G1: sendCall
     G1->>R1: sendPacket
+    R1-->>G1: sequence
+    G1-->>S: sequence
+    Note over R1: commits the packet for a relayer to pick up
+```
+
+Once a relayer carries it to the destination chain, the router verifies the packet with the light client and then calls `onRecvPacket`. ICS27GMP checks the payload's identity fields, finds or deploys the sender's account, and asks that account to call the receiver. The target's return data goes back to the router as the acknowledgement.
+
+```mermaid
+sequenceDiagram
+    participant Rel as Relayer
+    box Chain B
+        participant R2 as ICS26Router
+        participant G2 as ICS27GMP
+        participant Ac as ICS27Account
+        participant T as Target contract
+    end
     Rel->>R2: recvPacket with proof
     Note over R2: verifies with the light client
     R2->>G2: onRecvPacket
@@ -66,11 +59,31 @@ sequenceDiagram
     T-->>Ac: return data
     Ac-->>G2: result
     G2-->>R2: acknowledgement
+```
+
+Before it makes that call, `onRecvPacket` checks three things:
+
+- The payload's version, encoding, and both port identifiers match the ICS27 constants.
+- The payload carries bytes.
+- The `receiver` string parses as an EVM address, or the call reverts `ICS27InvalidReceiver`.
+
+Back on the source chain the router calls `onAcknowledgementPacket` when that acknowledgement arrives, or `onTimeoutPacket` when the deadline passes without receipt. Either handler recovers the original sender from the packet data and forwards the outcome to that sender's callback.
+
+```mermaid
+sequenceDiagram
+    participant Rel as Relayer
+    box Chain A
+        participant R1 as ICS26Router
+        participant G1 as ICS27GMP
+        participant S as Sender contract
+    end
     Rel->>R1: ackPacket with proof
     Note over R1: verifies with the light client
     R1->>G1: onAcknowledgementPacket
     G1-->>S: onAckPacket
 ```
+
+Only the router may call those three handlers, `onRecvPacket`, `onAcknowledgementPacket`, and `onTimeoutPacket`.
 
 ## Sending a call
 
@@ -137,28 +150,6 @@ The payload around it carries three more fields, fixed by constants in ICS27Lib 
 
 The memo travels in the packet data, and no handler reads it.
 
-## Packet handlers the router calls
-
-Packet handlers are the functions the router calls on an application when a packet arrives, when its acknowledgement comes back, and when it times out.
-
-Only the router may call the three handlers:
-
-| Function | What it does |
-|----------|--------------|
-| `onRecvPacket(OnRecvPacketCallback)` | Validates the payload, executes it through the sender's account, and returns the acknowledgement |
-| `onAcknowledgementPacket(OnAcknowledgementPacketCallback)` | Forwards the result to the original sender's callback |
-| `onTimeoutPacket(OnTimeoutPacketCallback)` | Forwards the timeout to the original sender's callback |
-
-`onRecvPacket` checks three things before the destination call:
-
-- The payload's version, encoding, and both port identifiers match the ICS27 constants.
-- The payload carries bytes.
-- The `receiver` string parses as an EVM address, or the call reverts `ICS27InvalidReceiver`.
-
-ICS27GMP then asks the account to make the call, as `account.functionCall(receiver, payload)`. The target's raw return data goes back to the router wrapped as `abi.encode(GMPAcknowledgement{ result })`.
-
-The other two handlers recover the original sender from the packet data and forward to it through IBCSenderCallbacksLib. The acknowledgement handler adds a `success` flag, set by comparing the acknowledgement against the universal error acknowledgement.
-
 ## Destination accounts and their addresses
 
 A destination account is the contract that makes a remote sender's call on this chain. It is identified by client, sender, and salt. It is deployed on first use at a CREATE2 address, which is computable in advance.
@@ -173,7 +164,7 @@ struct AccountIdentifier {
 }
 ```
 
-The salt is the sender's own choice, and changing it changes the identifier. One sender can drive several accounts on the same chain by choosing different salts.
+The salt is the sender's own choice, and changing it changes the identifier. One sender can drive several accounts on the same chain by choosing different salts. An empty salt is allowed, and gives the sender one default account per client.
 
 An account is deployed on the first inbound call for its identifier. ICS27GMP hashes the identifier, then uses that hash as the CREATE2 salt for a beacon proxy it deploys itself.
 

--- a/docs/5-ibc-solidity-contracts/ics27-gmp-and-accounts.md
+++ b/docs/5-ibc-solidity-contracts/ics27-gmp-and-accounts.md
@@ -83,7 +83,7 @@ sequenceDiagram
     G1-->>S: onAckPacket
 ```
 
-Only the router may call those three handlers, `onRecvPacket`, `onAcknowledgementPacket`, and `onTimeoutPacket`.
+The three handlers the router calls — `onRecvPacket`, `onAcknowledgementPacket`, and `onTimeoutPacket` — accept the router alone, and revert `ICS27Unauthorized` for any other caller.
 
 ## Sending a call
 
@@ -222,6 +222,8 @@ interface IIBCSenderCallbacks {
     function onTimeoutPacket(IIBCAppCallbacks.OnTimeoutPacketCallback calldata msg_) external;
 }
 ```
+
+The `success` flag is not carried in the acknowledgement. ICS27GMP derives it by hashing the acknowledgement bytes and comparing them against the universal error value, so anything that is not that value counts as success.
 
 IBCSenderCallbacksLib calls back only a sender that answers the ERC165 check, and skips any other in silence. A missing interface therefore costs the sender its callback, not the packet.
 


### PR DESCRIPTION
🤖 **Gnut** (automated assistant posting on behalf of Serdar)

Addresses the 8 inline comments I left in review https://github.com/cosmos/ibc/pull/1380#pullrequestreview-4980836083 on the two GMP pages (FOU-1386, FOU-1392). Based on `docs`, not `main`, so it lands as a follow-up on top of #1380's branch.

Two commits, one per page/ticket, so they can be reviewed separately.

| # | Comment | What changed |
|---|---|---|
| 1 | `gmp.md:46` — payload is opaque, must be encoded for the counterparty GMP impl | **Fixed.** The `payload` bullet and the paragraph now say the payload is opaque to GMP and that encoding it for the destination implementation is the sender's job; for IBC-solidity that is an ABI-encoded Solidity call (selector + ABI args) handed to the target verbatim. Split out the *packet data* encoding (`application/x-solidity-abi`) into its own paragraph, which the old text conflated with the payload encoding. |
| 2 | `gmp.md:80` — mostly packet lifecycle; say the relayer pays gas and insufficient gas can be retried | **Fixed.** Dropped the lifecycle narration (proof verification, router commits and emits the ack) down to the existing `/how-ibc-works/packet-lifecycle` link, kept the six GMP-specific steps, and added: the relayer delivers and pays, the call runs on whatever gas its transaction leaves, and an attempt that reverts before the packet is received leaves the packet in flight and can be re-delivered with more gas until the timeout. Also moved the gas paragraph out of "What comes back", where it was repeated. |
| 3 | `ics27-…:36` — flowchart not useful | **Cut.** Flowchart deleted; the "one account per `(clientId, sender, salt)`" line it sat above is kept. |
| 4 | `ics27-…:72` — diagram too complex, split it and box each chain | **Fixed.** The one 8-participant diagram is now three `sequenceDiagram`s — send, receive-and-execute, acknowledge — each paired with its own paragraph and using `box Chain A … end` / `box Chain B … end` so the chain name is no longer repeated in every participant label. |
| 5, 6 | `ics27-…:140` — title doesn't say what the section is; `ics27-…:160` — not sure this section is needed | **Cut.** "Packet handlers the router calls" is gone: its handler table restated "How a call moves through the contracts" and its closing paragraph restated "Acknowledgements and sender callbacks". The two things only it said — the three `onRecvPacket` checks, and that the router alone may call the three handlers — moved up into "How a call moves through the contracts". If you'd rather keep the section under a clearer title, say so and I'll restore it. |
| 7 | `ics27-…:176` — note that empty salt is allowed | **Fixed.** Added that an empty salt is allowed and gives the sender one default account per client, which matches what `gmp.md` already said. `sendCall` only rejects an empty *payload* (`ICS27PayloadEmpty`); salt length is never checked and is hashed as-is into the identifier. |
| 8 | `ics27-…:247` — "this is actually a bug in ICS27GMP if true" | **No doc change — deliberately.** Both copies of that paragraph (`ics27-gmp-and-accounts.md` and `gmp.md`) are left byte-identical and untouched, pending the answer to the bug question. If the `FailedCall` / empty-revert-data reasoning is wrong, both need rewriting together. Item 2's new wording is scoped to attempts that fail *before the packet is received*, so it doesn't contradict either copy whichever way that lands. |

Net effect: `gmp.md` +7/−7, `ics27-gmp-and-accounts.md` +42/−51 (one flowchart and one ~20-line section gone, one diagram split into three smaller ones).

Two things worth a look:

- **`box` in `sequenceDiagram`** is standard mermaid ≥9.4, but no other page in this docs set uses it, so it hasn't been confirmed against Mintlify's renderer here. If it doesn't render, the fallback is short participant aliases plus a `Note over` per chain.
- No other files are touched, no link paths changed, and no claim was altered beyond the seven items above.

Draft on purpose — marking it ready is @evan's call.
