### PR TITLE
fix(link): `ibc keys * ` fixes

### DIFF
--- a/link/cmd/ibc/config.go
+++ b/link/cmd/ibc/config.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/pkg/errors"
@@ -169,13 +170,43 @@ func setupHomeWithConfig() (config.Config, error) {
 		return config.Config{}, err
 	}
 
-	// allow db override
-	if globalFlags.DB != "" {
-		cfg.DB, err = config.DBConfigFromURL(globalFlags.DB)
-		if err != nil {
-			return config.Config{}, errors.Wrap(err, "invalid --db")
-		}
+	return cfg.OverrideFromFlags(globalFlags)
+}
+
+// setupHomeWithOptionalConfig changes process directory to `--home` and parses the config
+// if the config file doesn't exist, returns the default config
+func setupHomeWithOptionalConfig() (config.Config, error) {
+	logger := slog.Default().With("module", "config")
+
+	home, err := config.ExpandHome(globalFlags.Home)
+	if err != nil {
+		return config.Config{}, errors.Wrap(err, "home")
 	}
 
-	return cfg, nil
+	configPath, err := globalFlags.ConfigPath()
+	if err != nil {
+		return config.Config{}, errors.Wrap(err, "unable to get config path")
+	}
+
+	// ephemeral config
+	defaultConfig := config.DefaultConfig()
+
+	// if directory doesn't exist, return default config
+	if err = config.EnsureDirectory(configPath); err != nil {
+		logger.Debug("Config directory does not exist, returning default config", "path", configPath)
+		return defaultConfig, nil
+	}
+
+	if err = os.Chdir(home); err != nil {
+		return config.Config{}, errors.Wrapf(err, "unable to change working directory to %s", home)
+	}
+
+	// if file doesn't exist, return default config
+	cfg, err := config.LoadFromFile(configPath, globalFlags.ValidateConfig(), flagConfigValidateStrict)
+	if err != nil {
+		logger.Debug("Error loading config file, returning default config", "error", err, "path", configPath)
+		return defaultConfig, nil
+	}
+
+	return cfg.OverrideFromFlags(globalFlags)
 }

--- a/link/cmd/ibc/config.go
+++ b/link/cmd/ibc/config.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 
 	"github.com/pkg/errors"
@@ -170,43 +169,12 @@ func setupHomeWithConfig() (config.Config, error) {
 		return config.Config{}, err
 	}
 
-	return cfg.OverrideFromFlags(globalFlags)
-}
-
-// setupHomeWithOptionalConfig changes process directory to `--home` and parses the config
-// if the config file doesn't exist, returns the default config
-func setupHomeWithOptionalConfig() (config.Config, error) {
-	logger := slog.Default().With("module", "config")
-
-	home, err := config.ExpandHome(globalFlags.Home)
-	if err != nil {
-		return config.Config{}, errors.Wrap(err, "home")
+	if globalFlags.DB != "" {
+		cfg.DB, err = config.DBConfigFromURL(globalFlags.DB)
+		if err != nil {
+			return config.Config{}, errors.Wrap(err, "invalid --db")
+		}
 	}
 
-	configPath, err := globalFlags.ConfigPath()
-	if err != nil {
-		return config.Config{}, errors.Wrap(err, "unable to get config path")
-	}
-
-	// ephemeral config
-	defaultConfig := config.DefaultConfig()
-
-	// if directory doesn't exist, return default config
-	if err = config.EnsureDirectory(configPath); err != nil {
-		logger.Debug("Config directory does not exist, returning default config", "path", configPath)
-		return defaultConfig, nil
-	}
-
-	if err = os.Chdir(home); err != nil {
-		return config.Config{}, errors.Wrapf(err, "unable to change working directory to %s", home)
-	}
-
-	// if file doesn't exist, return default config
-	cfg, err := config.LoadFromFile(configPath, globalFlags.ValidateConfig(), flagConfigValidateStrict)
-	if err != nil {
-		logger.Debug("Error loading config file, returning default config", "error", err, "path", configPath)
-		return defaultConfig, nil
-	}
-
-	return cfg.OverrideFromFlags(globalFlags)
+	return cfg, nil
 }

--- a/link/cmd/ibc/keys.go
+++ b/link/cmd/ibc/keys.go
@@ -64,7 +64,7 @@ var (
 func keysNew(_ *cobra.Command, args []string) error {
 	globalFlags.SkipConfigValidation()
 
-	cfg, err := setupHomeWithConfig()
+	cfg, err := setupHomeWithOptionalConfig()
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func keysNew(_ *cobra.Command, args []string) error {
 func keysShow(_ *cobra.Command, args []string) error {
 	globalFlags.SkipConfigValidation()
 
-	_, err := setupHomeWithConfig()
+	_, err := setupHomeWithOptionalConfig()
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func keysShow(_ *cobra.Command, args []string) error {
 func keysList(_ *cobra.Command, _ []string) error {
 	globalFlags.SkipConfigValidation()
 
-	_, err := setupHomeWithConfig()
+	_, err := setupHomeWithOptionalConfig()
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func keysList(_ *cobra.Command, _ []string) error {
 func keysImport(_ *cobra.Command, args []string) error {
 	globalFlags.SkipConfigValidation()
 
-	cfg, err := setupHomeWithConfig()
+	cfg, err := setupHomeWithOptionalConfig()
 	if err != nil {
 		return err
 	}

--- a/link/cmd/ibc/keys.go
+++ b/link/cmd/ibc/keys.go
@@ -5,6 +5,7 @@ package main
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,9 +27,6 @@ var (
 	cmdKeys = &cobra.Command{
 		Use:   "keys",
 		Short: "Key management commands",
-		PersistentPreRun: func(_ *cobra.Command, _ []string) {
-			globalFlags.SkipConfigValidation()
-		},
 	}
 
 	cmdKeysNew = &cobra.Command{
@@ -65,11 +63,6 @@ var (
 
 //nolint:goconst // cli usage
 func keysNew(_ *cobra.Command, args []string) error {
-	cfg, err := setupHomeWithOptionalConfig()
-	if err != nil {
-		return err
-	}
-
 	keyType, err := signer.ParseKeyType(args[0])
 	if err != nil {
 		return err
@@ -92,23 +85,9 @@ func keysNew(_ *cobra.Command, args []string) error {
 	}
 
 	keyName := args[1]
-	keyPath, err := signer.KeyFilePath(globalFlags.Home, keyName)
+	keyPath, err := saveNamedKey(key, keyName, flagKeysPopulateConfig)
 	if err != nil {
 		return err
-	}
-
-	if err := key.StoreToFile(keyPath); err != nil {
-		if !os.IsExist(err) {
-			return err
-		}
-
-		return fmt.Errorf("key already exists: %s", keyPath)
-	}
-
-	if flagKeysPopulateConfig {
-		if err := addSignerToConfig(cfg, keyName); err != nil {
-			return err
-		}
 	}
 
 	// note that we don't print the private key here to avoid leaking it to the user
@@ -118,11 +97,6 @@ func keysNew(_ *cobra.Command, args []string) error {
 }
 
 func keysShow(_ *cobra.Command, args []string) error {
-	_, err := setupHomeWithOptionalConfig()
-	if err != nil {
-		return err
-	}
-
 	keyPath, err := signer.KeyFilePath(globalFlags.Home, args[0])
 	if err != nil {
 		return err
@@ -139,11 +113,6 @@ func keysShow(_ *cobra.Command, args []string) error {
 }
 
 func keysList(_ *cobra.Command, _ []string) error {
-	_, err := setupHomeWithOptionalConfig()
-	if err != nil {
-		return err
-	}
-
 	keyPath, err := config.ExpandHome(filepath.Join(globalFlags.Home, "keys"))
 	if err != nil {
 		return err
@@ -168,15 +137,6 @@ func keysList(_ *cobra.Command, _ []string) error {
 }
 
 func keysImport(_ *cobra.Command, args []string) error {
-	cfg, err := setupHomeWithOptionalConfig()
-	if err != nil {
-		return err
-	}
-
-	if flagKeysImportPrivateKey == "" {
-		return fmt.Errorf("--private-key is required")
-	}
-
 	keyType, err := signer.ParseKeyType(args[0])
 	switch {
 	case err != nil:
@@ -186,15 +146,6 @@ func keysImport(_ *cobra.Command, args []string) error {
 	}
 
 	keyName := args[1]
-	keyPath, err := signer.KeyFilePath(globalFlags.Home, keyName)
-	if err != nil {
-		return err
-	}
-
-	if _, err = os.Stat(keyPath); err == nil {
-		return fmt.Errorf("key already exists: %s", keyPath)
-	}
-
 	privateKey, err := signer.DecodeHex(flagKeysImportPrivateKey)
 	if err != nil {
 		return fmt.Errorf("decode private key: %w", err)
@@ -205,17 +156,9 @@ func keysImport(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("create ecdsa key: %w", err)
 	}
 
-	if err := key.StoreToFile(keyPath); err != nil {
-		if os.IsExist(err) {
-			return fmt.Errorf("key already exists: %s", keyPath)
-		}
+	keyPath, err := saveNamedKey(key, keyName, flagKeysPopulateConfig)
+	if err != nil {
 		return err
-	}
-
-	if flagKeysPopulateConfig {
-		if err := addSignerToConfig(cfg, keyName); err != nil {
-			return err
-		}
 	}
 
 	return printKey(key, false, map[string]any{
@@ -223,29 +166,56 @@ func keysImport(_ *cobra.Command, args []string) error {
 	})
 }
 
-// addSignerToConfig appends a local signer entry for the given key to the
-// config file, so a freshly created/imported key is immediately usable
-// as a `signers:` alias without a manual edit.
-// note: cfg argument is NOT modified, be careful.
-func addSignerToConfig(cfg config.Config, alias string) error {
-	signer := config.SignerConfig{
-		Alias: alias,
-		Type:  config.SignerLocal,
-		File:  alias,
-	}
-
-	cfg, added := cfg.AddSigner(signer)
-	if !added {
-		// already exists, no need to add
-		return nil
-	}
-
-	configPath, err := globalFlags.ConfigPath()
+func saveNamedKey(key signer.LocalKey, name string, populateConfig bool) (string, error) {
+	keyPath, err := signer.KeyFilePath(globalFlags.Home, name)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return cfg.StoreToFileWithComments(configPath)
+	var (
+		cfg        config.Config
+		configPath string
+	)
+	if populateConfig {
+		configPath, err = globalFlags.ConfigPath()
+		if err != nil {
+			return "", err
+		}
+
+		cfg, err = config.LoadFromFile(configPath, false, false)
+		if os.IsNotExist(err) {
+			cfg = config.DefaultConfig()
+		} else if err != nil {
+			return "", err
+		}
+
+		if _, exists := cfg.Signer(name); exists {
+			return "", fmt.Errorf("signer alias already exists: %q", name)
+		}
+	}
+
+	if err := key.StoreToFile(keyPath); err != nil {
+		if os.IsExist(err) {
+			return "", fmt.Errorf("key already exists: %s", keyPath)
+		}
+		return "", err
+	}
+
+	if !populateConfig {
+		return keyPath, nil
+	}
+
+	cfg.Signers = append(cfg.Signers, config.SignerConfig{
+		Alias: name,
+		Type:  config.SignerLocal,
+		File:  name,
+	})
+
+	if err := cfg.StoreToFileWithComments(configPath); err != nil {
+		return "", errors.Join(err, os.Remove(keyPath))
+	}
+
+	return keyPath, nil
 }
 
 func printKey(key signer.LocalKey, showPrivate bool, extra map[string]any) error {

--- a/link/cmd/ibc/keys.go
+++ b/link/cmd/ibc/keys.go
@@ -91,29 +91,22 @@ func keysNew(_ *cobra.Command, args []string) error {
 		return printKey(key, true, nil)
 	}
 
-	keyPath, err := signer.KeyFilePath(globalFlags.Home, args[1])
+	keyName := args[1]
+	keyPath, err := signer.KeyFilePath(globalFlags.Home, keyName)
 	if err != nil {
 		return err
 	}
 
 	if err := key.StoreToFile(keyPath); err != nil {
-		switch {
-		case !os.IsExist(err):
+		if !os.IsExist(err) {
 			return err
-		case !flagKeysPopulateConfig:
-			return fmt.Errorf("key already exists: %s", keyPath)
 		}
 
-		// --populate-config: an already-existing key is fine, load what's
-		// actually on disk instead of erroring
-		key, err = signer.LocalKeyFromFile(keyPath)
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("key already exists: %s", keyPath)
 	}
 
 	if flagKeysPopulateConfig {
-		if err := addSignerToConfig(cfg, args[1]); err != nil {
+		if err := addSignerToConfig(cfg, keyName); err != nil {
 			return err
 		}
 	}
@@ -180,42 +173,26 @@ func keysImport(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	if flagKeysImportPrivateKey == "" {
+		return fmt.Errorf("--private-key is required")
+	}
+
 	keyType, err := signer.ParseKeyType(args[0])
 	switch {
 	case err != nil:
 		return err
-	case keyType == keyfile.EDDSA:
-		return fmt.Errorf("importing eddsa keys is not supported")
+	case keyType != keyfile.ECDSA:
+		return fmt.Errorf("only ecdsa keys are supported")
 	}
 
-	keyPath, err := signer.KeyFilePath(globalFlags.Home, args[1])
+	keyName := args[1]
+	keyPath, err := signer.KeyFilePath(globalFlags.Home, keyName)
 	if err != nil {
 		return err
 	}
 
-	_, err = os.Stat(keyPath)
-	switch {
-	case err == nil && !flagKeysPopulateConfig:
+	if _, err = os.Stat(keyPath); err == nil {
 		return fmt.Errorf("key already exists: %s", keyPath)
-	case err == nil:
-		// --populate-config: reuse the existing keystore entry instead of
-		// erroring, no need to re-supply --private-key for it
-		key, loadErr := signer.LocalKeyFromFile(keyPath)
-		if loadErr != nil {
-			return loadErr
-		}
-		if configErr := addSignerToConfig(cfg, args[1]); configErr != nil {
-			return configErr
-		}
-		return printKey(key, false, map[string]any{
-			"path": keyPath,
-		})
-	case !os.IsNotExist(err):
-		return err
-	}
-
-	if flagKeysImportPrivateKey == "" {
-		return fmt.Errorf("--private-key is required")
 	}
 
 	privateKey, err := signer.DecodeHex(flagKeysImportPrivateKey)
@@ -236,7 +213,7 @@ func keysImport(_ *cobra.Command, args []string) error {
 	}
 
 	if flagKeysPopulateConfig {
-		if err := addSignerToConfig(cfg, args[1]); err != nil {
+		if err := addSignerToConfig(cfg, keyName); err != nil {
 			return err
 		}
 	}
@@ -247,18 +224,21 @@ func keysImport(_ *cobra.Command, args []string) error {
 }
 
 // addSignerToConfig appends a local signer entry for the given key to the
-// config file, so a freshly created/imported key is immediately usable as a
-// `signers:` alias without a manual edit.
+// config file, so a freshly created/imported key is immediately usable
+// as a `signers:` alias without a manual edit.
+// note: cfg argument is NOT modified, be careful.
 func addSignerToConfig(cfg config.Config, alias string) error {
-	if _, ok := cfg.Signer(alias); ok {
-		return nil
-	}
-
-	cfg.Signers = append(cfg.Signers, config.SignerConfig{
+	signer := config.SignerConfig{
 		Alias: alias,
 		Type:  config.SignerLocal,
 		File:  alias,
-	})
+	}
+
+	cfg, added := cfg.AddSigner(signer)
+	if !added {
+		// already exists, no need to add
+		return nil
+	}
 
 	configPath, err := globalFlags.ConfigPath()
 	if err != nil {

--- a/link/cmd/ibc/keys.go
+++ b/link/cmd/ibc/keys.go
@@ -26,6 +26,9 @@ var (
 	cmdKeys = &cobra.Command{
 		Use:   "keys",
 		Short: "Key management commands",
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+			globalFlags.SkipConfigValidation()
+		},
 	}
 
 	cmdKeysNew = &cobra.Command{
@@ -62,8 +65,6 @@ var (
 
 //nolint:goconst // cli usage
 func keysNew(_ *cobra.Command, args []string) error {
-	globalFlags.SkipConfigValidation()
-
 	cfg, err := setupHomeWithOptionalConfig()
 	if err != nil {
 		return err
@@ -124,8 +125,6 @@ func keysNew(_ *cobra.Command, args []string) error {
 }
 
 func keysShow(_ *cobra.Command, args []string) error {
-	globalFlags.SkipConfigValidation()
-
 	_, err := setupHomeWithOptionalConfig()
 	if err != nil {
 		return err
@@ -147,8 +146,6 @@ func keysShow(_ *cobra.Command, args []string) error {
 }
 
 func keysList(_ *cobra.Command, _ []string) error {
-	globalFlags.SkipConfigValidation()
-
 	_, err := setupHomeWithOptionalConfig()
 	if err != nil {
 		return err
@@ -178,8 +175,6 @@ func keysList(_ *cobra.Command, _ []string) error {
 }
 
 func keysImport(_ *cobra.Command, args []string) error {
-	globalFlags.SkipConfigValidation()
-
 	cfg, err := setupHomeWithOptionalConfig()
 	if err != nil {
 		return err

--- a/link/cmd/ibc/keys_test.go
+++ b/link/cmd/ibc/keys_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/ibc/link/internal/config"
+	"github.com/cosmos/ibc/link/internal/service/signer"
+)
+
+func TestSaveNamedKeyPopulatesConfig(t *testing.T) {
+	useKeyTestHome(t)
+
+	key, err := signer.GenerateLocalSecp256k1Signer()
+	require.NoError(t, err)
+	keyPath, err := saveNamedKey(key, "alice", true)
+	require.NoError(t, err)
+	require.FileExists(t, keyPath)
+
+	configPath, err := globalFlags.ConfigPath()
+	require.NoError(t, err)
+	cfg, err := config.LoadFromFile(configPath, false, false)
+	require.NoError(t, err)
+	require.Equal(t, config.Signers{{
+		Alias: "alice",
+		Type:  config.SignerLocal,
+		File:  "alice",
+	}}, cfg.Signers)
+}
+
+func TestSaveNamedKeyRejectsExistingSigner(t *testing.T) {
+	useKeyTestHome(t)
+
+	cfg := config.DefaultConfig()
+	cfg.Signers = config.Signers{{
+		Alias:       "alice",
+		Type:        config.SignerRemote,
+		GRPC:        "localhost:3000",
+		RemoteKeyID: "alice",
+	}}
+	configPath, err := globalFlags.ConfigPath()
+	require.NoError(t, err)
+	require.NoError(t, cfg.StoreToFile(configPath))
+
+	key, err := signer.GenerateLocalSecp256k1Signer()
+	require.NoError(t, err)
+	_, err = saveNamedKey(key, "alice", true)
+	require.ErrorContains(t, err, "signer alias already exists")
+
+	keyPath, err := signer.KeyFilePath(globalFlags.Home, "alice")
+	require.NoError(t, err)
+	require.NoFileExists(t, keyPath)
+}
+
+func TestSaveNamedKeyRollsBackAfterConfigWriteFailure(t *testing.T) {
+	home := useKeyTestHome(t)
+
+	configPath, err := globalFlags.ConfigPath()
+	require.NoError(t, err)
+	require.NoError(t, config.DefaultConfig().StoreToFile(configPath))
+	require.NoError(t, os.MkdirAll(filepath.Join(home, "keys"), 0o700))
+	require.NoError(t, os.Chmod(home, 0o500))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(home, 0o700)) })
+
+	if probe, probeErr := os.CreateTemp(home, "probe"); probeErr == nil {
+		_ = probe.Close()
+		_ = os.Remove(probe.Name())
+		t.Skip("filesystem permits writes to a read-only directory")
+	}
+
+	key, err := signer.GenerateLocalSecp256k1Signer()
+	require.NoError(t, err)
+	_, err = saveNamedKey(key, "alice", true)
+	require.Error(t, err)
+
+	keyPath, err := signer.KeyFilePath(home, "alice")
+	require.NoError(t, err)
+	require.NoFileExists(t, keyPath)
+}
+
+func TestSaveNamedKeyRejectsInvalidConfig(t *testing.T) {
+	useKeyTestHome(t)
+
+	configPath, err := globalFlags.ConfigPath()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, []byte("\tinvalid"), 0o600))
+
+	key, err := signer.GenerateLocalSecp256k1Signer()
+	require.NoError(t, err)
+	_, err = saveNamedKey(key, "alice", true)
+	require.Error(t, err)
+
+	keyPath, err := signer.KeyFilePath(globalFlags.Home, "alice")
+	require.NoError(t, err)
+	require.NoFileExists(t, keyPath)
+}
+
+func useKeyTestHome(t *testing.T) string {
+	t.Helper()
+
+	previousFlags := globalFlags
+	t.Cleanup(func() { globalFlags = previousFlags })
+
+	home := t.TempDir()
+	globalFlags = config.DefaultFlagSet()
+	globalFlags.Home = home
+	return home
+}

--- a/link/cmd/ibc/main.go
+++ b/link/cmd/ibc/main.go
@@ -83,8 +83,7 @@ func init() {
 	cmdKeysShow.Flags().BoolVarP(&flagKeysShowPrivate, "private", "", false, "show private key")
 	cmdKeysImport.Flags().StringVar(&flagKeysImportPrivateKey, "private-key", "", "hex-encoded private key")
 	for _, c := range []*cobra.Command{cmdKeysNew, cmdKeysImport} {
-		c.Flags().
-			BoolVar(&flagKeysPopulateConfig, "populate-config", false, "append the resulting key as a signers entry in the config file")
+		c.Flags().BoolVarP(&flagKeysPopulateConfig, "populate-config", "p", false, "write key reference to the config")
 	}
 
 	// Relayer commands

--- a/link/cmd/ibc/main.go
+++ b/link/cmd/ibc/main.go
@@ -82,6 +82,7 @@ func init() {
 	cmdKeys.AddCommand(cmdKeysNew, cmdKeysShow, cmdKeysImport, cmdKeysList)
 	cmdKeysShow.Flags().BoolVarP(&flagKeysShowPrivate, "private", "", false, "show private key")
 	cmdKeysImport.Flags().StringVar(&flagKeysImportPrivateKey, "private-key", "", "hex-encoded private key")
+	_ = cmdKeysImport.MarkFlagRequired("private-key")
 	for _, c := range []*cobra.Command{cmdKeysNew, cmdKeysImport} {
 		c.Flags().BoolVarP(&flagKeysPopulateConfig, "populate-config", "p", false, "write key reference to the config")
 	}

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -191,6 +191,18 @@ func LoadFromFile(path string, validate, restrictUnknownFields bool) (Config, er
 	return config, nil
 }
 
+func (c Config) OverrideFromFlags(flags FlagSet) (Config, error) {
+	if flags.DB != "" {
+		db, err := DBConfigFromURL(flags.DB)
+		if err != nil {
+			return Config{}, errors.Wrap(err, "invalid --db")
+		}
+		c.DB = db
+	}
+
+	return c, nil
+}
+
 func (c Config) Validate() error {
 	if err := c.Server.Validate(); err != nil {
 		return errors.Wrap(err, ".server")

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -191,18 +191,6 @@ func LoadFromFile(path string, validate, restrictUnknownFields bool) (Config, er
 	return config, nil
 }
 
-func (c Config) OverrideFromFlags(flags FlagSet) (Config, error) {
-	if flags.DB != "" {
-		db, err := DBConfigFromURL(flags.DB)
-		if err != nil {
-			return Config{}, errors.Wrap(err, "invalid --db")
-		}
-		c.DB = db
-	}
-
-	return c, nil
-}
-
 func (c Config) Validate() error {
 	if err := c.Server.Validate(); err != nil {
 		return errors.Wrap(err, ".server")
@@ -408,16 +396,6 @@ func (c Config) Signer(alias string) (SignerConfig, bool) {
 	return SignerConfig{}, false
 }
 
-func (c Config) AddSigner(signer SignerConfig) (Config, bool) {
-	if _, exists := c.Signer(signer.Alias); exists {
-		return c, false
-	}
-
-	c.Signers = append(c.Signers, signer)
-
-	return c, true
-}
-
 // AttestorByName returns the configured attestor with the given name.
 func (c Config) AttestorByName(name string) (AttestorConfig, bool) {
 	for _, attestor := range c.Attestors {
@@ -479,7 +457,36 @@ func (c Config) store(path string, comments map[string]string) error {
 		return err
 	}
 
-	return os.WriteFile(path, bz, 0o644)
+	mode := os.FileMode(0o644)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+		path, err = filepath.EvalSymlinks(path)
+		if err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(statErr) {
+		return statErr
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".config-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(bz); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp.Name(), path)
 }
 
 // toCommentMap converts comments (YAML path -> text) into a yaml.CommentMap

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -408,6 +408,16 @@ func (c Config) Signer(alias string) (SignerConfig, bool) {
 	return SignerConfig{}, false
 }
 
+func (c Config) AddSigner(signer SignerConfig) (Config, bool) {
+	if _, exists := c.Signer(signer.Alias); exists {
+		return c, false
+	}
+
+	c.Signers = append(c.Signers, signer)
+
+	return c, true
+}
+
 // AttestorByName returns the configured attestor with the given name.
 func (c Config) AttestorByName(name string) (AttestorConfig, bool) {
 	for _, attestor := range c.Attestors {

--- a/link/internal/config/config_test.go
+++ b/link/internal/config/config_test.go
@@ -313,6 +313,26 @@ attestors:
 	})
 }
 
+func TestStoreToFilePreservesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.yml")
+	path := filepath.Join(dir, "ibc.yml")
+	require.NoError(t, os.WriteFile(target, nil, 0o600))
+	require.NoError(t, os.Symlink(filepath.Base(target), path))
+
+	cfg := DefaultConfig()
+	cfg.Server.ListenAddress = "127.0.0.1:9090"
+	require.NoError(t, cfg.StoreToFile(path))
+
+	info, err := os.Lstat(path)
+	require.NoError(t, err)
+	require.NotZero(t, info.Mode()&os.ModeSymlink)
+
+	stored, err := LoadFromFile(target, false, false)
+	require.NoError(t, err)
+	require.Equal(t, cfg.Server.ListenAddress, stored.Server.ListenAddress)
+}
+
 func TestAttestorsValidate(t *testing.T) {
 	for _, tt := range []struct {
 		name        string


### PR DESCRIPTION
- [x] allow keys operations w/o config directory or config file
- [x] `--populate-config` shorthand `-p`
- [x] fail to populate config on existing key to reduce confusion and ambiguity  



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>