### PR TITLE
docs: add IBC CLI tutorial, guides, and reference

### DIFF
--- a/docs/6-ibc-cli/1-overview.md
+++ b/docs/6-ibc-cli/1-overview.md
@@ -9,7 +9,7 @@ It consists of three parts:
 
 - Contract deployment for IBC Solidity contracts on EVM chains
 - A relayer for moving packets between chains
-- An attestor service  for attestation light clients
+- An attestor service for attestation light clients
 
 Each of these services is configurable under a single configuration file. Proof aggregation and transaction-building logic are internalized in the relayer. Relayers and attestors can be run in a single process or standalone using the CLI.  IBC CLI also handles contract deployment and configuration for the operator.
 
@@ -133,7 +133,7 @@ IBC CLI stores the configuration for deployment, the relayer, and attestors in a
 
 It has six blocks:
 
-- `chains`: the chains all three parts talk to, with an RPC endpoint and a router address for each.
+- `chains`: the chains all three parts talk to, with a router address for each, an RPC endpoint, and a websocket endpoint where auto-relay is enabled.
 - `relayer`: the connections to relay, and per-chain relay settings.
 - `attestors`: the attestors this process runs, or queries over the network.
 - `signers`: the keys, each under an alias the other blocks reference by name.
@@ -143,9 +143,7 @@ Most configurations can be generated. `ibc config new` writes a starting file, `
 
 The IBC CLI also validates the file with the `ibc config validate` command. 
 
-The configuration reference carries every key and its default.
-
-Visit the CLI commands and API reference pages for more details.
+The [configuration reference](/ibc-cli/configuration) carries every key and its default. [CLI commands](/ibc-cli/cli-commands) and the [API reference](/ibc-cli/api) cover the rest of the surface.
 
 ## Next steps
 

--- a/docs/6-ibc-cli/1-overview.md
+++ b/docs/6-ibc-cli/1-overview.md
@@ -1,0 +1,153 @@
+---
+title: "Overview"
+description: "One binary that deploys IBC onto a chain, then runs the relayer and attestors that carry packets across it."
+---
+
+The IBC CLI is an all-in-one tool for deploying, configuring, and running an IBC connection between chains, simplifying the process of setting up and managing IBC connections.
+
+It consists of three parts:
+
+- Contract deployment for IBC Solidity contracts on EVM chains
+- A relayer for moving packets between chains
+- An attestor service  for attestation light clients
+
+Each of these services is configurable under a single configuration file. Proof aggregation and transaction-building logic are internalized in the relayer. Relayers and attestors can be run in a single process or standalone using the CLI.  IBC CLI also handles contract deployment and configuration for the operator.
+
+```mermaid
+flowchart LR
+    subgraph BIN["ibc binary"]
+        R["relayer"]
+        A["attestor"]
+        D["deployment"]
+    end
+    CFG["ibc.yml"] --> R
+    CFG --> A
+    CFG --> D
+```
+
+## Deployment
+
+You can deploy the IBC Solidity contracts to an EVM chain with an RPC endpoint and a funded key. The IBC CLI deploys them and wires them to each other.
+
+It deploys the following contracts:
+
+- The core routing stack: an access manager and the [ICS26Router](/ibc-solidity-contracts/ics26-router) behind a proxy.
+- An [attestation light client](/ibc-solidity-contracts/attestation-light-client) on each chain tracking the other, registered on the router.
+- The [ICS27GMP](/ibc-solidity-contracts/ics27-gmp-and-accounts) app and its account logic.
+- [IFT](/ibc-solidity-contracts/ift-contracts) token contracts, and the bridges between them.
+
+Signer keys, contract addresses, client IDs, and finality settings all have to stay consistent across the on-chain and off-chain pieces, which can be difficult to manage by hand. The CLI handles the deployment and the checks that catch a mismatch, so you do not write your own deployment and query scripts.
+
+Follow the [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) to learn the full process of deploying IBC between two chains and sending a token.
+
+Deployment is done from a single key. It becomes the access manager's admin, which governs the router and the GMP app, and the default owner of any token you deploy. See [Permissions and upgrades](/ibc-solidity-contracts/permissions-and-upgrades) for more details.
+
+## The relayer
+
+Relayers are responsible for moving packets between chains. The IBC CLI provides a relayer service that can run on its own, or in one process with an attestor. It moves packets between the chains named in its configuration file.
+
+Its work starts after an application has already sent a packet. The relayer reads that send transaction on the source chain, gathers the proofs the packet needs, and submits them to the destination chain. It then carries the acknowledgement back, or times the packet out if it never arrived.
+
+[The Relayer page](/how-ibc-works/relayer) covers what a relayer is for and what it is trusted with.
+
+```mermaid
+flowchart TB
+    CALLER["caller"] -->|"chain ID and tx hash"| API["relay API"]
+    API -->|"records each packet"| STORE[("store")]
+    STORE -.->|"picked up for delivery"| DELIV["delivery"]
+    DELIV -->|"re-reads the send transaction"| SRC["source chain"]
+    DELIV --> PG["proof generator"]
+    PG -->|"in process or over gRPC"| ATT["attestors"]
+    DELIV -->|"one transaction per batch"| DST["destination chain"]
+    DELIV -.->|"records progress"| STORE
+```
+
+### Starting a relay
+
+A relay begins by calling the relayer's API with the chain a packet was sent from, the transaction that sent it, and which packets in that transaction to relay.
+
+The relayer reads those packets off the source chain itself, records them, and returns. Then the relayer can start delivering the packets.
+
+Packets heading the same way are batched and delivered together, rather than one at a time.
+
+### Proof generation and transaction building
+
+Before it can deliver anything, the relayer needs proof of the packets for the light client. It runs one proof generator for each light client it submits to. Currently the only supported light client type is the attestation light client, with more light client types planned.
+
+The generator asks the client's attestors to attest to the chain's state at a height. It checks the signatures, and once enough attestors have signed the same attestation to meet the client's threshold, it packages that attestation and its signatures together. That package is the proof.
+
+It returns a proof of the chain's state at a height, and a proof for each packet in the batch.
+
+The relayer then turns each batch of packets heading to the same destination into one transaction. That transaction makes a single call to the router. It carries a list of operations: first an update advancing the light client to the height just proved, then one delivery for each packet in the batch.
+
+### Signing and gas
+
+A relayer's signing key is set in the IBC CLI's configuration file. That key can be a file on disk or a remote key manager.
+
+The `ibc keys` commands can create a key and add it to the configuration in one step.
+
+A connection relayed in both directions submits to both chains, so it needs a funded key on each to pay gas. Nothing reimburses those fees.
+
+### Database
+
+The relayer keeps a database to store the status of each packet and the transactions that carried it. It runs on SQLite by default, and a Postgres database is available for larger deployments, configured in the configuration file.
+
+### Relayer API
+
+The relayer exposes a gRPC API. `Relay` asks it to deliver the packets in a transaction, and `Status` reports where each of those packets got to.
+
+## The attestor
+
+An attestor signs statements about a chain: its state at a height, and the packets it holds. See [Attestors](/light-clients/attestors) for what it signs and why that is trustworthy.
+
+An attestor process is a stateless gRPC service with a connection to the chain it watches. It has a signer, and a rule for how far behind the head it will sign.
+
+Its signer is configured in the IBC CLI's configuration file. Just like the relayer's signer, it can be a key file or a remote key manager.
+
+An attestor's finality offset decides how far behind the chain head it signs. 
+
+One process can host several attestors, each with its own signer and one chain it watches. That is what lets a single process attest for several chains at once.
+
+```mermaid
+flowchart LR
+    GRPC["gRPC :3000"]
+    subgraph PROC["one ibc attestor run process"]
+        A1["attestor-a<br/>signer: key-a"]
+        A2["attestor-b<br/>signer: key-b"]
+        A3["attestor-c<br/>signer: key-c"]
+    end
+    GRPC -->|"requests name the attestor"| A1
+    GRPC --> A2
+    GRPC --> A3
+    A1 --> C1["chain A RPC"]
+    A2 --> C2["chain B RPC"]
+    A3 --> C3["chain C RPC"]
+```
+
+IBC CLI allows you to run an attestor as its own standalone process, or in-process with the relayer. 
+
+## Configuration
+
+IBC CLI stores the configuration for deployment, the relayer, and attestors in a single YAML file at `~/.ibc/ibc.yml`.
+
+It has six blocks:
+
+- `chains`: the chains all three parts talk to, with an RPC endpoint and a router address for each.
+- `relayer`: the connections to relay, and per-chain relay settings.
+- `attestors`: the attestors this process runs, or queries over the network.
+- `signers`: the keys, each under an alias the other blocks reference by name.
+- `server` and `db`: the address to listen on, and the relayer's database.
+
+Most configurations can be generated. `ibc config new` writes a starting file, `config add-chain` appends a chain, and the `ibc keys` commands can append a signer. After deploying, `ibc deploy render-config` prints the chains, connections, and attestors that the deployment implies.
+
+The IBC CLI also validates the file with the `ibc config validate` command. 
+
+The configuration reference carries every key and its default.
+
+Visit the CLI commands and API reference pages for more details.
+
+## Next steps
+
+- [Deploy IBC and send a token](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) brings up two chains and moves a token between them.
+- [Run a standalone attestor](/ibc-cli/run-a-standalone-attestor) takes an attestor out of the relayer's process and into its own.
+- [Run a standalone relayer](/ibc-cli/run-a-standalone-relayer) brings up a relayer against a connection someone else deployed.

--- a/docs/6-ibc-cli/1-overview.md
+++ b/docs/6-ibc-cli/1-overview.md
@@ -64,9 +64,10 @@ flowchart TB
 
 ### Starting a relay
 
-A relay begins by calling the relayer's API with the chain a packet was sent from, the transaction that sent it, and which packets in that transaction to relay.
+A relay starts one of two ways:
 
-The relayer reads those packets off the source chain itself, records them, and returns. Then the relayer can start delivering the packets.
+- With `autoRelay` enabled on a client end, the relayer subscribes to that chain over a websocket and carries packets leaving it as they are sent. 
+- Manually: a relay begins by calling the relayer's API, naming the source chain, the transaction, and which of its packets to relay.
 
 Packets heading the same way are batched and delivered together, rather than one at a time.
 

--- a/docs/6-ibc-cli/2-tutorial-deploy-ibc-and-send-a-token.md
+++ b/docs/6-ibc-cli/2-tutorial-deploy-ibc-and-send-a-token.md
@@ -20,6 +20,7 @@ By the end, you'll have the following:
 - [Go](https://go.dev/doc/install) v1.25.5 or later
 - [jq](https://jqlang.org/download/) installed
 - [Git](https://git-scm.com/downloads) installed
+
 ## 1. Set up your environment
 
 Start by installing IBC CLI and running two local Besu chains.
@@ -69,7 +70,7 @@ IBC CLI uses one config file for all its operations.
 
 The config is stored in `~/.ibc/ibc.yml` by default.
 
-This is the home directory for everything that follows: the config, the keystore, the deployment records, and the relayer's database. 
+This is the home directory for everything that follows: the config, the keystore, the deployment records, and the relayer's database.
 
 2. Import a deployer key from the accounts created during the chain setup. This key becomes the access manager's admin, which governs the IBC router and the GMP app. It is also the default owner of any token you deploy. 
 
@@ -257,12 +258,12 @@ This keeps your `server`, `db`, and `signers` blocks, and replaces the three the
 ```
 
 ```
-level=INFO msg="Attestor config provided, running in dual mode: relayer with attestor"
-level=INFO msg="Migrated database" migrations_applied=3
-{"event":"ready","chainsConnected":["41001","41002"],"http":"[::]:3000"}
+level=INFO msg="Attestor config provided, running in dual mode: relayer with attestor" module=bootstrap
+level=INFO msg="Migrated database" module=bootstrap migrations_applied=3
+level=INFO msg=Readiness module=bootstrap readiness="{Event:ready ChainsConnected:[41001 41002] HTTP:[::]:3000}"
 ```
 
-That last line is how you know it is up. "Dual mode" means the attestors are running inside this process, because the rendered configuration declared them local.
+The readiness line is how you know it is up. "Dual mode" means the attestors are running inside this process, because the rendered configuration declared them local.
 
 Leave it running, and go back to your first terminal for the rest of the tutorial.
 
@@ -271,6 +272,7 @@ Leave it running, and go back to your first terminal for the rest of the tutoria
 The next steps will mint the token and send it to the other chain.
 
 1. Mint an initial supply of the token into the deployer account.
+
 ```bash
 ./bin/ibc tx ift mint --chain 41001 --ift "$IFT_A" --to deployer --from deployer --amount 100000000000000000000
 ```
@@ -285,7 +287,7 @@ The `--from` key must be the token's owner, which is the deployer. Amounts are i
 TX=$(./bin/ibc tx ift send --chain 41001 --ift "$IFT_A" --client-id link-41001-41002 --to deployer --from deployer --amount 10000000000000000000 | jq -r '.txHash') && echo "$TX"
 ```
 
-The send prints `{"txHash": "0x..."}`. That hash is stored in `$TX`, which the next two commands use:
+The send prints `{"txHash": "0x..."}`. That hash is stored in `$TX`, which the next command uses:
 
 ```
 0xf1fa599e3e4d048113a9ffd1cbe4749ae55492d2911b09d10a98fd6d3567f5f0
@@ -294,29 +296,30 @@ The send prints `{"txHash": "0x..."}`. That hash is stored in `$TX`, which the n
 Once this transaction is mined, the tokens are burned on the source chain. They are minted on the destination only when the packet is delivered. If delivery fails, or the packet times out, the tokens are minted back to the sender once a relayer carries that outcome home.
 
 3. The relayer will automatically detect the ibc packet was created and relay it.
+
 4. Now you can check the status of the transfer:
 
 ```bash
 ./bin/ibc relayer packets --chain-id 41001 --tx-hash "$TX"
 ```
 
-It will read `PACKET_STATE_PENDING` for a few seconds, then it should read `PACKET_STATE_SUCCEEDED`:
+It will read `PACKET_STATE_PENDING` for up to a minute, then it should read `PACKET_STATE_SUCCEEDED`:
 
 ```json
 {
   "packets":  [
     {
       "state":  "PACKET_STATE_SUCCEEDED",
-      "sequence_number":  "1",
-      "source_client_id":  "link-41001-41002",
-      "send_tx":  {"tx_hash":  "0xf1fa599e...", "chain_id":  "41001"},
-      "recv_tx":  {"tx_hash":  "0xf8281f04...", "chain_id":  "41002"},
-      "ack_tx":  {"tx_hash":  "0x0f56d3f0...", "chain_id":  "41001"},
-      "timeout_tx":  null
+      "sequenceNumber":  "1",
+      "sourceClientId":  "link-41001-41002",
+      "sendTx":  {"txHash":  "0xf1fa599e...", "chainId":  "41001"},
+      "recvTx":  {"txHash":  "0xf8281f04...", "chainId":  "41002"},
+      "ackTx":  {"txHash":  "0x0f56d3f0...", "chainId":  "41001"},
+      "timeoutTx":  null
     }
   ],
-  "has_more":  false,
-  "next_cursor":  ""
+  "hasMore":  false,
+  "nextCursor":  ""
 }
 ```
 

--- a/docs/6-ibc-cli/2-tutorial-deploy-ibc-and-send-a-token.md
+++ b/docs/6-ibc-cli/2-tutorial-deploy-ibc-and-send-a-token.md
@@ -1,0 +1,378 @@
+---
+title: "Deploy IBC and send a token"
+description: "Bring up two chains, deploy IBC on both, and move an Interchain Fungible Token from one to the other."
+---
+
+This tutorial walks you through all the steps to deploy and run IBC on two EVM chains using IBC CLI.
+
+By the end, you'll have the following:
+
+- IBC CLI installed and configured
+- IBC contracts deployed on two local Besu chains
+- IBC connections established between the chains
+- A relayer running
+- An attestor running
+- An Interchain Fungible Token that can be transferred between the chains
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-started/get-docker/) installed and running
+- [Go](https://go.dev/doc/install) v1.25.5 or later
+- [jq](https://jqlang.org/download/) installed
+- [Git](https://git-scm.com/downloads) installed
+## 1. Set up your environment
+
+Start by installing IBC CLI and running two local Besu chains.
+
+1. Clone the IBC repository and build the binary:
+
+```bash
+git clone https://github.com/cosmos/ibc.git && cd ibc/link && make build
+```
+
+The binary is located at `bin/ibc`.
+
+2. This tutorial uses two local [Besu](https://docs.besu-eth.org/) chains which are EVM-based. Start both chains:
+
+```bash
+../examples/besu-to-besu/setup.sh
+```
+
+The script initializes two single-validator Besu chains, starts them, and waits until both answer RPC calls. It finishes by printing something similar to the following:
+
+```
+Chain status:
+  besu-a (chain-id 41001) RPC=http://localhost:8545 WS=ws://localhost:8546 block=1
+  besu-b (chain-id 41002) RPC=http://localhost:8745 WS=ws://localhost:8746 block=1
+Chains are live and producing blocks.
+```
+
+Now there are two live chains, each producing blocks.
+
+3. You can use the following command to look at the funded accounts included in the setup script:
+
+```bash
+../examples/besu-to-besu/setup.sh accounts
+```
+
+Five accounts are derived from one mnemonic and funded on both chains, so the same key works on either side. The next step uses these. 
+
+## 2. Create a config and keys
+
+IBC CLI uses one config file for all its operations.
+
+1. Start by creating the config file:
+
+```bash
+./bin/ibc config new
+```
+
+The config is stored in `~/.ibc/ibc.yml` by default.
+
+This is the home directory for everything that follows: the config, the keystore, the deployment records, and the relayer's database. 
+
+2. Import a deployer key from the accounts created during the chain setup. This key becomes the access manager's admin, which governs the IBC router and the GMP app. It is also the default owner of any token you deploy. 
+
+Passing `--populate-config` adds each key to the config as a named signer. Later commands then name a key by alias instead of by path.
+
+```bash
+./bin/ibc keys import ecdsa deployer --private-key 0x33fa40f84e854b941c2b0436dd4a256e1df1cb41b9c1c0ccc8446408c19b8bf9 --populate-config
+```
+
+```json
+{
+  "evmAddress": "0x58A57ed9d8d624cBD12e2C467D34787555bB1b25",
+  "path": "/Users/you/.ibc/keys/deployer.json",
+  "publicKey": "0x03a70d1ef368ad99e90d509496e9888ee7404e4f4d360376bf521d769cf0c4de46",
+  "type": "ecdsa"
+}
+```
+
+3. Import a relayer key, which signs packet delivery and pays for the relayer's gas:
+
+```bash
+./bin/ibc keys import ecdsa relayer --private-key 0xd46507376b3a8a4af4f1f934375df25213a09857a3ed1086ba284c82d387904b --populate-config
+```
+
+4. Generate an attestor key for each chain. These sign attestations and never need funding. Never reuse an attestor key across clients, so each chain gets its own: see [Attestors](/light-clients/attestors#attestor-keys).
+
+```bash
+./bin/ibc keys new ecdsa attestor-41001 --populate-config
+```
+
+```bash
+./bin/ibc keys new ecdsa attestor-41002 --populate-config
+```
+
+5. Next, register the first chain's details in the config. This passes the chain id, RPC and websocket endpoints, and deployer key.
+
+```bash
+./bin/ibc config add-chain --chain-id 41001 --rpc http://localhost:8545 --ws ws://localhost:8546 --deployer deployer
+```
+
+6. Register the second chain's details:
+
+```bash
+./bin/ibc config add-chain --chain-id 41002 --rpc http://localhost:8745 --ws ws://localhost:8746 --deployer deployer
+```
+
+The `--deployer` flag names the key that signs deployments on that chain, so you won't need to pass it again.
+
+## 3. Deploy IBC on both chains
+
+With both chains registered, deploy the IBC contracts on each. 
+
+1. Deploy the IBC core on each chain. This deploys the ICS26 router and the access manager:
+
+```bash
+./bin/ibc deploy core --chain 41001 --yes
+```
+
+```bash
+./bin/ibc deploy core --chain 41002 --yes
+```
+
+Each run sends four transactions: an access manager, the router implementation, the router behind a proxy, and one call that opens the packet-delivery methods to any caller. Your deployer key is the access manager's admin.
+
+```
+level=INFO msg="transaction mined" label="deploy AccessManager" tx=0xa1c9fe97... block=38 chain=41001
+level=INFO msg="transaction mined" label="deploy ICS26Router implementation" tx=0x23988e80... block=39 chain=41001
+level=INFO msg="transaction mined" label="deploy ICS26Router proxy" tx=0x064d03a3... block=40 chain=41001
+level=INFO msg="transaction mined" label=setTargetFunctionRole tx=0x2fb39d8a... block=41 chain=41001
+[
+  {
+    "name": "core stack on chain 41001",
+    "action": "executed"
+  }
+]
+```
+
+2. Deploy an attestation light client on each chain. Each deployment tracks the state of the other chain:
+
+```bash
+./bin/ibc deploy client --chain 41001 --counterparty-chain 41002 --attestors attestor-41002 --threshold 1 --yes
+```
+
+```bash
+./bin/ibc deploy client --chain 41002 --counterparty-chain 41001 --attestors attestor-41001 --threshold 1 --yes
+```
+
+The `--attestors` flag takes the aliases from step 4. Each resolves to that key's address, and those addresses become the client's attestation set on chain.
+
+The `--threshold` flag is how many of them must sign for the client to accept a proof. Both are fixed on chain when the client is deployed.
+
+Note the crossed pairing. A client verifies the state of the chain it tracks, so the client on 41001 tracks 41002 and trusts the attestor watching 41002.
+
+Both sides share one client identifier, derived from the two chain IDs in sorted order, so it reads the same on either chain. Here it is `link-41001-41002` which will be used later to identify the connection.
+
+## 4. Deploy the application
+
+The next steps deploy the General Message Passing (GMP) app and the Interchain Fungible Token (IFT) contracts on each chain. IFT uses GMP to send and receive messages between the chains and facilitate token transfers.
+
+1. Deploy the GMP app on each chain. This allows cross-chain contract calls between the chains:
+
+```bash
+./bin/ibc deploy gmp --chain 41001 --yes
+```
+
+```bash
+./bin/ibc deploy gmp --chain 41002 --yes
+```
+
+2. Deploy an IFT contract on each chain. This is the token that will be transferred between the chains:
+
+```bash
+./bin/ibc deploy ift --name "Demo Token" --symbol DEMO --chain 41001 --yes
+```
+
+```bash
+./bin/ibc deploy ift --name "Demo Token" --symbol DEMO --chain 41002 --yes
+```
+
+```
+level=INFO msg="ift token deployed" chain=41001 symbol=DEMO address=0x6bbcD66DA283F6cD4e630b9fc6A91C37D5B2C7A8
+```
+
+3. Use the following commands to read both token addresses out of the deployment records. These will be used in later steps:
+
+```bash
+IFT_A=$(./bin/ibc deploy show 41001 | jq -r '.tokens[0].address')
+IFT_B=$(./bin/ibc deploy show 41002 | jq -r '.tokens[0].address')
+```
+
+If you need to view these addresses later, the `deploy show` command prints a chain's deployment record as JSON.
+
+4. The next step is to link the two token contracts together. Registering a bridge tells each token to accept mints from its counterpart on the other chain. A transfer then burns tokens on the source chain and mints them on the destination.
+
+```bash
+./bin/ibc deploy ift-bridge --chain-a 41001 --ift-a "$IFT_A" --chain-b 41002 --ift-b "$IFT_B" --yes
+```
+
+This command registers both sides. It ties each token to the client pointing at the other chain, which is how a transfer knows where to land.
+
+## 5. Configure and start the relayer
+
+Next you'll need to configure the relayer to start sending packets between the two chains.
+
+1. Generate the relayer's configuration.
+
+```bash
+./bin/ibc deploy render-config 41001 41002 --signer-a relayer --signer-b relayer
+```
+
+This prints the three sections relaying needs: the chains with their router addresses, the connection, and the attestors. Each is already filled in with the addresses your deploy commands recorded.
+
+The two signer flags name the key that submits relay transactions on each chain. Both are required, and each is checked against your configured signers. You imported `relayer` in step 3.
+
+The attestors section declares both of your attestor keys as `type: local`. This means the relayer will run the attestors in the same process.
+
+2. Use the following command to merge the generated sections into your config:
+
+```bash
+{ sed -n '1,/^chains:/p' ~/.ibc/ibc.yml | sed '$d'
+  ./bin/ibc deploy render-config 41001 41002 --signer-a relayer --signer-b relayer
+  sed -n '/^signers:/,$p' ~/.ibc/ibc.yml
+} > /tmp/ibc.yml.merged && mv /tmp/ibc.yml.merged ~/.ibc/ibc.yml
+```
+
+This keeps your `server`, `db`, and `signers` blocks, and replaces the three the deploy tool generated.
+
+3. Use the validate command to check the result against both chains before starting anything:
+
+```bash
+./bin/ibc config validate --live --strict
+```
+
+```json
+{
+  "status": "valid"
+}
+```
+
+4. Now you'll need to open a new terminal to start the relayer and attestors. Leave your first terminal open. You come back to it in the next step.
+
+```bash
+# open a new terminal and start the relayer
+./bin/ibc relayer run
+```
+
+```
+level=INFO msg="Attestor config provided, running in dual mode: relayer with attestor"
+level=INFO msg="Migrated database" migrations_applied=4
+{"event":"ready","chainsConnected":["41001","41002"],"http":"[::]:3000"}
+```
+
+That last line is how you know it is up. "Dual mode" means the attestors are running inside this process, because the rendered configuration declared them local.
+
+Leave it running, and go back to your first terminal for the rest of the tutorial.
+
+## 6. Transfer a token
+
+The next steps will mint the token and send it to the other chain.
+
+1. Mint an initial supply of the token into the deployer account.
+```bash
+./bin/ibc tx ift mint --chain 41001 --ift "$IFT_A" --to deployer --from deployer --amount 100000000000000000000
+```
+
+The `--from` key must be the token's owner, which is the deployer. Amounts are in base units, so this is 100 tokens at 18 decimals.
+
+2. Send 10 tokens from one chain to the other, keeping the transaction hash. `$IFT_A` is the token address you stored earlier.
+
+> **Note:** The `--timeout` flag sets how long the packet has to be delivered, counted from when you send. It defaults to 15 minutes and cannot exceed one day. A packet that misses that window can only be timed out and refunded, and the deadline cannot be changed after the send.
+
+```bash
+TX=$(./bin/ibc tx ift send --chain 41001 --ift "$IFT_A" --client-id link-41001-41002 --to deployer --from deployer --amount 10000000000000000000 | jq -r '.txHash') && echo "$TX"
+```
+
+The send prints `{"txHash": "0x..."}`. That hash is stored in `$TX`, which the next two commands use:
+
+```
+0xf1fa599e3e4d048113a9ffd1cbe4749ae55492d2911b09d10a98fd6d3567f5f0
+```
+
+Once this transaction is mined, the tokens are burned on the source chain. They are minted on the destination only when the packet is delivered. If delivery fails, or the packet times out, the tokens are minted back to the sender once a relayer carries that outcome home.
+
+3. The next command asks the relayer to relay the transaction: 
+
+```bash
+./bin/ibc relayer relay --chain-id 41001 --tx-hash "$TX"
+```
+
+```json
+{
+  "packets":  [
+    {
+      "source_client_id":  "link-41001-41002",
+      "sequence_number":  "1",
+      "selection":  "PACKET_SELECTION_SELECTED"
+    }
+  ]
+}
+```
+
+`PACKET_SELECTION_SELECTED` means the request was accepted. The relayer reads the packets out of that transaction and records them, and its dispatcher picks them up on its next poll.
+
+4. Now you can check the status of the transfer:
+
+```bash
+./bin/ibc relayer packets --chain-id 41001 --tx-hash "$TX"
+```
+
+It will read `PACKET_STATE_PENDING` for a few seconds, then it should read `PACKET_STATE_SUCCEEDED`:
+
+```json
+{
+  "packets":  [
+    {
+      "state":  "PACKET_STATE_SUCCEEDED",
+      "sequence_number":  "1",
+      "source_client_id":  "link-41001-41002",
+      "send_tx":  {"tx_hash":  "0xf1fa599e...", "chain_id":  "41001"},
+      "recv_tx":  {"tx_hash":  "0xf8281f04...", "chain_id":  "41002"},
+      "ack_tx":  {"tx_hash":  "0x0f56d3f0...", "chain_id":  "41001"},
+      "timeout_tx":  null
+    }
+  ],
+  "has_more":  false,
+  "next_cursor":  ""
+}
+```
+
+This shows three transactions across two chains: the send you made, the receive on 41002, and the acknowledgement carried back to 41001.
+
+5. Confirm the tokens arrived on the destination chain:
+
+```bash
+./bin/ibc query ift balance --chain 41002 --ift "$IFT_B" --address deployer
+```
+
+```json
+{
+  "address": "0x58A57ed9d8d624cBD12e2C467D34787555bB1b25",
+  "balance": "10000000000000000000",
+  "symbol": "DEMO"
+}
+```
+
+Then check that the source chain was debited:
+
+```bash
+./bin/ibc query ift balance --chain 41001 --ift "$IFT_A" --address deployer
+```
+
+```json
+{
+  "address": "0x58A57ed9d8d624cBD12e2C467D34787555bB1b25",
+  "balance": "90000000000000000000",
+  "symbol": "DEMO"
+}
+```
+
+Congratulations! You've deployed IBC and transferred a token between two chains.
+
+## Next steps
+
+- [Overview](/ibc-cli/overview) explains what the three parts are made of and how they fit together.
+- [Run a standalone attestor](/ibc-cli/run-a-standalone-attestor) moves an attestor out of the relayer's process and into its own.
+- [Run a standalone relayer](/ibc-cli/run-a-standalone-relayer) brings up a relayer against a deployment, including one that replaces a relayer that stopped.

--- a/docs/6-ibc-cli/2-tutorial-deploy-ibc-and-send-a-token.md
+++ b/docs/6-ibc-cli/2-tutorial-deploy-ibc-and-send-a-token.md
@@ -11,7 +11,7 @@ By the end, you'll have the following:
 - IBC contracts deployed on two local Besu chains
 - IBC connections established between the chains
 - A relayer running
-- An attestor running
+- Attestors running 
 - An Interchain Fungible Token that can be transferred between the chains
 
 ## Prerequisites
@@ -258,7 +258,7 @@ This keeps your `server`, `db`, and `signers` blocks, and replaces the three the
 
 ```
 level=INFO msg="Attestor config provided, running in dual mode: relayer with attestor"
-level=INFO msg="Migrated database" migrations_applied=4
+level=INFO msg="Migrated database" migrations_applied=3
 {"event":"ready","chainsConnected":["41001","41002"],"http":"[::]:3000"}
 ```
 
@@ -293,26 +293,7 @@ The send prints `{"txHash": "0x..."}`. That hash is stored in `$TX`, which the n
 
 Once this transaction is mined, the tokens are burned on the source chain. They are minted on the destination only when the packet is delivered. If delivery fails, or the packet times out, the tokens are minted back to the sender once a relayer carries that outcome home.
 
-3. The next command asks the relayer to relay the transaction: 
-
-```bash
-./bin/ibc relayer relay --chain-id 41001 --tx-hash "$TX"
-```
-
-```json
-{
-  "packets":  [
-    {
-      "source_client_id":  "link-41001-41002",
-      "sequence_number":  "1",
-      "selection":  "PACKET_SELECTION_SELECTED"
-    }
-  ]
-}
-```
-
-`PACKET_SELECTION_SELECTED` means the request was accepted. The relayer reads the packets out of that transaction and records them, and its dispatcher picks them up on its next poll.
-
+3. The relayer will automatically detect the ibc packet was created and relay it.
 4. Now you can check the status of the transfer:
 
 ```bash

--- a/docs/6-ibc-cli/3-run-a-standalone-attestor.md
+++ b/docs/6-ibc-cli/3-run-a-standalone-attestor.md
@@ -23,27 +23,13 @@ The commands below continue from the [tutorial](/ibc-cli/tutorial-deploy-ibc-and
 
 ## 1. Attestor config
 
-1. Create a new configuration file for the attestor:
+Create a second configuration file alongside the tutorial's:
 
 ```bash
-./bin/ibc config new --home ~/.ibc-attestor
+./bin/ibc config new --config ibc-attestor-41002.yml
 ```
 
-2. Copy the attestor key the tutorial generated for chain 41002:
-
-```bash
-./bin/ibc keys import ecdsa attestor-41002 --home ~/.ibc-attestor --private-key "$(./bin/ibc keys show attestor-41002 --private | jq -r '.privateKey')"
-```
-
-```json
-{
-  "evmAddress": "0xc7f148Da846781a9a1D9d22F699A7A88c592CCee",
-  "path": "/Users/you/.ibc-attestor/keys/attestor-41002.json",
-  "type": "ecdsa"
-}
-```
-
-This key must match the address in the attestation set.
+It shares the tutorial's keystore, so the attestor key generated there is already available. That key's address matches the one in the client's attestation set.
 
 > **Warning:** An attestor address must never appear in more than one client's attestation set. The signed attestation carries no domain separation, so a signature made for one client can be replayed against another.
 
@@ -52,7 +38,7 @@ This key must match the address in the attestation set.
 Write the attestor's configuration file, reading the router address and your own signing address from the deployment:
 
 ```bash
-cat > ~/.ibc-attestor/ibc.yml <<EOF
+cat > ~/.ibc/ibc-attestor-41002.yml <<EOF
 server:
   listenAddr: 0.0.0.0:3001
 
@@ -63,7 +49,7 @@ chains:
     ics26Router: "$(./bin/ibc deploy show 41002 | jq -r '.core.router')"
 
 attestors:
-- name: attestor-41002-$(./bin/ibc keys show attestor-41002 --home ~/.ibc-attestor | jq -r '.evmAddress')
+- name: attestor-41002
   type: local
   chainId: "41002"
   signer: attestor-41002
@@ -76,7 +62,7 @@ signers:
 EOF
 ```
 
-An attestor's name is `attestor-<chain it watches>-<its address>`.
+An attestor's name is `attestor-<chain it watches>`.
 
 > **Warning:** The attestor's name has to match the name the relayer uses for it. A relayer sends that name in every query, and the process serves its attestors by name, so a mismatch makes every lookup fail.
 
@@ -87,7 +73,7 @@ A finality offset of `1` signs one block behind the chain head. Zero waits for t
 1. Validate the configuration:
 
 ```bash
-./bin/ibc config validate --home ~/.ibc-attestor --strict
+./bin/ibc config validate --config ibc-attestor-41002.yml --strict
 ```
 
 ```json
@@ -99,12 +85,12 @@ A finality offset of `1` signs one block behind the chain head. Zero waits for t
 2. Start the process in a new terminal, and leave it running:
 
 ```bash
-./bin/ibc attestor run --home ~/.ibc-attestor
+./bin/ibc attestor run --config ibc-attestor-41002.yml
 ```
 
 ```
-level=INFO msg="Starting attestor"
-{"event":"ready","http":"[::]:3001"}
+level=INFO msg="Starting attestor" module=bootstrap
+level=INFO msg=Readiness module=bootstrap readiness="{Event:ready HTTP:[::]:3001}"
 ```
 
 That readiness line names the address it bound.
@@ -112,12 +98,12 @@ That readiness line names the address it bound.
 3. Back in your first terminal, ask the process what its address is:
 
 ```bash
-./bin/ibc attestor info attestor-41002-$(./bin/ibc keys show attestor-41002 --home ~/.ibc-attestor | jq -r '.evmAddress') --host 127.0.0.1:3001
+./bin/ibc attestor info attestor-41002 --host 127.0.0.1:3001
 ```
 
 ```json
 {
-  "chain_id": "41002",
+  "chainId": "41002",
   "address": "0xc7f148Da846781a9a1D9d22F699A7A88c592CCee"
 }
 ```
@@ -127,12 +113,12 @@ This should be the address of the attestor.
 4. Ask how far it can attest:
 
 ```bash
-./bin/ibc attestor latest-height attestor-41002-$(./bin/ibc keys show attestor-41002 --home ~/.ibc-attestor | jq -r '.evmAddress') --host 127.0.0.1:3001
+./bin/ibc attestor latest-height attestor-41002 --host 127.0.0.1:3001
 ```
 
 ```json
 {
-  "height": 25509
+  "height": "25509"
 }
 ```
 
@@ -140,18 +126,18 @@ This shows the attestor's latest height.
 
 ## 4. Run the second attestor
 
-The [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) this guide follows generated one attestor per chain. The following steps repeat the process to create an attestor for chain 41001, in its own home on port 3003. Port 3002 is left free for the relayer in the next guide.
+The [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) this guide follows generated one attestor per chain. The following steps repeat the process to create an attestor for chain 41001, in its own configuration file on port 3003. Port 3002 is left free for the relayer in the next guide.
 
-1. Create a new configuration file and copy the key:
+1. Create a third configuration file:
 
 ```bash
-./bin/ibc config new --home ~/.ibc-attestor-41001 && ./bin/ibc keys import ecdsa attestor-41001 --home ~/.ibc-attestor-41001 --private-key "$(./bin/ibc keys show attestor-41001 --private | jq -r '.privateKey')"
+./bin/ibc config new --config ibc-attestor-41001.yml
 ```
 
 2. Write its configuration:
 
 ```bash
-cat > ~/.ibc-attestor-41001/ibc.yml <<EOF
+cat > ~/.ibc/ibc-attestor-41001.yml <<EOF
 server:
   listenAddr: 0.0.0.0:3003
 
@@ -162,7 +148,7 @@ chains:
     ics26Router: "$(./bin/ibc deploy show 41001 | jq -r '.core.router')"
 
 attestors:
-- name: attestor-41001-$(./bin/ibc keys show attestor-41001 --home ~/.ibc-attestor-41001 | jq -r '.evmAddress')
+- name: attestor-41001
   type: local
   chainId: "41001"
   signer: attestor-41001
@@ -178,22 +164,23 @@ EOF
 3. Start it in another terminal:
 
 ```bash
-./bin/ibc attestor run --home ~/.ibc-attestor-41001
+./bin/ibc attestor run --config ibc-attestor-41001.yml
 ```
 
 ```
-{"event":"ready","http":"[::]:3003"}
+level=INFO msg="Starting attestor" module=bootstrap
+level=INFO msg=Readiness module=bootstrap readiness="{Event:ready HTTP:[::]:3003}"
 ```
 
 Both attestors now run in processes of their own, and no relayer is running.
 
-## What a relayer needs from you
+## Connect a relayer
 
 A relayer references your attestor by name and network address:
 
 ```yaml
 attestors:
-- name: attestor-41002-0xc7f148Da846781a9a1D9d22F699A7A88c592CCee
+- name: attestor-41002
   type: remote
   grpc: 127.0.0.1:3001
 ```

--- a/docs/6-ibc-cli/3-run-a-standalone-attestor.md
+++ b/docs/6-ibc-cli/3-run-a-standalone-attestor.md
@@ -1,0 +1,205 @@
+---
+title: "Run a standalone attestor"
+description: "Run an attestor in its own process, separate from any relayer, so a relayer can query it and count its signatures toward a light client's quorum."
+---
+
+This guide runs an attestor as its own process, serving one chain. A relayer can then query it and count its signatures toward a light client's quorum.
+
+In order to run a standalone attestor, your signing address must already be in the light client's attestation set, which is fixed when the client is deployed and read from the chain.
+
+## Before you begin
+
+You need:
+
+- **A chain with IBC deployed, and a light client tracking it.** This guide continues from the [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token).
+- **Your signing address already in that client's attestation set.**
+- **Your signing key.**
+- **The chain's RPC endpoint and its router address.** Configuration validation treats the router address as optional, but the process cannot start without it.
+- [Go](https://go.dev/doc/install) 1.25.5 or later and a [build of the binary](/ibc-cli/tutorial-deploy-ibc-and-send-a-token).
+
+The commands below continue from the [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token). They move the attestor keys it generated into processes of their own, reading values from your own deployment rather than asking you to copy one.
+
+> **Warning:** Stop the tutorial's relayer before you start, with `Ctrl+C` in its terminal. It hosts both attestors inside its own process, and this guide gives those same attestors processes of their own.
+
+## 1. Attestor config
+
+1. Create a new configuration file for the attestor:
+
+```bash
+./bin/ibc config new --home ~/.ibc-attestor
+```
+
+2. Copy the attestor key the tutorial generated for chain 41002:
+
+```bash
+./bin/ibc keys import ecdsa attestor-41002 --home ~/.ibc-attestor --private-key "$(./bin/ibc keys show attestor-41002 --private | jq -r '.privateKey')"
+```
+
+```json
+{
+  "evmAddress": "0xc7f148Da846781a9a1D9d22F699A7A88c592CCee",
+  "path": "/Users/you/.ibc-attestor/keys/attestor-41002.json",
+  "type": "ecdsa"
+}
+```
+
+This key must match the address in the attestation set.
+
+> **Warning:** An attestor address must never appear in more than one client's attestation set. The signed attestation carries no domain separation, so a signature made for one client can be replayed against another.
+
+## 2. Write its configuration
+
+Write the attestor's configuration file, reading the router address and your own signing address from the deployment:
+
+```bash
+cat > ~/.ibc-attestor/ibc.yml <<EOF
+server:
+  listenAddr: 0.0.0.0:3001
+
+chains:
+- chainId: "41002"
+  evm:
+    rpc: http://localhost:8745
+    ics26Router: "$(./bin/ibc deploy show 41002 | jq -r '.core.router')"
+
+attestors:
+- name: attestor-41002-$(./bin/ibc keys show attestor-41002 --home ~/.ibc-attestor | jq -r '.evmAddress')
+  type: local
+  chainId: "41002"
+  signer: attestor-41002
+  finalityOffset: 1
+
+signers:
+- alias: attestor-41002
+  type: local
+  file: attestor-41002
+EOF
+```
+
+An attestor's name is `attestor-<chain it watches>-<its address>`.
+
+> **Warning:** The attestor's name has to match the name the relayer uses for it. A relayer sends that name in every query, and the process serves its attestors by name, so a mismatch makes every lookup fail.
+
+A finality offset of `1` signs one block behind the chain head. Zero waits for the chain's own finalized block instead.
+
+## 3. Start it and verify
+
+1. Validate the configuration:
+
+```bash
+./bin/ibc config validate --home ~/.ibc-attestor --strict
+```
+
+```json
+{
+  "status": "valid"
+}
+```
+
+2. Start the process in a new terminal, and leave it running:
+
+```bash
+./bin/ibc attestor run --home ~/.ibc-attestor
+```
+
+```
+level=INFO msg="Starting attestor"
+{"event":"ready","http":"[::]:3001"}
+```
+
+That readiness line names the address it bound.
+
+3. Back in your first terminal, ask the process what its address is:
+
+```bash
+./bin/ibc attestor info attestor-41002-$(./bin/ibc keys show attestor-41002 --home ~/.ibc-attestor | jq -r '.evmAddress') --host 127.0.0.1:3001
+```
+
+```json
+{
+  "chain_id": "41002",
+  "address": "0xc7f148Da846781a9a1D9d22F699A7A88c592CCee"
+}
+```
+
+This should be the address of the attestor.
+
+4. Ask how far it can attest:
+
+```bash
+./bin/ibc attestor latest-height attestor-41002-$(./bin/ibc keys show attestor-41002 --home ~/.ibc-attestor | jq -r '.evmAddress') --host 127.0.0.1:3001
+```
+
+```json
+{
+  "height": 25509
+}
+```
+
+This shows the attestor's latest height.
+
+## 4. Run the second attestor
+
+The [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) this guide follows generated one attestor per chain. The following steps repeat the process to create an attestor for chain 41001, in its own home on port 3003. Port 3002 is left free for the relayer in the next guide.
+
+1. Create a new configuration file and copy the key:
+
+```bash
+./bin/ibc config new --home ~/.ibc-attestor-41001 && ./bin/ibc keys import ecdsa attestor-41001 --home ~/.ibc-attestor-41001 --private-key "$(./bin/ibc keys show attestor-41001 --private | jq -r '.privateKey')"
+```
+
+2. Write its configuration:
+
+```bash
+cat > ~/.ibc-attestor-41001/ibc.yml <<EOF
+server:
+  listenAddr: 0.0.0.0:3003
+
+chains:
+- chainId: "41001"
+  evm:
+    rpc: http://localhost:8545
+    ics26Router: "$(./bin/ibc deploy show 41001 | jq -r '.core.router')"
+
+attestors:
+- name: attestor-41001-$(./bin/ibc keys show attestor-41001 --home ~/.ibc-attestor-41001 | jq -r '.evmAddress')
+  type: local
+  chainId: "41001"
+  signer: attestor-41001
+  finalityOffset: 1
+
+signers:
+- alias: attestor-41001
+  type: local
+  file: attestor-41001
+EOF
+```
+
+3. Start it in another terminal:
+
+```bash
+./bin/ibc attestor run --home ~/.ibc-attestor-41001
+```
+
+```
+{"event":"ready","http":"[::]:3003"}
+```
+
+Both attestors now run in processes of their own, and no relayer is running.
+
+## What a relayer needs from you
+
+A relayer references your attestor by name and network address:
+
+```yaml
+attestors:
+- name: attestor-41002-0xc7f148Da846781a9a1D9d22F699A7A88c592CCee
+  type: remote
+  grpc: 127.0.0.1:3001
+```
+
+[Run a standalone relayer](/ibc-cli/run-a-standalone-relayer) brings up a relayer that uses these two instead of hosting its own.
+
+## Next steps
+
+- [Run a standalone relayer](/ibc-cli/run-a-standalone-relayer) brings up a relayer that queries these attestors instead of hosting its own.

--- a/docs/6-ibc-cli/4-run-a-standalone-relayer.md
+++ b/docs/6-ibc-cli/4-run-a-standalone-relayer.md
@@ -1,6 +1,6 @@
 ---
 title: "Run a standalone relayer"
-description: "Run a relayer in its own process, querying attestors it does not host, including one that finishes packets a stopped relayer left behind."
+description: "Run a relayer in its own process, querying attestors it does not host."
 ---
 
 This guide shows you how to run a relayer in its own process. It hosts no attestors and queries them over the network instead.
@@ -9,40 +9,36 @@ This guide shows you how to run a relayer in its own process. It hosts no attest
 
 Before proceeding, run the [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) and [standalone attestor](/ibc-cli/run-a-standalone-attestor) guides first, in order. You'll need to have an IBC deployment and standalone attestors on both chains to complete this guide.
 
-You also need a key funded on every chain you submit to.
+The tutorial's keystore already holds a funded key, so this guide reuses it rather than importing another.
 
 ## 1. Relayer config
 
-1. Create a new configuration file for the relayer:
+1. Create a second configuration file alongside the tutorial's:
 
 ```bash
-./bin/ibc config new --home ~/.ibc-relayer2
+./bin/ibc config new --config ibc-relayer2.yml
 ```
 
-2. Import a funded key. This is an account from the tutorial's setup script:
+2. Write its configuration, reading both router addresses from your deployment:
 
 ```bash
-./bin/ibc keys import ecdsa relayer2 --home ~/.ibc-relayer2 --private-key 0xa42b90503f0d4a418e2b8b140a03901c89d76704c8af49c3ef82d6f3cd91f23d
-```
-
-3. Write its configuration, reading both router addresses and both attestor names from your deployment:
-
-```bash
-cat > ~/.ibc-relayer2/ibc.yml <<EOF
+cat > ~/.ibc/ibc-relayer2.yml <<EOF
 server:
   listenAddr: 0.0.0.0:3002
 db:
   type: sqlite
-  url: ibc.db
+  url: relayer2.db
 
 chains:
 - chainId: "41001"
   evm:
     rpc: http://localhost:8545
+    ws: ws://localhost:8546
     ics26Router: "$(./bin/ibc deploy show 41001 | jq -r '.core.router')"
 - chainId: "41002"
   evm:
     rpc: http://localhost:8745
+    ws: ws://localhost:8746
     ics26Router: "$(./bin/ibc deploy show 41002 | jq -r '.core.router')"
 
 relayer:
@@ -51,36 +47,42 @@ relayer:
     clientA:
       chainId: "41001"
       clientId: link-41001-41002
-      signer: relayer2
+      signer: relayer
       type: attestation
+      autoRelay:
+        enabled: true
     clientB:
       chainId: "41002"
       clientId: link-41001-41002
-      signer: relayer2
+      signer: relayer
       type: attestation
+      autoRelay:
+        enabled: true
 
 attestors:
-- name: attestor-41002-$(./bin/ibc keys show attestor-41002 --home ~/.ibc-attestor | jq -r '.evmAddress')
+- name: attestor-41002
   type: remote
   grpc: 127.0.0.1:3001
-- name: attestor-41001-$(./bin/ibc keys show attestor-41001 --home ~/.ibc-attestor-41001 | jq -r '.evmAddress')
+- name: attestor-41001
   type: remote
   grpc: 127.0.0.1:3003
 
 signers:
-- alias: relayer2
+- alias: relayer
   type: local
-  file: relayer2
+  file: relayer
 EOF
 ```
 
 - No chain names a deployer, because this relayer deploys nothing.
 - The signer on each client end is the key that submits on that end's own chain, so one connection can use a different key per side.
+- `autoRelay` is set on each client end and governs packets leaving that end's chain. It requires the chain's `ws` endpoint.
+- The listen address and the database are this relayer's own, so neither collides with the tutorial's.
 
 ## 2. Validate the config
 
 ```bash
-./bin/ibc config validate --home ~/.ibc-relayer2 --live --strict
+./bin/ibc config validate --config ibc-relayer2.yml --live --strict
 ```
 
 ```json
@@ -91,71 +93,45 @@ EOF
 
 ## 3. Relay a packet
 
-1. Send a transfer and keep the hash:
+1. Start your relayer in a new terminal, and leave it running:
+
+```bash
+./bin/ibc relayer run --config ibc-relayer2.yml
+```
+
+```
+level=INFO msg="Migrated database" module=bootstrap migrations_applied=3
+level=INFO msg="Starting relayer" module=bootstrap
+level=INFO msg="Subscribed to send packets" module=bootstrap module=watcher chainID=41001 clientIDs=[link-41001-41002]
+level=INFO msg=Readiness module=bootstrap readiness="{Event:ready ChainsConnected:[41001 41002] HTTP:[::]:3002}"
+level=INFO msg="Subscribed to send packets" module=bootstrap module=watcher chainID=41002 clientIDs=[link-41001-41002]
+```
+
+The relayer is running and waiting for packets.
+
+2. Back in your first terminal, send a transfer and keep the hash:
 
 ```bash
 TX=$(./bin/ibc tx ift send --chain 41001 --ift "$(./bin/ibc deploy show 41001 | jq -r '.tokens[0].address')" --client-id link-41001-41002 --to deployer --from deployer --amount 1000000000000000000 | jq -r '.txHash') && echo "$TX"
 ```
 
-The tokens are burned on 41001 and nothing has delivered them yet.
+The relayer will pick up the packet automatically and relay it to the destination.
 
-2. Start your relayer in a new terminal, and leave it running:
-
-```bash
-./bin/ibc relayer run --home ~/.ibc-relayer2
-```
-
-```
-level=INFO msg="Migrated database" migrations_applied=3
-level=INFO msg="Starting relayer"
-{"event":"ready","chainsConnected":["41001","41002"],"http":"[::]:3002"}
-```
-
-It creates its database on the way up.
-
-3. Back in your first terminal, relay the packet:
+3. Watch it settle:
 
 ```bash
-./bin/ibc relayer relay --home ~/.ibc-relayer2 --chain-id 41001 --tx-hash "$TX"
-```
-
-```json
-{
-  "packets": [
-    {
-      "source_client_id": "link-41001-41002",
-      "sequence_number": "2",
-      "selection": "PACKET_SELECTION_SELECTED"
-    }
-  ]
-}
-```
-
-4. Watch it settle:
-
-```bash
-./bin/ibc relayer packets --home ~/.ibc-relayer2 --chain-id 41001 --tx-hash "$TX"
+./bin/ibc relayer packets --config ibc-relayer2.yml --chain-id 41001 --tx-hash "$TX"
 ```
 
 It reads `PACKET_STATE_PENDING` until the receive and the acknowledgement have both landed, then `PACKET_STATE_SUCCEEDED` with all three transaction hashes.
 
-5. Confirm the balance on the destination chain:
+4. Confirm the balance on the destination chain:
 
 ```bash
 ./bin/ibc query ift balance --chain 41002 --ift "$(./bin/ibc deploy show 41002 | jq -r '.tokens[0].address')" --address deployer
 ```
 
 The balance should be one token higher, meaning the packet was delivered successfully.
-
-## What can go wrong
-
-**The relayer refuses to start on the attestor quorum.** It prints the addresses each client trusts next to the attestors it managed to reach, and stops when too few match the threshold. Check that your attestor addresses are reachable and that each remote entry's name matches the name its host serves it under.
-
-**Two attestors share one signing address on the same chain.** That is a startup error, because they would be one signer counted twice.
-
-**A packet stays pending.** The delivery is waiting on a finality gate, which asks the attestor quorum what height it can currently prove. A gate that has waited half an hour logs a warning that the chain may be lagging.
-
-**A transaction is rejected before it is sent.** The relayer builds EIP-1559 transactions and refuses a chain that reports no base fee.
 
 ## Next steps
 

--- a/docs/6-ibc-cli/4-run-a-standalone-relayer.md
+++ b/docs/6-ibc-cli/4-run-a-standalone-relayer.md
@@ -1,0 +1,162 @@
+---
+title: "Run a standalone relayer"
+description: "Run a relayer in its own process, querying attestors it does not host, including one that finishes packets a stopped relayer left behind."
+---
+
+This guide shows you how to run a relayer in its own process. It hosts no attestors and queries them over the network instead.
+
+## Before you begin
+
+Before proceeding, run the [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) and [standalone attestor](/ibc-cli/run-a-standalone-attestor) guides first, in order. You'll need to have an IBC deployment and standalone attestors on both chains to complete this guide.
+
+You also need a key funded on every chain you submit to.
+
+## 1. Relayer config
+
+1. Create a new configuration file for the relayer:
+
+```bash
+./bin/ibc config new --home ~/.ibc-relayer2
+```
+
+2. Import a funded key. This is an account from the tutorial's setup script:
+
+```bash
+./bin/ibc keys import ecdsa relayer2 --home ~/.ibc-relayer2 --private-key 0xa42b90503f0d4a418e2b8b140a03901c89d76704c8af49c3ef82d6f3cd91f23d
+```
+
+3. Write its configuration, reading both router addresses and both attestor names from your deployment:
+
+```bash
+cat > ~/.ibc-relayer2/ibc.yml <<EOF
+server:
+  listenAddr: 0.0.0.0:3002
+db:
+  type: sqlite
+  url: ibc.db
+
+chains:
+- chainId: "41001"
+  evm:
+    rpc: http://localhost:8545
+    ics26Router: "$(./bin/ibc deploy show 41001 | jq -r '.core.router')"
+- chainId: "41002"
+  evm:
+    rpc: http://localhost:8745
+    ics26Router: "$(./bin/ibc deploy show 41002 | jq -r '.core.router')"
+
+relayer:
+  connections:
+  - alias: 41001-41002
+    clientA:
+      chainId: "41001"
+      clientId: link-41001-41002
+      signer: relayer2
+      type: attestation
+    clientB:
+      chainId: "41002"
+      clientId: link-41001-41002
+      signer: relayer2
+      type: attestation
+
+attestors:
+- name: attestor-41002-$(./bin/ibc keys show attestor-41002 --home ~/.ibc-attestor | jq -r '.evmAddress')
+  type: remote
+  grpc: 127.0.0.1:3001
+- name: attestor-41001-$(./bin/ibc keys show attestor-41001 --home ~/.ibc-attestor-41001 | jq -r '.evmAddress')
+  type: remote
+  grpc: 127.0.0.1:3003
+
+signers:
+- alias: relayer2
+  type: local
+  file: relayer2
+EOF
+```
+
+- No chain names a deployer, because this relayer deploys nothing.
+- The signer on each client end is the key that submits on that end's own chain, so one connection can use a different key per side.
+
+## 2. Validate the config
+
+```bash
+./bin/ibc config validate --home ~/.ibc-relayer2 --live --strict
+```
+
+```json
+{
+  "status": "valid"
+}
+```
+
+## 3. Relay a packet
+
+1. Send a transfer and keep the hash:
+
+```bash
+TX=$(./bin/ibc tx ift send --chain 41001 --ift "$(./bin/ibc deploy show 41001 | jq -r '.tokens[0].address')" --client-id link-41001-41002 --to deployer --from deployer --amount 1000000000000000000 | jq -r '.txHash') && echo "$TX"
+```
+
+The tokens are burned on 41001 and nothing has delivered them yet.
+
+2. Start your relayer in a new terminal, and leave it running:
+
+```bash
+./bin/ibc relayer run --home ~/.ibc-relayer2
+```
+
+```
+level=INFO msg="Migrated database" migrations_applied=3
+level=INFO msg="Starting relayer"
+{"event":"ready","chainsConnected":["41001","41002"],"http":"[::]:3002"}
+```
+
+It creates its database on the way up.
+
+3. Back in your first terminal, relay the packet:
+
+```bash
+./bin/ibc relayer relay --home ~/.ibc-relayer2 --chain-id 41001 --tx-hash "$TX"
+```
+
+```json
+{
+  "packets": [
+    {
+      "source_client_id": "link-41001-41002",
+      "sequence_number": "2",
+      "selection": "PACKET_SELECTION_SELECTED"
+    }
+  ]
+}
+```
+
+4. Watch it settle:
+
+```bash
+./bin/ibc relayer packets --home ~/.ibc-relayer2 --chain-id 41001 --tx-hash "$TX"
+```
+
+It reads `PACKET_STATE_PENDING` until the receive and the acknowledgement have both landed, then `PACKET_STATE_SUCCEEDED` with all three transaction hashes.
+
+5. Confirm the balance on the destination chain:
+
+```bash
+./bin/ibc query ift balance --chain 41002 --ift "$(./bin/ibc deploy show 41002 | jq -r '.tokens[0].address')" --address deployer
+```
+
+The balance should be one token higher, meaning the packet was delivered successfully.
+
+## What can go wrong
+
+**The relayer refuses to start on the attestor quorum.** It prints the addresses each client trusts next to the attestors it managed to reach, and stops when too few match the threshold. Check that your attestor addresses are reachable and that each remote entry's name matches the name its host serves it under.
+
+**Two attestors share one signing address on the same chain.** That is a startup error, because they would be one signer counted twice.
+
+**A packet stays pending.** The delivery is waiting on a finality gate, which asks the attestor quorum what height it can currently prove. A gate that has waited half an hour logs a warning that the chain may be lagging.
+
+**A transaction is rejected before it is sent.** The relayer builds EIP-1559 transactions and refuses a chain that reports no base fee.
+
+## Next steps
+
+- [Overview](/ibc-cli/overview) covers what the three parts are made of and how they fit together.

--- a/docs/6-ibc-cli/5-make-a-cross-chain-gmp-call.md
+++ b/docs/6-ibc-cli/5-make-a-cross-chain-gmp-call.md
@@ -13,14 +13,13 @@ The commands on this page need:
 - [jq](https://jqlang.org/download/) installed
 - [Git](https://git-scm.com/downloads) installed
 
-Follow the [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) to set up a deployment with a GMP app, a client, and a relayer.
+Follow the [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) to set up a deployment with a GMP app and a client, then [run a standalone relayer](/ibc-cli/run-a-standalone-relayer) to carry the packet.
 
 Once you have a live connection and running relayer, you'll need the following values from each chain. Run the commands in this guide from the `ibc/link` directory:
 
 ```bash
 ./bin/ibc deploy show 41001 | jq '{router: .core.router, gmp: .gmp.address, clients: [.clients[].clientId]}'
 ./bin/ibc deploy show 41002 | jq '{router: .core.router, gmp: .gmp.address, clients: [.clients[].clientId]}'
-
 ```
 
 Print the private key you imported from the tutorial:
@@ -126,7 +125,7 @@ export TIMEOUT=$(( $(cast block latest --rpc-url $RPC_A --field timestamp) + 360
 cast call $GMP_A "sendCall((string,string,bytes,bytes,uint64,string))(uint64)" "($CLIENT_A,$RECEIVER,0x,$PAYLOAD,$TIMEOUT,\"\")" --rpc-url $RPC_A --from $SENDER
 ```
 
-The number it returns is the sequence the packet would get. 
+The number it returns is the sequence the packet would get.
 
 4. Send the source transaction, keeping the hash so you can relay it:
 
@@ -140,30 +139,12 @@ cast receipt $TX status --rpc-url $RPC_A
 
 ## 3. Relay the packet
 
-Call the relayer to relay the packet:
+The relayer will pick up the packet automatically and relay it to the destination chain.
 
-1. Name the chain the transaction is on and the transaction:
-
-```bash
-./bin/ibc relayer relay --chain-id 41001 --tx-hash $TX
-```
-
-```json
-{
-  "packets": [
-    {
-      "source_client_id": "link-41001-41002",
-      "sequence_number": "2",
-      "selection": "PACKET_SELECTION_SELECTED"
-    }
-  ]
-}
-```
-
-2. Watch it settle. This may take a few seconds:
+You can watch the transaction settle on the destination. This takes about a minute:
 
 ```bash
-./bin/ibc relayer packets --chain-id 41001 --tx-hash $TX
+./bin/ibc relayer packets --config ibc-relayer2.yml --chain-id 41001 --tx-hash $TX
 ```
 
 Success looks like this:
@@ -173,25 +154,25 @@ Success looks like this:
   "packets": [
     {
       "state": "PACKET_STATE_SUCCEEDED",
-      "sequence_number": "2",
-      "source_client_id": "link-41001-41002",
-      "send_tx": {
-        "tx_hash": "0x832cb445e9bba060ed1794deef26258986ea7c5b8719d35f0df3bf00d09b8c95",
-        "chain_id": "41001"
+      "sequenceNumber": "2",
+      "sourceClientId": "link-41001-41002",
+      "sendTx": {
+        "txHash": "0x832cb445e9bba060ed1794deef26258986ea7c5b8719d35f0df3bf00d09b8c95",
+        "chainId": "41001"
       },
-      "recv_tx": {
-        "tx_hash": "0xfe6b97036fe6881d4d4f08f11a0bbd85eb74432c4a82bb8249b6d33fd2605520",
-        "chain_id": "41002"
+      "recvTx": {
+        "txHash": "0xfe6b97036fe6881d4d4f08f11a0bbd85eb74432c4a82bb8249b6d33fd2605520",
+        "chainId": "41002"
       },
-      "ack_tx": {
-        "tx_hash": "0x6aaa4665369f3224da4e4c10192742515be49b5f1a3fc3f05de89026164fcc45",
-        "chain_id": "41001"
+      "ackTx": {
+        "txHash": "0x6aaa4665369f3224da4e4c10192742515be49b5f1a3fc3f05de89026164fcc45",
+        "chainId": "41001"
       },
-      "timeout_tx": null
+      "timeoutTx": null
     }
   ],
-  "has_more": false,
-  "next_cursor": ""
+  "hasMore": false,
+  "nextCursor": ""
 }
 ```
 
@@ -217,7 +198,7 @@ cast call $RECEIVER "lastCaller()(address)" --rpc-url $RPC_B
 0x82589a599B4b5cf636f80242509Ef821519560cD
 ```
 
-That is your account on the destination chain, derived from the destination chain's client identifier, your sender string, and the salt. 
+That is your account on the destination chain, derived from the destination chain's client identifier, your sender string, and the salt.
 
 This can also be computed ahead of time by calling the destination's GMP contract:
 
@@ -251,8 +232,7 @@ function onAckPacket(bool success, IIBCAppCallbacks.OnAcknowledgementPacketCallb
 function onTimeoutPacket(IIBCAppCallbacks.OnTimeoutPacketCallback calldata msg_) external;
 ```
 
-Both structs carry the two client identifiers, the sequence, the original payload, and the relayer's address. The acknowledgement path adds the raw acknowledgement bytes. Those decode as a `GMPAcknowledgement` when `success` is true, and carry a fixed error constant when it is not. 
+Both structs carry the two client identifiers, the sequence, the original payload, and the relayer's address. The acknowledgement path adds the raw acknowledgement bytes. Those decode as a `GMPAcknowledgement` when `success` is true, and carry a fixed error constant when it is not.
 
 - GMP only calls back if your contract advertises that it can receive callbacks. You can do that by inheriting `IBCCallbackReceiver`.
 - Each `sendCall` returns a sequence number. Save it if you need to match an acknowledgement to the call that caused it.
-

--- a/docs/6-ibc-cli/5-make-a-cross-chain-gmp-call.md
+++ b/docs/6-ibc-cli/5-make-a-cross-chain-gmp-call.md
@@ -1,0 +1,258 @@
+---
+title: "Make a cross-chain GMP call"
+description: "Call a contract on another chain over IBC, and receive the result back as an acknowledgement."
+---
+
+This guide uses the General Message Passing (GMP) app to call a contract on another chain. You'll send the call from a source chain and execute it on the destination chain from an account derived from the sender.
+
+## Before you begin
+
+The commands on this page need:
+
+- [Foundry](https://getfoundry.sh) v1.5.1 or later, for `forge` and `cast`
+- [jq](https://jqlang.org/download/) installed
+- [Git](https://git-scm.com/downloads) installed
+
+Follow the [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) to set up a deployment with a GMP app, a client, and a relayer.
+
+Once you have a live connection and running relayer, you'll need the following values from each chain. Run the commands in this guide from the `ibc/link` directory:
+
+```bash
+./bin/ibc deploy show 41001 | jq '{router: .core.router, gmp: .gmp.address, clients: [.clients[].clientId]}'
+./bin/ibc deploy show 41002 | jq '{router: .core.router, gmp: .gmp.address, clients: [.clients[].clientId]}'
+
+```
+
+Print the private key you imported from the tutorial:
+
+```bash
+./bin/ibc keys show deployer --private | jq -r '.privateKey'
+```
+
+Export the values from the outputs above:
+
+```bash
+export RPC_A=http://localhost:8545
+export RPC_B=http://localhost:8745
+export CLIENT_A=link-41001-41002
+export CLIENT_B=link-41001-41002
+export GMP_A=0xA0408F356956Ae9BECa5Ac57040695012fa3CAAB
+export GMP_B=0xA0408F356956Ae9BECa5Ac57040695012fa3CAAB
+export KEY=0x33fa40f84e854b941c2b0436dd4a256e1df1cb41b9c1c0ccc8446408c19b8bf9
+export SENDER=$(cast wallet address --private-key $KEY)
+```
+
+## 1. Deploy a contract to call
+
+A GMP call arrives on the destination as a contract call, carrying the packet's payload as its call data.
+
+Every GMP call executes through an account contract that belongs to the sender, so the target reads that account's address as `msg.sender`.
+
+Create a Foundry project in the `ibc/link` directory:
+
+```bash
+forge init gmp-guide
+```
+
+1. Write a receiver that stores a value it is passed and the caller. Save it in the project as `gmp-guide/src/Remote.sol`:
+
+```solidity
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+contract Remote {
+    uint256 public value;
+    address public lastCaller;
+
+    function set(uint256 v) external {
+        value = v;
+        lastCaller = msg.sender;
+    }
+}
+```
+
+2. Deploy the contract on the destination chain:
+
+```bash
+cd gmp-guide
+forge create src/Remote.sol:Remote --rpc-url $RPC_B --private-key $KEY --broadcast
+cd ..
+```
+
+```
+Deployer: 0x58A57ed9d8d624cBD12e2C467D34787555bB1b25
+Deployed to: 0x890EdF334Fa33373ec945Bdd757C55DfB4e038e6
+Transaction hash: 0xb9173f4c897c0621d7756ea81fb731c0b74ebdf0ad7a799ecb25e8abc0be0e2c
+```
+
+3. Keep the address it printed:
+
+```bash
+export RECEIVER=0x890EdF334Fa33373ec945Bdd757C55DfB4e038e6
+```
+
+## 2. Send the call
+
+Sending is a single call to `sendCall` on the source chain's GMP contract:
+
+```solidity
+struct SendCallMsg {
+    string sourceClient;      // the client to send over
+    string receiver;          // destination contract, as a string
+    bytes salt;               // used to create multiple accounts from the same sender
+    bytes payload;            // call data for the receiver
+    uint64 timeoutTimestamp;  // unix seconds, at most one day out
+    string memo;              // a memo
+}
+```
+
+The four steps below build one packet on chain A. It carries a call to `set(42)`, addressed to the `Remote` contract you deployed on chain B.
+
+1. Encode the call to be made as the payload:
+
+```bash
+export PAYLOAD=$(cast calldata "set(uint256)" 42)
+```
+
+2. Read the source chain's clock and pick a timeout an hour out:
+
+```bash
+export TIMEOUT=$(( $(cast block latest --rpc-url $RPC_A --field timestamp) + 3600 ))
+```
+
+3. Dry-run the send:
+
+```bash
+cast call $GMP_A "sendCall((string,string,bytes,bytes,uint64,string))(uint64)" "($CLIENT_A,$RECEIVER,0x,$PAYLOAD,$TIMEOUT,\"\")" --rpc-url $RPC_A --from $SENDER
+```
+
+The number it returns is the sequence the packet would get. 
+
+4. Send the source transaction, keeping the hash so you can relay it:
+
+```bash
+export TX=$(cast send $GMP_A "sendCall((string,string,bytes,bytes,uint64,string))(uint64)" "($CLIENT_A,$RECEIVER,0x,$PAYLOAD,$TIMEOUT,\"\")" --rpc-url $RPC_A --private-key $KEY --json | jq -r .transactionHash)
+```
+
+```bash
+cast receipt $TX status --rpc-url $RPC_A
+```
+
+## 3. Relay the packet
+
+Call the relayer to relay the packet:
+
+1. Name the chain the transaction is on and the transaction:
+
+```bash
+./bin/ibc relayer relay --chain-id 41001 --tx-hash $TX
+```
+
+```json
+{
+  "packets": [
+    {
+      "source_client_id": "link-41001-41002",
+      "sequence_number": "2",
+      "selection": "PACKET_SELECTION_SELECTED"
+    }
+  ]
+}
+```
+
+2. Watch it settle. This may take a few seconds:
+
+```bash
+./bin/ibc relayer packets --chain-id 41001 --tx-hash $TX
+```
+
+Success looks like this:
+
+```json
+{
+  "packets": [
+    {
+      "state": "PACKET_STATE_SUCCEEDED",
+      "sequence_number": "2",
+      "source_client_id": "link-41001-41002",
+      "send_tx": {
+        "tx_hash": "0x832cb445e9bba060ed1794deef26258986ea7c5b8719d35f0df3bf00d09b8c95",
+        "chain_id": "41001"
+      },
+      "recv_tx": {
+        "tx_hash": "0xfe6b97036fe6881d4d4f08f11a0bbd85eb74432c4a82bb8249b6d33fd2605520",
+        "chain_id": "41002"
+      },
+      "ack_tx": {
+        "tx_hash": "0x6aaa4665369f3224da4e4c10192742515be49b5f1a3fc3f05de89026164fcc45",
+        "chain_id": "41001"
+      },
+      "timeout_tx": null
+    }
+  ],
+  "has_more": false,
+  "next_cursor": ""
+}
+```
+
+## Verify the call landed
+
+Now verify the state changed on the destination contract:
+
+```bash
+cast call $RECEIVER "value()(uint256)" --rpc-url $RPC_B
+```
+
+```
+42
+```
+
+Then read the caller:
+
+```bash
+cast call $RECEIVER "lastCaller()(address)" --rpc-url $RPC_B
+```
+
+```
+0x82589a599B4b5cf636f80242509Ef821519560cD
+```
+
+That is your account on the destination chain, derived from the destination chain's client identifier, your sender string, and the salt. 
+
+This can also be computed ahead of time by calling the destination's GMP contract:
+
+```bash
+cast call $GMP_B "getOrComputeAccountAddress((string,string,bytes))(address)" "($CLIENT_B,$SENDER,0x)" --rpc-url $RPC_B
+```
+
+```
+0x82589a599B4b5cf636f80242509Ef821519560cD
+```
+
+The mapping works in reverse too, which is how a receiving contract identifies who called it:
+
+```bash
+cast call $GMP_B "getAccountIdentifier(address)((string,string,bytes))" 0x82589a599B4b5cf636f80242509Ef821519560cD --rpc-url $RPC_B
+```
+
+```
+("link-41001-41002", "0x58A57ed9d8d624cBD12e2C467D34787555bB1b25", 0x)
+```
+
+The account is a contract that is deployed on the first inbound call for that identifier.
+
+## Contract acknowledgement callbacks
+
+When sending from a contract, the sender can receive the acknowledgement by implementing two callback functions:
+
+```solidity
+function onAckPacket(bool success, IIBCAppCallbacks.OnAcknowledgementPacketCallback calldata msg_) external;
+
+function onTimeoutPacket(IIBCAppCallbacks.OnTimeoutPacketCallback calldata msg_) external;
+```
+
+Both structs carry the two client identifiers, the sequence, the original payload, and the relayer's address. The acknowledgement path adds the raw acknowledgement bytes. Those decode as a `GMPAcknowledgement` when `success` is true, and carry a fixed error constant when it is not. 
+
+- GMP only calls back if your contract advertises that it can receive callbacks. You can do that by inheriting `IBCCallbackReceiver`.
+- Each `sendCall` returns a sequence number. Save it if you need to match an acknowledgement to the call that caused it.
+

--- a/docs/6-ibc-cli/6-configuration.md
+++ b/docs/6-ibc-cli/6-configuration.md
@@ -36,12 +36,14 @@ chains:
   - chainId: "41001"
     evm:
       rpc: http://localhost:8545
+      ws: ws://localhost:8546
       ics26Router: "0x64A6714075b7590f8b07D07a5B431409337de29B"
     deployer: deployer
 
   - chainId: "41002"
     evm:
       rpc: http://localhost:8745
+      ws: ws://localhost:8746
       ics26Router: "0x64A6714075b7590f8b07D07a5B431409337de29B"
     deployer: deployer
 
@@ -53,11 +55,15 @@ relayer:
         signer: relayer
         clientId: link-41001-41002
         type: attestation
+        autoRelay:
+          enabled: true
       clientB:
         chainId: "41002"
         signer: relayer
         clientId: link-41001-41002
         type: attestation
+        autoRelay:
+          enabled: true
 
 attestors:
   - name: attestor-41001

--- a/docs/6-ibc-cli/6-configuration.md
+++ b/docs/6-ibc-cli/6-configuration.md
@@ -1,0 +1,337 @@
+---
+title: "Configuration"
+description: "Configure chains, connections, attestors, signers, and storage in ibc.yml."
+---
+
+The IBC CLI reads its configuration from `ibc.yml`. The file tells the CLI:
+
+- which chains to connect to
+- which clients form each connection
+- which attestors to run or query
+- which keys to use for deployment, relaying, and attestation
+- where the relayer stores packet state
+
+Run the following commands to create and validate the file:
+
+```sh
+ibc config new
+ibc config validate
+```
+
+Values can contain `${VAR}`. The CLI replaces each variable from the environment before it parses the file. <!-- [config.go:L169](link/internal/config/config.go#L169) -->
+
+## Example config.yml
+
+This configuration comes from the tutorial. In this setup, a single process runs the relayer and one attestor for each chain.
+
+```yaml
+server:
+  listenAddr: 0.0.0.0:3000
+
+db:
+  type: sqlite
+  url: ibc.db
+
+chains:
+  - chainId: "41001"
+    evm:
+      rpc: http://localhost:8545
+      ics26Router: "0x64A6714075b7590f8b07D07a5B431409337de29B"
+    deployer: deployer
+
+  - chainId: "41002"
+    evm:
+      rpc: http://localhost:8745
+      ics26Router: "0x64A6714075b7590f8b07D07a5B431409337de29B"
+    deployer: deployer
+
+relayer:
+  connections:
+    - alias: 41001-41002
+      clientA:
+        chainId: "41001"
+        signer: relayer
+        clientId: link-41001-41002
+        type: attestation
+      clientB:
+        chainId: "41002"
+        signer: relayer
+        clientId: link-41001-41002
+        type: attestation
+
+attestors:
+  - name: attestor-41001
+    type: local
+    chainId: "41001"
+    signer: attestor-41001
+    finalityOffset: 1
+
+  - name: attestor-41002
+    type: local
+    chainId: "41002"
+    signer: attestor-41002
+    finalityOffset: 1
+
+signers:
+  - alias: deployer
+    type: local
+    file: deployer
+
+  - alias: relayer
+    type: local
+    file: relayer
+
+  - alias: attestor-41001
+    type: local
+    file: attestor-41001
+
+  - alias: attestor-41002
+    type: local
+    file: attestor-41002
+```
+
+The names in this file are references:
+
+| Reference | Must match |
+| --- | --- |
+| `clientA.chainId` and `clientB.chainId` | A `chains[].chainId` value <!-- [config.go:L300-L319](link/internal/config/config.go#L300-L319) --> |
+| `clientA.signer` and `clientB.signer` | A `signers[].alias` value <!-- [config.go:L323-L336](link/internal/config/config.go#L323-L336) --> |
+| A local attestor's `signer` | A `signers[].alias` value <!-- [config.go:L232-L239](link/internal/config/config.go#L232-L239) --> |
+| `chains[].deployer` | A `signers[].alias` value <!-- [config.go:L241-L248](link/internal/config/config.go#L241-L248) --> |
+
+For example, `signer: attestor-41001` selects the signer whose alias is `attestor-41001`. `ibc config validate` reports an unresolved reference. A local attestor's `chainId` is checked when the process starts rather than by validation. <!-- [resolve.go:L55-L57](link/internal/service/attestor/resolve.go#L55-L57) -->
+
+## `server`
+
+`server` sets the address for the relayer and attestor APIs. A process that runs both services uses one server.
+
+<!-- GEN:config:server START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `listenAddr` | `string` | `0.0.0.0:3000` | Address the gRPC server binds. It serves the relayer and attestor APIs together. |
+
+<!-- [config.go:L47](link/internal/config/config.go#L47) -->
+
+<!-- GEN:config:server END -->
+
+Server reflection is always enabled. <!-- [bootstrap.go:L120](link/internal/bootstrap/bootstrap.go#L120) --> <!-- [server.go:L103-L113](link/internal/server/server.go#L103-L113) -->
+
+## `db`
+
+`db` configures the relayer's packet store. The store lets the relayer resume unfinished work after a restart.
+
+<!-- GEN:config:db START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `type` | `sqlite` \| `postgres` | `sqlite` | Database backend. |
+| `url` | `string` | `ibc.db` | File path for sqlite, connection string for postgres. `:memory:` is rejected. |
+
+<!-- [config.go:L52](link/internal/config/config.go#L52) -->
+
+<!-- GEN:config:db END -->
+
+`ibc relayer run` applies pending migrations at startup. Pass `--no-migrate` to disable automatic migration, or run `ibc migrate up` separately.
+
+## `chains`
+
+`chains` lists every chain used elsewhere in the file.
+
+<!-- GEN:config:chains START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `chainId` | `string` | **required** | The chain's id, as the chain reports it. |
+| `deployer` | `string` | optional | Optional signer alias used by `ibc deploy` for this chain. |
+| `evm.rpc` | `string` | **required** | JSON-RPC endpoint for the chain. |
+| `evm.ws` | `string` | optional | A websocket endpoint, required for chains sourcing auto-relayed routes. |
+| `evm.ics26Router` | `string` | optional | Address of the ICS26 router on the chain. |
+
+<!-- [config.go:L115](link/internal/config/config.go#L115) -->
+
+<!-- GEN:config:chains END -->
+
+`ibc deploy core` deploys the router. <!-- [steps.go:L67-L97](link/internal/deploy/steps.go#L67-L97) --> Omit `ics26Router` before deployment, then fill it in from the manifest, or let `ibc deploy render-config` write the finished blocks. <!-- [deploy.go:L544-L600](link/cmd/ibc/deploy.go#L544-L600) -->
+
+The deployer must be a local signer, because deployment requires direct access to the key. <!-- [deploy.go:L123-L155](link/cmd/ibc/deploy.go#L123-L155) -->
+
+## `relayer`
+
+### Connections
+
+`relayer.connections` selects the connections this process relays. Each entry identifies one client on each chain, and the relayer handles traffic in both directions.
+
+<!-- GEN:config:relayer:connections START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `connections[].alias` | `string` | **required** | Name for the connection, unique in the file. |
+| `connections[].clientA.chainId, connections[].clientB.chainId` | `string` | **required** | The chain this end's client lives on. |
+| `connections[].clientA.signer, connections[].clientB.signer` | `string` | **required** | `signers` alias that submits relay transactions on this chain. |
+| `connections[].clientA.clientId, connections[].clientB.clientId` | `string` | **required** | The light client's id on this chain. |
+| `connections[].clientA.type, connections[].clientB.type` | `attestation` | **required** | Light client type. |
+| `connections[].clientA.autoRelay.enabled, connections[].clientB.autoRelay.enabled` | `bool` | optional | Whether the relayer carries packets leaving this end without being asked. |
+
+<!-- [relayer.go:L53](link/internal/config/relayer.go#L53) -->
+
+<!-- GEN:config:relayer:connections END -->
+
+Client identifiers are scoped to a chain, so both ends can use the same `clientId`, as in the example above. `ibc deploy client` does this by default. <!-- [deploy.go:L256-L262](link/cmd/ibc/deploy.go#L256-L262) -->
+
+The two client ends must belong to different chains. A client can appear in only one configured connection on a given chain. <!-- [relayer.go:L149-L176](link/internal/config/relayer.go#L149-L176) -->
+
+With `autoRelay.enabled` on an end, the relayer carries that end's outgoing packets without being asked. <!-- [set.go:L27-L39](link/internal/relay/watcher/set.go#L27-L39) --> That end's chain needs `evm.ws`, and validation fails without it. <!-- [config.go:L237-L264](link/internal/config/config.go#L237-L264) --> Unset and `false` are the same input. <!-- [relayer.go:L118-L135](link/internal/config/relayer.go#L118-L135) -->
+
+### Relay settings
+
+The relayer uses these defaults unless you override them.
+
+<!-- GEN:config:relayer START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `dispatchPollInterval` | `duration` | `5s` | How often the dispatcher polls the store for unfinished packets. |
+
+<!-- [relayer.go:L29](link/internal/config/relayer.go#L29) --> <!-- [dispatcher.go:L17](link/internal/relay/dispatch/dispatcher.go#L17) -->
+
+<!-- GEN:config:relayer END -->
+
+<!-- GEN:config:relayer:chainOverrides START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `chainOverrides[].chainId` | `string` | **required** | The chain these settings apply to. |
+| `chainOverrides[].txSubmissionDelay` | `duration` | `2s` | Minimum delay between two transaction submissions on the chain. |
+| `chainOverrides[].packetBatchSize` | `int` | `50` | How many packets the relayer puts in one transaction. |
+| `chainOverrides[].packetBatchTimeout` | `duration` | `10s` (receive and acknowledge), `1m` (timeout) | How long the relayer waits to fill a batch before submitting it. |
+| `chainOverrides[].evm.gasFeeCapMultiplier` | `float64` | optional | Multiplies the fee cap the node suggests. |
+| `chainOverrides[].evm.gasTipCapMultiplier` | `float64` | optional | Multiplies the tip cap the node suggests. |
+
+<!-- [relayer.go:L36](link/internal/config/relayer.go#L36) --> <!-- [evm.go:L26](link/internal/txsubmitter/evm/evm.go#L26) --> <!-- [opts.go:L14](link/internal/relay/pipeline/opts.go#L14) --> <!-- [opts.go:L15](link/internal/relay/pipeline/opts.go#L15) --> <!-- [opts.go:L16](link/internal/relay/pipeline/opts.go#L16) -->
+
+<!-- GEN:config:relayer:chainOverrides END -->
+
+Add an override only when a chain needs different behavior:
+
+```yaml
+relayer:
+  dispatchPollInterval: 5s
+  chainOverrides:
+    - chainId: "41002"
+      txSubmissionDelay: 3s
+      packetBatchSize: 25
+      packetBatchTimeout: 15s
+      evm:
+        gasFeeCapMultiplier: 1.2
+        gasTipCapMultiplier: 1.1
+```
+
+Receive batches use the destination chain's settings. Acknowledgement and timeout batches use the source chain's settings. <!-- [opts.go:L34-L71](link/internal/relay/pipeline/opts.go#L34-L71) -->
+
+## `attestors`
+
+`attestors` lists the attestors that the process runs or queries. A `local` attestor watches a configured chain and signs with a configured signer. A `remote` attestor runs elsewhere and is queried over gRPC.
+
+### Local attestor
+
+<!-- GEN:config:attestors:local START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `chainId` | `string` | **required** | The chain this attestor watches. |
+| `name` | `string` | **required** | The attestor's own self-reported identity. Not required unique. |
+| `type` | `local` | **required** | Whether this process runs the attestor or queries it. |
+| `signer` | `string` | **required** | The signer used to sign attestations. |
+| `finalityOffset` | `uint` | optional | Zero attests up to the chain's `finalized` tag; n > 0 attests up to `latest` - n instead. |
+
+<!-- [config.go:L64](link/internal/config/config.go#L64) -->
+
+<!-- GEN:config:attestors:local END -->
+
+Set `finalityOffset` according to the chain's finality model.
+
+### Remote attestor
+
+```yaml
+attestors:
+  - name: attestor-41002
+    type: remote
+    grpc: attestor.example.com:3000
+```
+
+<!-- GEN:config:attestors:remote START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `name` | `string` | **required** | The attestor's own self-reported identity. Not required unique. |
+| `type` | `remote` | **required** | Whether this process runs the attestor or queries it. |
+| `grpc` | `string` | **required** | Bare host:port. |
+
+<!-- [config.go:L64](link/internal/config/config.go#L64) -->
+
+<!-- GEN:config:attestors:remote END -->
+
+A remote entry does not set `chainId` or `signer`. The process obtains the attestor's chain and signing address from its `Info` RPC. <!-- [remote.go:L31-L51](link/internal/service/attestor/remote.go#L31-L51) -->
+
+Fields from the other attestor type are rejected. A remote attestor cannot set `chainId`, and a local attestor cannot set `grpc`. <!-- [config.go:L513-L536](link/internal/config/config.go#L513-L536) -->
+
+Local attestor names must be unique. Two local attestors for the same chain must also use different signers. <!-- [config.go:L474-L503](link/internal/config/config.go#L474-L503) -->
+
+## `signers`
+
+`signers` defines the keys referenced elsewhere in the file. Each signer has a unique alias.
+
+### Local signer
+
+<!-- GEN:config:signers:local START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `alias` | `string` | **required** | Unique name for a signer. |
+| `type` | `local` | **required** | Whether the key is a file on disk or a key held by a remote signer. |
+| `file` | `string` | **required** | Key file path for a local signer. |
+
+<!-- [config.go:L89](link/internal/config/config.go#L89) -->
+
+<!-- GEN:config:signers:local END -->
+
+For `file: relayer`, the CLI checks `relayer`, `relayer.json`, and the `keys` directory under the IBC home directory. The final path is typically `~/.ibc/keys/relayer.json`. <!-- [config.go:L591-L615](link/internal/config/config.go#L591-L615) -->
+
+### Remote signer
+
+```yaml
+signers:
+  - alias: relayer
+    type: remote
+    grpc: signer.example.com:9090
+    remoteKeyId: relayer-key-id
+```
+
+<!-- GEN:config:signers:remote START -->
+
+| Key | Type | Default or required | Description |
+|---|---|---|---|
+| `alias` | `string` | **required** | Unique name for a signer. |
+| `type` | `remote` | **required** | Whether the key is a file on disk or a key held by a remote signer. |
+| `grpc` | `string` | **required** | Address for a remote signer. |
+| `remoteKeyId` | `string` | **required** | KMS key ID for a remote signer. |
+
+<!-- [config.go:L89](link/internal/config/config.go#L89) -->
+
+<!-- GEN:config:signers:remote END -->
+
+The remote signer holds the key material and performs signing.
+
+## Split the configuration by process
+
+The complete example runs the relayer and both attestors together. In production, you can give each process only the blocks it uses:
+
+- A standalone relayer needs `server`, `db`, `chains`, `relayer`, the attestors it queries, and its transaction signers.
+- A standalone local attestor needs `server`, its chain, its `attestors` entry, and its attestation signer. It does not need `db` or `relayer`.
+
+## Next steps
+
+- [Run a standalone relayer](/ibc-cli/run-a-standalone-relayer)
+- [Run a standalone attestor](/ibc-cli/run-a-standalone-attestor)
+- [CLI commands](/ibc-cli/cli-commands) for command-line overrides

--- a/docs/6-ibc-cli/6-configuration.md
+++ b/docs/6-ibc-cli/6-configuration.md
@@ -90,7 +90,7 @@ signers:
     file: attestor-41002
 ```
 
-The names in this file are references:
+The following fields in this file are references to other fields:
 
 | Reference | Must match |
 | --- | --- |
@@ -126,7 +126,7 @@ Server reflection is always enabled. <!-- [bootstrap.go:L120](link/internal/boot
 | Key | Type | Default or required | Description |
 |---|---|---|---|
 | `type` | `sqlite` \| `postgres` | `sqlite` | Database backend. |
-| `url` | `string` | `ibc.db` | File path for sqlite, connection string for postgres. `:memory:` is rejected. |
+| `url` | `string` | `ibc.db` | File path for sqlite, connection string for postgres. |
 
 <!-- [config.go:L52](link/internal/config/config.go#L52) -->
 

--- a/docs/6-ibc-cli/7-cli-commands.md
+++ b/docs/6-ibc-cli/7-cli-commands.md
@@ -1,0 +1,579 @@
+---
+title: "CLI commands"
+description: "IBC CLI command reference"
+---
+
+The IBC CLI contains commands for configuring, deploying, running, and monitoring IBC deployments, relayers, and attestors.
+
+Commands are grouped here the way the binary groups them, so any of them prints its own flags with `--help`. The sections run in the order a reader meets them: `config` and `keys`, then `deploy`, then `relayer` and `attestor`, then `tx` and `query`, then `migrate`.
+
+## Global flags
+
+<!-- GEN:cli:global-flags START -->
+
+| Flag | Default | Description |
+|---|---|---|
+| `--config <string>` | `ibc.yml` | Config file relative to home. |
+| `--db <string>` |  | Database URL override. |
+| `--home <string>` | `~/.ibc` | IBC home directory. |
+| `--log-json` |  | Enable JSON logging. |
+| `-q, --quiet` |  | Quiet mode. |
+
+<!-- [flags.go:L38](link/internal/config/flags.go#L38) -->
+
+<!-- GEN:cli:global-flags END -->
+
+`--home` is where the config file, the keystore, the manifests, and the relayer's database live. A command that reads the config changes into that directory first, so a config naming `keys/alice.json` finds `~/.ibc/keys/alice.json`. <!-- [config.go:L142-L160](link/cmd/ibc/config.go#L142-L160) -->
+
+## `config`
+
+The config is a YAML file describing every chain, connection, attestor, and signer the other commands use.
+
+### `ibc config add-chain`
+
+<!-- GEN:cli:cmd:config-add-chain START -->
+
+Add a chain entry to the config.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--chain-id <string>` | required | Chain ID. |
+| `--deployer <string>` |  | Signer alias used by ibc deploy for this chain. |
+| `--router <string>` | left blank, fill in via render-config | Ics26Router address. |
+| `--rpc <string>` | required | Chain RPC URL. |
+| `--ws <string>` |  | Chain websocket URL, required for chains sourcing auto-relayed routes. |
+
+<!-- [main.go:L75](link/cmd/ibc/main.go#L75) -->
+
+<!-- GEN:cli:cmd:config-add-chain END -->
+
+```bash
+ibc config add-chain --chain-id 41001 --rpc http://localhost:8545
+```
+
+Leave `--router` out until the chain has a router to point at. `ibc deploy render-config` prints the finished chain entries, with the router addresses filled in from the manifests.
+
+### `ibc config new`
+
+<!-- GEN:cli:cmd:config-new START -->
+
+Create new config file.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--out` |  | Output the config to stdout. |
+
+<!-- [main.go:L71](link/cmd/ibc/main.go#L71) -->
+
+<!-- GEN:cli:cmd:config-new END -->
+
+The command refuses to overwrite an existing file, so it is safe to run twice. <!-- [config.go:L95-L112](link/cmd/ibc/config.go#L95-L112) -->
+
+### `ibc config validate`
+
+<!-- GEN:cli:cmd:config-validate START -->
+
+Validate the config.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--live` |  | Extra validation checks. |
+| `--strict` |  | Fail on unknown fields in the config file. |
+
+<!-- [main.go:L72](link/cmd/ibc/main.go#L72) -->
+
+<!-- GEN:cli:cmd:config-validate END -->
+
+`--live` adds the checks that need the chains. `--strict` catches a misspelled key that would otherwise be ignored.
+
+## `keys`
+
+Keys live in `<ibc-home>/keys/`, one file each. These can be named by signers in the config file. <!-- [keys.go:L157-L162](link/cmd/ibc/keys.go#L157-L162) -->
+
+### `ibc keys import`
+
+<!-- GEN:cli:cmd:keys-import START -->
+
+Import a private key into `<ibc-home>/keys/<name>`.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--populate-config` |  | Append the resulting key as a signers entry in the config file. |
+| `--private-key <string>` |  | Hex-encoded private key. |
+
+<!-- [main.go:L90](link/cmd/ibc/main.go#L90) -->
+
+<!-- GEN:cli:cmd:keys-import END -->
+
+### `ibc keys list`
+
+<!-- GEN:cli:cmd:keys-list START -->
+
+Lists every key from `<ibc-home>/keys/`.
+
+<!-- [main.go:L59](link/cmd/ibc/main.go#L59) -->
+
+<!-- GEN:cli:cmd:keys-list END -->
+
+### `ibc keys new`
+
+<!-- GEN:cli:cmd:keys-new START -->
+
+Saves key into `<ibc-home>/keys/<name>` or prints to stdout if name is not provided.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--populate-config` |  | Append the resulting key as a signers entry in the config file. |
+
+<!-- [main.go:L91](link/cmd/ibc/main.go#L91) -->
+
+<!-- GEN:cli:cmd:keys-new END -->
+
+### `ibc keys show`
+
+<!-- GEN:cli:cmd:keys-show START -->
+
+Show key details from `<ibc-home>/keys/<name>`; optionally print the private key.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--private` |  | Show private key. |
+
+<!-- [main.go:L89](link/cmd/ibc/main.go#L89) -->
+
+<!-- GEN:cli:cmd:keys-show END -->
+
+> **Warning:** Do not run `keys show --private` on a shared or recorded terminal. The private key it prints controls every asset its address holds.
+
+## `deploy`
+
+Deploying a working connection between two chains takes `deploy core` on both, then `deploy client` on both, each client tracking the other chain. The [tutorial](/ibc-cli/tutorial-deploy-ibc-and-send-a-token) walks that through end to end.
+
+`--chain` is required by the commands that provision something, and the table cannot show it: they check it themselves rather than declaring it required. <!-- [deploy.go:L315-L317](link/cmd/ibc/deploy.go#L315-L317) -->
+
+`--dry-run` prints the steps a command would take and submits nothing.
+
+Manifests are machine-generated. A command that provisions something reads the manifest, decides from it what is already done, and writes it back. <!-- [steps.go:L73-L95](link/internal/deploy/steps.go#L73-L95) -->
+
+> **Warning:** Do not edit a manifest by hand. A deploy command decides what to skip from it, and an edit that disagrees with the chain either is overwritten or makes the next run fail.
+
+### `ibc deploy client`
+
+<!-- GEN:cli:cmd:deploy-client START -->
+
+Deploy and register a light client tracking a counterparty chain.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--attestors <strings>` | configured attestations for the tracked chain | Attestors for the new client: addresses, attestation names, or signer aliases. |
+| `--client-id <string>` | `link-<a>-<b>`, chain ids sorted | Client id. |
+| `--counterparty-chain <string>` | required | Counterparty chain id the client tracks. |
+| `--counterparty-client-id <string>` | `link-<a>-<b>`, chain ids sorted | Counterparty's client id. |
+| `--height <uint>` | counterparty head | Initial trusted height. |
+| `--threshold <uint8>` | `1` | Attestation signature threshold. |
+| `--timestamp <uint>` | counterparty head | Initial trusted timestamp seconds. |
+| `--type <string>` | `attestation` | Light client type. |
+| `--chain <string>` |  | Chain ID for the chain being deployed to. |
+| `--deployer <string>` |  | Signer alias override for deployment transactions. |
+| `--dry-run` |  | Print the step plan without submitting transactions. |
+| `--manifest-dir <string>` | `deployments` | Manifest directory relative to home. |
+| `--yes` |  | Skip confirmation prompts. |
+
+<!-- [main.go:L161](link/cmd/ibc/main.go#L161) -->
+
+<!-- GEN:cli:cmd:deploy-client END -->
+
+```bash
+ibc deploy client --chain 41001 --counterparty-chain 41002 --threshold 1 --yes
+```
+
+The client lives on `--chain` and watches `--counterparty-chain`. `--attestors` names the attestors watching the counterparty, since those are the signatures this client verifies. For `remote` attestors, pass the address instead of names. <!-- [attestors.go:L15-L30](link/cmd/ibc/attestors.go#L15-L30) --> Left out entirely, the command fails when the config lists no attestors for the counterparty chain. <!-- [attestors.go:L32-L42](link/cmd/ibc/attestors.go#L32-L42) -->
+
+Rerunning with the same `--client-id` continues that client. Rerunning with different attestors or a different threshold under the same id fails and lists the differences, because those values are fixed when the client is constructed. <!-- [steps.go:L126-L138](link/internal/deploy/steps.go#L126-L138) -->
+
+### `ibc deploy core`
+
+<!-- GEN:cli:cmd:deploy-core START -->
+
+Deploy the core IBC routing stack on one chain.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--chain <string>` |  | Chain ID for the chain being deployed to. |
+| `--deployer <string>` |  | Signer alias override for deployment transactions. |
+| `--dry-run` |  | Print the step plan without submitting transactions. |
+| `--manifest-dir <string>` | `deployments` | Manifest directory relative to home. |
+| `--yes` |  | Skip confirmation prompts. |
+
+<!-- [main.go:L59](link/cmd/ibc/main.go#L59) -->
+
+<!-- GEN:cli:cmd:deploy-core END -->
+
+### `ibc deploy gmp`
+
+<!-- GEN:cli:cmd:deploy-gmp START -->
+
+Deploy the ICS27-GMP app on one chain.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--chain <string>` |  | Chain ID for the chain being deployed to. |
+| `--deployer <string>` |  | Signer alias override for deployment transactions. |
+| `--dry-run` |  | Print the step plan without submitting transactions. |
+| `--manifest-dir <string>` | `deployments` | Manifest directory relative to home. |
+| `--yes` |  | Skip confirmation prompts. |
+
+<!-- [main.go:L59](link/cmd/ibc/main.go#L59) -->
+
+<!-- GEN:cli:cmd:deploy-gmp END -->
+
+### `ibc deploy ift`
+
+<!-- GEN:cli:cmd:deploy-ift START -->
+
+Deploy an IFT token on one chain.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--name <string>` | required | ERC20 token name. |
+| `--owner <string>` | `deployer` | Token owner address. |
+| `--symbol <string>` | required | ERC20 token symbol (need not be unique). |
+| `--chain <string>` |  | Chain ID for the chain being deployed to. |
+| `--deployer <string>` |  | Signer alias override for deployment transactions. |
+| `--dry-run` |  | Print the step plan without submitting transactions. |
+| `--manifest-dir <string>` | `deployments` | Manifest directory relative to home. |
+| `--yes` |  | Skip confirmation prompts. |
+
+<!-- [main.go:L184](link/cmd/ibc/main.go#L184) -->
+
+<!-- GEN:cli:cmd:deploy-ift END -->
+
+```bash
+ibc deploy ift --chain 41001 --name "Demo Token" --symbol DEMO --yes
+```
+
+### `ibc deploy ift-bridge`
+
+<!-- GEN:cli:cmd:deploy-ift-bridge START -->
+
+Register both sides of an IFT bridge between two chains' tokens.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--chain-a <string>` | required | First chain id. |
+| `--chain-b <string>` | required | Second chain id. |
+| `--client-id <string>` | `link-<a>-<b>` | Client id the bridge relays over. |
+| `--ift-a <string>` | required | IFT token address on chain A. |
+| `--ift-b <string>` | required | IFT token address on chain B. |
+| `--send-call-constructor-a <string>` | deploy or reuse the EVM constructor | Send call constructor address on chain A. |
+| `--send-call-constructor-b <string>` | deploy or reuse the EVM constructor | Send call constructor address on chain B. |
+| `--chain <string>` |  | Chain ID for the chain being deployed to. |
+| `--deployer <string>` |  | Signer alias override for deployment transactions. |
+| `--dry-run` |  | Print the step plan without submitting transactions. |
+| `--manifest-dir <string>` | `deployments` | Manifest directory relative to home. |
+| `--yes` |  | Skip confirmation prompts. |
+
+<!-- [main.go:L190](link/cmd/ibc/main.go#L190) -->
+
+<!-- GEN:cli:cmd:deploy-ift-bridge END -->
+
+```bash
+ibc deploy ift-bridge --chain-a 41001 --ift-a 0xTokenOnA --chain-b 41002 --ift-b 0xTokenOnB --yes
+```
+
+### `ibc deploy render-config`
+
+<!-- GEN:cli:cmd:deploy-render-config START -->
+
+Project two deployment manifests into config sections for relaying between them (stdout).
+
+| Flag | Default | Description |
+|---|---|---|
+| `--signer-a <string>` |  | Signers[] alias submitting relay txs on chainA. |
+| `--signer-b <string>` |  | Signers[] alias submitting relay txs on chainB. |
+| `--chain <string>` |  | Chain ID for the chain being deployed to. |
+| `--deployer <string>` |  | Signer alias override for deployment transactions. |
+| `--dry-run` |  | Print the step plan without submitting transactions. |
+| `--manifest-dir <string>` | `deployments` | Manifest directory relative to home. |
+| `--yes` |  | Skip confirmation prompts. |
+
+<!-- [main.go:L178](link/cmd/ibc/main.go#L178) -->
+
+<!-- GEN:cli:cmd:deploy-render-config END -->
+
+### `ibc deploy show`
+
+<!-- GEN:cli:cmd:deploy-show START -->
+
+Print the recorded deployment manifest for a chain.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--chain <string>` |  | Chain ID for the chain being deployed to. |
+| `--deployer <string>` |  | Signer alias override for deployment transactions. |
+| `--dry-run` |  | Print the step plan without submitting transactions. |
+| `--manifest-dir <string>` | `deployments` | Manifest directory relative to home. |
+| `--yes` |  | Skip confirmation prompts. |
+
+<!-- [main.go:L59](link/cmd/ibc/main.go#L59) -->
+
+<!-- GEN:cli:cmd:deploy-show END -->
+
+### `ibc deploy status`
+
+<!-- GEN:cli:cmd:deploy-status START -->
+
+Verify recorded deployments against live chain state.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--chain <string>` |  | Chain ID for the chain being deployed to. |
+| `--deployer <string>` |  | Signer alias override for deployment transactions. |
+| `--dry-run` |  | Print the step plan without submitting transactions. |
+| `--manifest-dir <string>` | `deployments` | Manifest directory relative to home. |
+| `--yes` |  | Skip confirmation prompts. |
+
+<!-- [main.go:L59](link/cmd/ibc/main.go#L59) -->
+
+<!-- GEN:cli:cmd:deploy-status END -->
+
+## `relayer`
+
+The relayer runs in the foreground and serves gRPC on `server.listenAddr`.
+
+### `ibc relayer relay`
+
+<!-- GEN:cli:cmd:relayer-relay START -->
+
+Trigger relaying of the packets emitted by a source transaction.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--chain-id <string>` | required | Source chain id. |
+| `--host <string>` |  | Dial this address instead of resolving from config. |
+| `--tx-hash <string>` | required | Source transaction hash. |
+
+<!-- [main.go:L99](link/cmd/ibc/main.go#L99) -->
+
+<!-- GEN:cli:cmd:relayer-relay END -->
+
+```bash
+ibc relayer relay --chain-id 41001 --tx-hash 0xSendTxHash
+```
+
+The command asks for every packet in that transaction. The relayer takes the ones it has a configured client and route for.
+
+### `ibc relayer run`
+
+<!-- GEN:cli:cmd:relayer-run START -->
+
+Run the relayer.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--no-migrate` |  | Skip database migrations. |
+
+<!-- [main.go:L98](link/cmd/ibc/main.go#L98) -->
+
+<!-- GEN:cli:cmd:relayer-run END -->
+
+One process can be both. `relayer run` serves the relayer API and also runs every attestor the config marks `local`. <!-- [bootstrap.go:L59-L79](link/internal/bootstrap/bootstrap.go#L59-L79) --> It applies pending database migrations at startup, and `--no-migrate` skips that.
+
+### `ibc relayer packets`
+
+<!-- GEN:cli:cmd:relayer-packets START -->
+
+List the packets the relayer is aware of, most recent first.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--all` |  | Follow every page and print the combined result. |
+| `--chain-id <string>` |  | Source chain id. |
+| `--cursor <string>` |  | Next_cursor from a previous response, to resume paging. |
+| `--destination-chain-id <string>` |  | Destination chain id. |
+| `--destination-client-id <string>` |  | Destination client id. |
+| `--host <string>` |  | Dial this address instead of resolving from config. |
+| `--limit <uint32>` | 100, max 1000 | Maximum packets to return. |
+| `--sequence <uint>` |  | Packet sequence number. |
+| `--source-client-id <string>` |  | Source client id. |
+| `--state <string>` |  | Relay state (not-selected, pending, rejected, relay-failed, succeeded, timed-out). |
+| `--tx-hash <string>` |  | Source transaction hash. |
+
+<!-- [main.go:L108](link/cmd/ibc/main.go#L108) -->
+
+<!-- GEN:cli:cmd:relayer-packets END -->
+
+```bash
+ibc relayer packets --chain-id 41001 --tx-hash 0xSendTxHash
+```
+
+Every filter flag is optional, and they combine. Results are paged: `--all` follows the pages and prints the combined result, and `--cursor` resumes from a previous one. [API](/ibc-cli/api) lists the states `--state` accepts.
+
+## `attestor`
+
+The attestor also runs in the foreground and serves gRPC on `server.listenAddr`. The query commands take an attestor's name as an argument rather than a flag, and `--host` dials an address directly instead of resolving that name through the config.
+
+### `ibc attestor info`
+
+<!-- GEN:cli:cmd:attestor-info START -->
+
+Query a local attestor's identity.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--host <string>` |  | Dial this address instead of resolving from config. |
+
+<!-- [main.go:L127](link/cmd/ibc/main.go#L127) -->
+
+<!-- GEN:cli:cmd:attestor-info END -->
+
+### `ibc attestor latest-height`
+
+<!-- GEN:cli:cmd:attestor-latest-height START -->
+
+Query a local attestor's latest attestable height.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--host <string>` |  | Dial this address instead of resolving from config. |
+
+<!-- [main.go:L127](link/cmd/ibc/main.go#L127) -->
+
+<!-- GEN:cli:cmd:attestor-latest-height END -->
+
+### `ibc attestor run`
+
+<!-- GEN:cli:cmd:attestor-run START -->
+
+Run the attestor.
+
+<!-- [main.go:L59](link/cmd/ibc/main.go#L59) -->
+
+<!-- GEN:cli:cmd:attestor-run END -->
+
+### `ibc attestor state-attestation`
+
+<!-- GEN:cli:cmd:attestor-state-attestation START -->
+
+Query a local attestor for a state attestation at `--height`.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--height <uint>` |  | Height to attest. |
+| `--host <string>` |  | Dial this address instead of resolving from config. |
+
+<!-- [main.go:L130](link/cmd/ibc/main.go#L130) -->
+
+<!-- GEN:cli:cmd:attestor-state-attestation END -->
+
+## `tx`
+
+These commands submit transactions to a chain.
+
+### `ibc tx ift mint`
+
+<!-- GEN:cli:cmd:tx-ift-mint START -->
+
+Mint `--amount` of the IFT token at `--ift` to `--to`. The `--from` signer must be the token's owner.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--amount <string>` | required | Amount to mint, in the token's base unit. |
+| `--to <string>` | required | Recipient address, or a configured signer alias. |
+| `--chain <string>` | required | Chain ID the IFT token is deployed on. |
+| `--from <string>` | required | Signer alias to submit the transaction with. |
+| `--ift <string>` | required | IFT token address. |
+
+<!-- [main.go:L216](link/cmd/ibc/main.go#L216) -->
+
+<!-- GEN:cli:cmd:tx-ift-mint END -->
+
+### `ibc tx ift send`
+
+<!-- GEN:cli:cmd:tx-ift-send START -->
+
+Initiate a cross-chain transfer of `--amount` of the IFT token at `--ift`, over the bridge registered for `--client-id`, to `--to` on the counterparty chain.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--amount <string>` | required | Amount to send, in the token's base unit. |
+| `--client-id <string>` | required | Client id the bridge is registered for. |
+| `--timeout <duration>` | `15m0s` | Relative send timeout. |
+| `--to <string>` | required | Receiver address on the counterparty chain, or a configured signer alias. |
+| `--chain <string>` | required | Chain ID the IFT token is deployed on. |
+| `--from <string>` | required | Signer alias to submit the transaction with. |
+| `--ift <string>` | required | IFT token address. |
+
+<!-- [main.go:L221](link/cmd/ibc/main.go#L221) -->
+
+<!-- GEN:cli:cmd:tx-ift-send END -->
+
+```bash
+ibc tx ift send --chain 41001 --ift 0xTokenOnA --client-id link-41001-41002 \
+  --to 0xReceiver --amount 500000000000000000 --from deployer
+```
+
+The send commits a packet and emits it. Relaying can then be called with `relayer relay`.
+
+## `query`
+
+These commands read chain state and submit nothing.
+
+### `ibc query ift balance`
+
+<!-- GEN:cli:cmd:query-ift-balance START -->
+
+Query an address's IFT token balance.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--address <string>` | required | Account address, or a configured signer alias. |
+| `--chain <string>` | required | Chain ID the IFT token is deployed on. |
+| `--ift <string>` | required | IFT token address. |
+
+<!-- [main.go:L141](link/cmd/ibc/main.go#L141) -->
+
+<!-- GEN:cli:cmd:query-ift-balance END -->
+
+## `migrate`
+
+These commands move the schema of the relayer's database up and down.
+
+### `ibc migrate down`
+
+<!-- GEN:cli:cmd:migrate-down START -->
+
+Migrate DB down.
+
+<!-- [main.go:L59](link/cmd/ibc/main.go#L59) -->
+
+<!-- GEN:cli:cmd:migrate-down END -->
+
+`migrate down` reverses one migration, the most recent. <!-- [store_postgres.go:L110-L114](link/internal/store/store_postgres.go#L110-L114) -->
+
+### `ibc migrate status`
+
+<!-- GEN:cli:cmd:migrate-status START -->
+
+Print migration status.
+
+<!-- [main.go:L59](link/cmd/ibc/main.go#L59) -->
+
+<!-- GEN:cli:cmd:migrate-status END -->
+
+### `ibc migrate up`
+
+<!-- GEN:cli:cmd:migrate-up START -->
+
+Migrate DB up.
+
+<!-- [main.go:L59](link/cmd/ibc/main.go#L59) -->
+
+<!-- GEN:cli:cmd:migrate-up END -->
+
+Migrations run against the `db` block, so `--db` picks a different database for one invocation.
+
+## Next steps
+
+- [Configuration](/ibc-cli/configuration) for the file these commands read.
+- [API](/ibc-cli/api) for the gRPC calls behind `relayer relay`, `relayer packets`, and the attestor queries.

--- a/docs/6-ibc-cli/8-api.md
+++ b/docs/6-ibc-cli/8-api.md
@@ -1,0 +1,457 @@
+---
+title: "API"
+description: "The two gRPC services a running relayer and attestor serve, and how to call them."
+---
+
+The IBC CLI exposes two APIs: a relayer API and an attestation API.
+
+The relayer's API has two main parts:
+
+- `Relay` takes the transaction that sent the packets.
+- `Packets` reports how far each of them got.
+
+The attestor's API serves the attestations a light client verifies. A relayer is its usual caller, gathering proofs for a packet it is delivering. An operator calls it directly to check which attestor is answering and how far behind the head it will sign.
+
+Both services listen on `server.listenAddr`, defaulting to `0.0.0.0:3000`.
+
+Connections are plaintext, HTTP/1.1 or HTTP/2 without TLS, and reflection is registered, so a client needs no TLS setup and no proto files. <!-- [server.go:L38-L43](link/internal/server/server.go#L38-L43) --> <!-- [server.go:L103-L113](link/internal/server/server.go#L103-L113) -->
+
+To list running services:
+
+```bash
+grpcurl -plaintext localhost:3000 list
+```
+
+```
+ibc.v2.relayer.RelayerApiService
+```
+
+## Relayer service
+
+`ibc.v2.relayer.RelayerApiService`. `ibc relayer relay` and `ibc relayer packets` call these two.
+
+### `Relay`
+
+<!-- GEN:api:rpc:Relay START -->
+
+Tracks the packets emitted by a source transaction and submits the transactions required to complete them.
+
+<!-- [relayer.proto:L12](proto/link/relayer.proto#L12) -->
+
+<!-- GEN:api:rpc:Relay END -->
+
+#### `RelayRequest`
+
+<!-- GEN:api:msg:RelayRequest START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `tx_hash` | `string` | The transaction that sent the packets, on the source chain. |
+| `source_chain_id` | `string` | The chain that transaction was sent on. |
+| `selection` | oneof: `all_packets` or `selected_packets` | Required and controls only this relayer instance; IBC relaying remains permissionless. |
+
+<!-- [relayer.proto:L18](proto/link/relayer.proto#L18) -->
+
+<!-- GEN:api:msg:RelayRequest END -->
+
+Field names in these tables are the schema's. The JSON encoding uses lowerCamelCase, so `tx_hash` is sent as `txHash`.
+
+`all_packets` takes every packet for which this relayer has a configured client and route. Packets without one are skipped, and the request succeeds even when that leaves nothing to relay. <!-- [relayer.proto:L30-L33](proto/link/relayer.proto#L30-L33) -->
+
+#### `SelectedPackets`
+
+<!-- GEN:api:msg:SelectedPackets START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `packets` | `PacketSelector[]` | The packets to relay. At least one. |
+
+<!-- [relayer.proto:L37](proto/link/relayer.proto#L37) -->
+
+<!-- GEN:api:msg:SelectedPackets END -->
+
+#### `PacketSelector`
+
+<!-- GEN:api:msg:PacketSelector START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `source_client_id` | `string` | The client the packet was sent on. |
+| `sequence_number` | `uint64` | The packet's number on that client. |
+
+<!-- [relayer.proto:L41](proto/link/relayer.proto#L41) -->
+
+<!-- GEN:api:msg:PacketSelector END -->
+
+A `selected_packets` request fails if any packet it names is absent or has no configured route. Naming a packet that is already selected, in flight, or finished succeeds and changes nothing. <!-- [relayer.proto:L35-L37](proto/link/relayer.proto#L35-L37) -->
+
+`Relay` answers with every send packet in the transaction, including the ones it will not carry.
+
+#### `RelayResponse`
+
+<!-- GEN:api:msg:RelayResponse START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `packets` | `ObservedPacket[]` | Every send packet in the transaction, including those this relayer will not deliver. |
+
+<!-- [relayer.proto:L46](proto/link/relayer.proto#L46) -->
+
+<!-- GEN:api:msg:RelayResponse END -->
+
+#### `ObservedPacket`
+
+<!-- GEN:api:msg:ObservedPacket START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `source_client_id` | `string` | The client the packet was sent on. |
+| `sequence_number` | `uint64` | The packet's number on that client. |
+| `selection` | `PacketSelection` | Whether this relayer took the packet. See the values below. |
+
+<!-- [relayer.proto:L52](proto/link/relayer.proto#L52) -->
+
+<!-- GEN:api:msg:ObservedPacket END -->
+
+#### `PacketSelection`
+
+<!-- GEN:api:enum:PacketSelection START -->
+
+| Value | Meaning |
+|---|---|
+| `PACKET_SELECTION_SELECTED` | Recorded for delivery by this relayer. Delivery happens afterwards and can still fail; query the packet's state to follow it. |
+| `PACKET_SELECTION_NOT_SELECTED` | Configured and routed, but this request did not select it. |
+| `PACKET_SELECTION_UNCONFIGURED` | No configured client or route, so this relayer skips it. |
+
+<!-- [relayer.proto:L58](proto/link/relayer.proto#L58) -->
+
+<!-- GEN:api:enum:PacketSelection END -->
+
+A successful call means the relayer recorded the request. `Packets` reports what happens after that.
+
+```bash
+grpcurl -plaintext -d '{"txHash":"0xSendTxHash","sourceChainId":"41001","allPackets":{}}' \
+  localhost:3000 ibc.v2.relayer.RelayerApiService/Relay
+```
+
+### `Packets`
+
+<!-- GEN:api:rpc:Packets START -->
+
+Lists the packets this relayer is aware of, most recent first.
+
+<!-- [relayer.proto:L15](proto/link/relayer.proto#L15) -->
+
+<!-- GEN:api:rpc:Packets END -->
+
+#### `PacketsRequest`
+
+<!-- GEN:api:msg:PacketsRequest START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `filter` | `PacketFilter` | Narrows the results. Every field is optional. |
+| `limit` | `uint32` | Zero applies the default of 100; values above 1000 are capped. |
+| `cursor` | `string` | Opaque next_cursor from a previous response. Empty starts at the newest packet. |
+
+<!-- [relayer.proto:L69](proto/link/relayer.proto#L69) -->
+
+<!-- GEN:api:msg:PacketsRequest END -->
+
+#### `PacketFilter`
+
+Every field is optional, and a request with none returns everything the relayer has recorded.
+
+<!-- GEN:api:msg:PacketFilter START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `source_chain_id` | `string` (optional) | Only packets sent from this chain. |
+| `destination_chain_id` | `string` (optional) | Only packets bound for this chain. |
+| `source_client_id` | `string` (optional) | Only packets sent on this client. |
+| `destination_client_id` | `string` (optional) | Only packets received on this client. |
+| `state` | `PacketState` (optional) | Only packets in this state. |
+| `source_tx_hash` | `string` (optional) | Only packets sent by this transaction. |
+| `sequence_number` | `uint64` (optional) | Only packets with this sequence number. |
+
+<!-- [relayer.proto:L78](proto/link/relayer.proto#L78) -->
+
+<!-- GEN:api:msg:PacketFilter END -->
+
+#### `PacketsResponse`
+
+<!-- GEN:api:msg:PacketsResponse START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `packets` | `PacketStatus[]` | One entry per matching packet on this page, newest first. |
+| `has_more` | `bool` | More `packets` match beyond this page. |
+| `next_cursor` | `string` | Cursor for the next page, set only when `has_more`. |
+
+<!-- [relayer.proto:L88](proto/link/relayer.proto#L88) -->
+
+<!-- GEN:api:msg:PacketsResponse END -->
+
+Results are paged. Ask again with `next_cursor` while `has_more` is set.
+
+#### `PacketStatus`
+
+<!-- GEN:api:msg:PacketStatus START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `state` | `PacketState` | Where the packet got to. See the states below. |
+| `sequence_number` | `uint64` | Together with `source_client_id`, identifies the packet. |
+| `source_client_id` | `string` | Together with `sequence_number`, identifies the packet. |
+| `send_tx` | `TransactionInfo` | The source-chain SendPacket transaction. Always present. |
+| `recv_tx` | `TransactionInfo` | The destination-chain receive transaction, once submitted or discovered. |
+| `ack_tx` | `TransactionInfo` | The source-chain acknowledgement transaction. Present for succeeded and rejected packets, and may be present while pending. |
+| `timeout_tx` | `TransactionInfo` | The source-chain timeout transaction. Present for timed-out packets, and may be present while pending. |
+
+<!-- [relayer.proto:L119](proto/link/relayer.proto#L119) -->
+
+<!-- GEN:api:msg:PacketStatus END -->
+
+#### `TransactionInfo`
+
+<!-- GEN:api:msg:TransactionInfo START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `tx_hash` | `string` | The transaction's hash. |
+| `chain_id` | `string` | The chain it was submitted to. |
+
+<!-- [relayer.proto:L114](proto/link/relayer.proto#L114) -->
+
+<!-- GEN:api:msg:TransactionInfo END -->
+
+#### `PacketState`
+
+`NOT_SELECTED` and `PENDING` are still open. The other four are final.
+
+<!-- GEN:api:enum:PacketState START -->
+
+| Value | Meaning |
+|---|---|
+| `PACKET_STATE_NOT_SELECTED` | The packet was discovered but has not been selected by this relayer instance. Another relayer may still deliver it. |
+| `PACKET_STATE_PENDING` | The relayer is still processing the packet. |
+| `PACKET_STATE_SUCCEEDED` | The packet completed with a successful acknowledgement on the source chain. |
+| `PACKET_STATE_TIMED_OUT` | The packet completed with a timeout refund on the source chain. |
+| `PACKET_STATE_REJECTED` | The packet completed with an error acknowledgement on the source chain. |
+| `PACKET_STATE_RELAY_FAILED` | A permanent error prevents the relayer from processing the packet. |
+
+<!-- [relayer.proto:L96](proto/link/relayer.proto#L96) -->
+
+<!-- GEN:api:enum:PacketState END -->
+
+`REJECTED` means the packet arrived and the application refused it, which is a completed relay and a failed application call. `RELAY_FAILED` means a permanent error stopped the relayer, wherever the packet had got to.
+
+```bash
+grpcurl -plaintext -d '{"filter":{"sourceChainId":"41001"},"limit":20}' \
+  localhost:3000 ibc.v2.relayer.RelayerApiService/Packets
+```
+
+## Attestation service
+
+`ibc.v2.attestor.AttestationService`. One process can run several attestors, so every request names one.
+
+### `Attestation`
+
+Both attestation calls return this shape.
+
+<!-- GEN:api:msg:Attestation START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `height` | `uint64` | The height of the attestation |
+| `timestamp` | `uint64` (optional) | The timestamp of the block |
+| `attested_data` | `bytes` | The attested data |
+| `signature` | `bytes` | The attestation signature |
+
+<!-- [attestor.proto:L80](proto/link/attestor.proto#L80) -->
+
+<!-- GEN:api:msg:Attestation END -->
+
+`attested_data` is what was signed. A light client accepts the attestation when its threshold of attestors or more sign the same data. <!-- [resolve.go:L37-L60](link/internal/relay/proofgen/attestation/resolve.go#L37-L60) -->
+
+### `StateAttestation`
+
+<!-- GEN:api:rpc:StateAttestation START -->
+
+Retrieves an attestation for a state at a given height.
+
+<!-- [attestor.proto:L12](proto/link/attestor.proto#L12) -->
+
+<!-- GEN:api:rpc:StateAttestation END -->
+
+#### `StateAttestationRequest`
+
+<!-- GEN:api:msg:StateAttestationRequest START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `attestor` | `string` | Which attestor to ask, by its `name` in the `attestors` block. |
+| `height` | `uint64` | The height to attest to. |
+
+<!-- [attestor.proto:L24](proto/link/attestor.proto#L24) -->
+
+<!-- GEN:api:msg:StateAttestationRequest END -->
+
+#### `StateAttestationResponse`
+
+<!-- GEN:api:msg:StateAttestationResponse START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `attestation` | `Attestation` | The signed attestation. See below. |
+
+<!-- [attestor.proto:L29](proto/link/attestor.proto#L29) -->
+
+<!-- GEN:api:msg:StateAttestationResponse END -->
+
+A height above what `LatestHeight` reports is refused, so ask for the height first. <!-- [local.go:L111-L117](link/internal/service/attestor/local.go#L111-L117) -->
+
+### `PacketAttestation`
+
+<!-- GEN:api:rpc:PacketAttestation START -->
+
+Retrieves an attestation for a set of packets.
+
+<!-- [attestor.proto:L15](proto/link/attestor.proto#L15) -->
+
+<!-- GEN:api:rpc:PacketAttestation END -->
+
+#### `PacketAttestationRequest`
+
+<!-- GEN:api:msg:PacketAttestationRequest START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `attestor` | `string` | Which attestor to ask, by its `name` in the `attestors` block. |
+| `packets` | `bytes[]` | The packets to attest to |
+| `height` | `uint64` | The height to attest to the `packets` at |
+| `commitment_type` | `CommitmentType` | The type of commitment to attest (packet or acknowledgment) Defaults to COMMITMENT_TYPE_PACKET if not specified (for backward compatibility) |
+
+<!-- [attestor.proto:L35](proto/link/attestor.proto#L35) -->
+
+<!-- GEN:api:msg:PacketAttestationRequest END -->
+
+#### `CommitmentType`
+
+`commitment_type` selects what is being proven, which differs by direction. A delivery proves a packet commitment, an acknowledgement proves an acknowledgement commitment, and a timeout proves that no receipt exists.
+
+<!-- GEN:api:enum:CommitmentType START -->
+
+| Value | Meaning |
+|---|---|
+| `COMMITMENT_TYPE_PACKET` | Packet commitment (for SendPacket events) |
+| `COMMITMENT_TYPE_ACK` | Acknowledgment commitment (for WriteAcknowledgement events) |
+| `COMMITMENT_TYPE_RECEIPT` | Receipt commitment (for Timeout events - non-membership proof) |
+
+<!-- [attestor.proto:L69](proto/link/attestor.proto#L69) -->
+
+<!-- GEN:api:enum:CommitmentType END -->
+
+#### `PacketAttestationResponse`
+
+<!-- GEN:api:msg:PacketAttestationResponse START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `attestation` | `Attestation` | The signed attestation. See below. |
+
+<!-- [attestor.proto:L51](proto/link/attestor.proto#L51) -->
+
+<!-- GEN:api:msg:PacketAttestationResponse END -->
+
+One request carries at most 100 packets, each at most 128 KB, and a request over either limit is refused. <!-- [service.go:L72-L76](link/internal/service/attestor/service.go#L72-L76) --> <!-- [service.go:L169-L180](link/internal/service/attestor/service.go#L169-L180) -->
+
+### `LatestHeight`
+
+<!-- GEN:api:rpc:LatestHeight START -->
+
+Returns the latest height the attestor will generate attestations for.
+
+<!-- [attestor.proto:L18](proto/link/attestor.proto#L18) -->
+
+<!-- GEN:api:rpc:LatestHeight END -->
+
+#### `LatestHeightRequest`
+
+<!-- GEN:api:msg:LatestHeightRequest START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `attestor` | `string` | Which attestor to ask, by its `name` in the `attestors` block. |
+
+<!-- [attestor.proto:L55](proto/link/attestor.proto#L55) -->
+
+<!-- GEN:api:msg:LatestHeightRequest END -->
+
+#### `LatestHeightResponse`
+
+<!-- GEN:api:msg:LatestHeightResponse START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `height` | `uint64` | The highest height this attestor will attest to. |
+
+<!-- [attestor.proto:L57](proto/link/attestor.proto#L57) -->
+
+<!-- GEN:api:msg:LatestHeightResponse END -->
+
+Offset zero attests up to the chain's `finalized` tag. Above zero, the attestor reads `latest` and subtracts, which sits closer to the head. <!-- [local.go:L77-L104](link/internal/service/attestor/local.go#L77-L104) -->
+
+### `Info`
+
+<!-- GEN:api:rpc:Info START -->
+
+Returns identity information about a configured attestor.
+
+<!-- [attestor.proto:L21](proto/link/attestor.proto#L21) -->
+
+<!-- GEN:api:rpc:Info END -->
+
+#### `InfoRequest`
+
+<!-- GEN:api:msg:InfoRequest START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `attestor` | `string` | Which attestor to ask, by its `name` in the `attestors` block. |
+
+<!-- [attestor.proto:L59](proto/link/attestor.proto#L59) -->
+
+<!-- GEN:api:msg:InfoRequest END -->
+
+#### `InfoResponse`
+
+<!-- GEN:api:msg:InfoResponse START -->
+
+| Field | Type | Description |
+|---|---|---|
+| `chain_id` | `string` | The chain this attestor watches. |
+| `address` | `string` | The attestor's signing address. |
+
+<!-- [attestor.proto:L61](proto/link/attestor.proto#L61) -->
+
+<!-- GEN:api:msg:InfoResponse END -->
+
+`address` is what a light client checks signatures against. So this call is how an operator confirms that the running attestor is the one an on-chain client expects.
+
+```bash
+grpcurl -plaintext -d '{"attestor":"attestor-41002"}' \
+  localhost:3000 ibc.v2.attestor.AttestationService/Info
+```
+
+```json
+{
+  "chainId": "41002",
+  "address": "0xc7f148Da846781a9a1D9d22F699A7A88c592CCee"
+}
+```
+
+## Next steps
+
+- [Configuration](/ibc-cli/configuration) for `server.listenAddr` and the `attestors` block these calls read.
+- [CLI commands](/ibc-cli/cli-commands) for the commands that make these calls.

--- a/docs/6-ibc-cli/tools/README.md
+++ b/docs/6-ibc-cli/tools/README.md
@@ -1,0 +1,79 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# docs/6-ibc-cli tooling
+
+Reference documentation for the `ibc` binary. The tables on these pages are
+generated from this repository; the prose around them is written by hand.
+
+| Page | Covers | Generated from |
+|------|--------|----------------|
+| [6-configuration.md](../6-configuration.md) | every key in `ibc.yml` | the config structs in `link/internal/config/` |
+| [7-cli-commands.md](../7-cli-commands.md) | every command and flag | the built binary's `--help` tree, plus `link/cmd/ibc/main.go` |
+| [8-api.md](../8-api.md) | both gRPC services | `proto/link/relayer.proto`, `proto/link/attestor.proto` |
+
+## Editing a page
+
+Edit it. Prose, headings, section order, examples: all normal markdown.
+
+**One rule: never edit between a `<!-- GEN:... START -->` and its `END`.**
+Those blocks are regenerated from source, so a hand edit there is reverted the
+next time anyone regenerates. It is a change that looks like a fix and is not.
+
+Then check that the markers still line up:
+
+```sh
+python3 docs/6-ibc-cli/tools/refgen.py all --check
+```
+
+## When the code changes
+
+A pull request touching `link/`, `proto/`, or `gen/` runs
+[`.github/workflows/reference-currency.yml`](../../.github/workflows/reference-currency.yml),
+which fails if a generated table no longer matches the code. It reports and
+never rewrites anything. To fix a failure:
+
+```sh
+python3 docs/6-ibc-cli/tools/refgen.py all --list-regions   # what moved
+python3 docs/6-ibc-cli/tools/refgen.py all                  # heal the tables
+```
+
+**Then read the prose around whatever moved.** Regenerating repairs the tables
+and touches no sentence next to them, so a page can be green and still wrong:
+a removed flag leaves the example that used it, a new default leaves the
+paragraph that called the key required. The region ids from `--list-regions`
+are the list of sections to re-read.
+
+## Changing what the tables contain
+
+The generator holds the choices a schema cannot make, and it fails loudly
+rather than guessing. Edit `docs/6-ibc-cli/tools/refgen.py`:
+
+| To change | Edit |
+|-----------|------|
+| which task group a command appears under | `CLI_TASKS` |
+| which commands get their own flag section | `CLI_FLAG_SECTIONS`, and add the page section with its markers |
+| which config blocks get a table | `CONFIG_BLOCKS`, and add the page section with its markers |
+| the description of a config key the Go source does not document | `FALLBACK_DOCS` |
+| where a pointer field's default comes from | `DEFAULT_CONSTS` |
+
+Any of these left half-done stops the generator, with a message naming what
+is missing. A command in no task group, a config key with no description, a
+region with no marker, a flag documented nowhere: each refuses to write.
+
+## Tests
+
+```sh
+python3 docs/6-ibc-cli/tools/test-refgen.py       # the marker engine and the extraction
+python3 docs/6-ibc-cli/tools/test-refgen-e2e.py   # mutates a copy of the source 15 ways
+```
+
+The second is the one that matters when changing the generator. It breaks the
+source on purpose, fifteen ways, and asserts that a stale page goes red and
+that each loud failure still fires. Removals are covered as well as additions.
+
+## Why generated
+
+A reference page's content already exists in the code. Anything retyped by
+hand drifts from it silently, and the drift is invisible until a reader trusts
+a wrong default. Generating the tables also repairs their line-numbered
+citations, which rot on every refactor and which no path checker can catch.

--- a/docs/6-ibc-cli/tools/refgen.py
+++ b/docs/6-ibc-cli/tools/refgen.py
@@ -1,0 +1,1618 @@
+#!/usr/bin/env python3
+"""Generate reference-page tables from source, in place, between markers.
+
+A reference page is part prose and part table. The prose is written by a human
+and the tables are derived from code, so the tables can be regenerated whenever
+the code moves and the page cannot drift from it.
+
+    python3 tools/refgen.py api    ibc-docs/ibc-cli/api.mdx
+    python3 tools/refgen.py config ibc-docs/ibc-cli/configuration.mdx
+    python3 tools/refgen.py cli    ibc-docs/ibc-cli/cli-commands.mdx
+    python3 tools/refgen.py all --check      # exit 1 if any page is stale
+
+Generated regions are delimited by comments the review-copy stripper removes:
+
+    {/* GEN:api:relayer:rpcs START */}
+    ...generated...
+    {/* GEN:api:relayer:rpcs END */}
+
+Only bytes strictly between a START and its END are ever rewritten. Text
+outside every marker is asserted byte-identical after a write, because a tool
+that edits these pages has destroyed content here twice before.
+
+Currency has two halves. This tool is the first one:
+
+    python3 tools/refgen.py all --check           # fails if a table moved
+    python3 tools/refgen.py all --list-regions    # names which ones
+    python3 tools/refgen.py all                   # heals them
+
+The second half is the prose around the tables, which regenerating does not
+touch, and which only reading can check. See the `reference-drift` skill, run
+after regenerating and triggered by check mode going red.
+
+--------------------------------------------------------------------------
+THE PAGES LIVE IN cosmos/ibc (Evan, 2026-08-21)
+--------------------------------------------------------------------------
+The reference pages are upstream's, at link/docs/, and are edited there. This
+copy of the tool runs against the pinned clone so the docs project can still
+generate and check; `tools/upstreamize.py` syncs the tool upstream and
+deliberately does not copy the pages, which would clobber them.
+
+This checklist stays for the record, and for the next surface that moves.
+
+  1. Copy `refgen.py`, `test-refgen.py`, and `test-refgen-e2e.py`.
+  2. Set IBC to the repo root. Here it points at a pinned clone in `repos/ibc`;
+     upstream it is the repo itself, so `--check` runs against the working tree
+     and a developer sees their own change.
+  3. Copy the reference pages, or point PAGES at wherever they live. PAGES is
+     the coverage contract: a region with no marker on its owning page is an
+     error, which is what stops a new key from landing in the generator and
+     never reaching a reader.
+  4. Copy the workflow. Switch its `paths` to `link/**` and `proto/**`, which
+     is the whole point of moving: the pull request that adds a flag is the
+     one that goes red. The workflow header carries that block.
+  5. Drop the clone step from the workflow. Upstream the source is already
+     checked out, and CLI generation needs only the Go toolchain.
+  6. Run `test-refgen-e2e.py` first. Ten mutations, and each one proves a
+     failure this design depends on. If they pass upstream, the move worked.
+  7. Keep check mode alone until it has been quiet for a while. A scheduled
+     regenerate-and-open-a-PR job comes after that, never straight to the
+     default branch.
+
+What does NOT travel: the hand-written prose passes and the `reference-drift`
+skill, which are docs-side. Upstream sees a red check and a diff; deciding
+what the prose should now say stays with whoever owns the pages.
+"""
+import argparse
+import difflib
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+# upstream layout: this file is docs/6-ibc-cli/tools/refgen.py, so the repo root
+# is three levels up, and the source it reads is the working tree itself
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+IBC = ROOT
+
+# Markers and citations sit in comments the reader never sees. MDX pages use
+# {/* ... */}; a plain markdown page upstream uses <!-- ... -->. Both are
+# recognised, and COMMENT emits the style this checkout writes.
+START = re.compile(r"(?:\{/\*|<!--)\s*GEN:(?P<id>[A-Za-z0-9_:.-]+)\s+START\s*(?:\*/\}|-->)")
+END = re.compile(r"(?:\{/\*|<!--)\s*GEN:(?P<id>[A-Za-z0-9_:.-]+)\s+END\s*(?:\*/\}|-->)")
+
+COMMENT = ("<!--", "-->")   # plain markdown, so GitHub hides them
+
+
+class MarkerError(Exception):
+    pass
+
+
+def find_regions(text):
+    """Return [(id, body_start, body_end, outer_start, outer_end)] in order.
+
+    Raises on unbalanced, nested, mismatched, or duplicated markers. A page
+    whose markers do not make sense is never written to.
+    """
+    events = []
+    for m in START.finditer(text):
+        events.append((m.start(), "start", m.group("id"), m))
+    for m in END.finditer(text):
+        events.append((m.start(), "end", m.group("id"), m))
+    events.sort()
+
+    regions, open_at = [], None
+    for _pos, kind, ident, m in events:
+        if kind == "start":
+            if open_at is not None:
+                raise MarkerError(f"GEN:{ident} START inside unclosed GEN:{open_at[0]}")
+            open_at = (ident, m)
+        else:
+            if open_at is None:
+                raise MarkerError(f"GEN:{ident} END with no START")
+            if open_at[0] != ident:
+                raise MarkerError(f"GEN:{open_at[0]} START closed by GEN:{ident} END")
+            s = open_at[1]
+            regions.append((ident, s.end(), m.start(), s.start(), m.end()))
+            open_at = None
+    if open_at is not None:
+        raise MarkerError(f"GEN:{open_at[0]} START never closed")
+
+    seen = set()
+    for ident, *_ in regions:
+        if ident in seen:
+            raise MarkerError(f"GEN:{ident} appears more than once")
+        seen.add(ident)
+    return regions
+
+
+def outside(text, regions):
+    """The page with every generated body blanked, for equality checks."""
+    out, last = [], 0
+    for _ident, bs, be, _os_, _oe in regions:
+        out.append(text[last:bs])
+        last = be
+    out.append(text[last:])
+    return "".join(out)
+
+
+def render(text, blocks):
+    """Replace region bodies from {id: body}. Unknown ids on the page are an
+    error; a generator that produces nothing for a marker is a bug, not a
+    no-op."""
+    regions = find_regions(text)
+    have = {i for i, *_ in regions}
+    missing = set(blocks) - have
+    if missing:
+        raise MarkerError(f"no marker on page for: {', '.join(sorted(missing))}")
+    unfilled = have - set(blocks)
+    if unfilled:
+        raise MarkerError(
+            "marker present but generator produced nothing: "
+            + ", ".join(sorted(unfilled))
+            + ". The source no longer has what that region described, so delete "
+              "the page section along with its markers, or restore the source. "
+              "Nothing is written until one of those happens.")
+
+    new = text
+    for ident, bs, be, _os_, _oe in reversed(regions):
+        new = new[:bs] + "\n\n" + blocks[ident].strip() + "\n\n" + new[be:]
+
+    # the safety property: nothing outside a generated body may change
+    if outside(new, find_regions(new)) != outside(text, regions):
+        raise MarkerError("refusing to write: text outside generated regions would change")
+    return new
+
+
+def table(headers, rows):
+    if not rows:
+        return "_None._"
+    out = ["| " + " | ".join(headers) + " |", "|" + "|".join("---" for _ in headers) + "|"]
+    for r in rows:
+        cells = [str(c).replace("|", r"\|").replace("\n", " ") for c in r]
+        out.append("| " + " | ".join(cells) + " |")
+    return "\n".join(out)
+
+
+def cite(path, start, end=None):
+    rng = f"L{start}" if end is None or end == start else f"L{start}-L{end}"
+    open_, close = COMMENT
+    return f"{open_} [{os.path.basename(path)}:{rng}]({path}#{rng}) {close}"
+
+
+# ---------------------------------------------------------------- proto -> api
+
+
+def _decl_blocks(src):
+    """Yield (kind, name, line_no, doc, body) for every top-level proto decl.
+
+    Brace-aware, so a message written on one line and a message with a body
+    are handled by the same code. The earlier line-scanning version read
+    forward past a one-line message and stole the next message's fields.
+    """
+    lines = src.split("\n")
+    doc, i = [], 0
+    decl = re.compile(r"^(service|message|enum)\s+(\w+)\s*\{")
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith("//"):
+            doc.append(stripped[2:].strip())
+            i += 1
+            continue
+        m = decl.match(stripped)
+        if not m:
+            doc, i = [], i + 1
+            continue
+        # walk characters from the opening brace until it balances
+        depth, j, body = 0, i, []
+        while j < len(lines):
+            line = lines[j]
+            start = line.index("{") + 1 if j == i else 0
+            piece, cut = [], None
+            for pos in range(start, len(line)):
+                ch = line[pos]
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    if depth == 0:
+                        cut = pos
+                        break
+                    depth -= 1
+                piece.append(ch)
+            body.append("".join(piece))
+            if cut is not None:
+                break
+            j += 1
+        yield m.group(1), m.group(2), i + 1, " ".join(doc), "\n".join(body)
+        doc, i = [], j + 1
+
+
+FIELD = re.compile(r"^(optional\s+|repeated\s+|required\s+)?([\w.]+)\s+(\w+)\s*=\s*\d+")
+RPC = re.compile(r"rpc\s+(\w+)\s*\(\s*([\w.]+)\s*\)\s*returns\s*\(\s*([\w.]+)\s*\)")
+
+
+def _statements(body):
+    """Yield (doc, statement, offset) for each `;`-terminated statement in a
+    body, carrying the comment lines that precede it and the line it sits on,
+    counted from the body's first line. Statements may share a line."""
+    doc = []
+    for offset, raw in enumerate(body.split("\n")):
+        line = raw.strip()
+        if line.startswith("//"):
+            doc.append(line[2:].strip())
+            continue
+        for part in line.split(";"):
+            part = part.strip()
+            if not part:
+                continue
+            yield " ".join(doc), part, offset
+            doc = []
+
+
+def _fields(body):
+    """Fields of a message body, in declaration order, with a oneof folded
+    into one entry."""
+    oneofs = {name: {"name": name, "type": "oneof", "doc": doc,
+                     "opts": [f.group(3) for _d, s, _o in _statements(inner)
+                              for f in [FIELD.match(s)] if f]}
+              for name, doc, inner in _decl_oneofs(body)}
+    # blank the oneof bodies, keeping line positions, so one ordered pass works
+    masked = body
+    for _n, _d, inner in _decl_oneofs(body):
+        masked = masked.replace(inner, "\n" * inner.count("\n"))
+
+    out, doc = [], []
+    for raw in masked.split("\n"):
+        line = raw.strip()
+        if line.startswith("//"):
+            doc.append(line[2:].strip())
+            continue
+        m = re.match(r"oneof\s+(\w+)\s*\{", line)
+        if m:
+            out.append(oneofs[m.group(1)])
+            doc = []
+            continue
+        for part in line.split(";"):
+            stmt = part.strip()
+            if not stmt or stmt in ("}", "{"):
+                continue
+            f = FIELD.match(stmt)
+            if not f:
+                continue
+            prefix = (f.group(1) or "").strip()
+            t = f.group(2)
+            if prefix == "repeated":
+                t = "repeated " + t
+            elif prefix == "optional":
+                t = t + ", optional"
+            out.append({"name": f.group(3), "type": t, "doc": " ".join(doc)})
+            doc = []
+    return out
+
+
+def _decl_oneofs(body):
+    """Yield (name, doc, inner_body) for each oneof in a message."""
+    lines = body.split("\n")
+    doc = []
+    for idx, raw in enumerate(lines):
+        line = raw.strip()
+        if line.startswith("//"):
+            doc.append(line[2:].strip())
+            continue
+        m = re.match(r"oneof\s+(\w+)\s*\{", line)
+        if not m:
+            doc = []
+            continue
+        rest = "\n".join(lines[idx:])
+        open_at = rest.index("{")
+        depth, end = 0, None
+        for pos in range(open_at + 1, len(rest)):
+            if rest[pos] == "{":
+                depth += 1
+            elif rest[pos] == "}":
+                if depth == 0:
+                    end = pos
+                    break
+                depth -= 1
+        yield m.group(1), " ".join(doc), rest[open_at + 1:end]
+        doc = []
+
+
+def parse_proto(path):
+    """Services, rpcs, messages, enums with their leading // comments."""
+    src = open(os.path.join(IBC, path)).read()
+    out = {"services": [], "messages": [], "enums": []}
+    for kind, name, line, doc, body in _decl_blocks(src):
+        if kind == "service":
+            rpcs = []
+            for rdoc, stmt, offset in _statements(body):
+                m = RPC.match(stmt)
+                if m:
+                    # the rpc's own line, so its citation points at itself
+                    # rather than at the service declaration above it
+                    rpcs.append({"name": m.group(1), "req": m.group(2),
+                                 "resp": m.group(3), "doc": rdoc,
+                                 "line": line + offset})
+            out["services"].append({"name": name, "doc": doc, "line": line, "rpcs": rpcs})
+        elif kind == "message":
+            out["messages"].append({"name": name, "doc": doc, "line": line,
+                                    "fields": _fields(body)})
+        else:
+            values = []
+            for vdoc, stmt, _offset in _statements(body):
+                m = re.match(r"(\w+)\s*=\s*\d+", stmt)
+                if m:
+                    values.append({"name": m.group(1), "doc": vdoc})
+            out["enums"].append({"name": name, "doc": doc, "line": line, "values": values})
+    return out
+
+def _proto_type(t):
+    """A field's type as a reader of JSON meets it.
+
+    `repeated` is protobuf's word for a list and means nothing to someone
+    writing a request body, so it renders as an array instead.
+    """
+    if t.startswith("repeated "):
+        return f"`{t[len('repeated '):]}[]`"
+    if t.endswith(", optional"):
+        return f"`{t[:-len(', optional')]}` (optional)"
+    return f"`{t}`"
+
+
+def _lead_strip(name, doc):
+    """Drop the identifier a Go or proto comment opens with.
+
+    `// Relay tracks the packets` documents the RPC named Relay, and a table
+    cell that repeats the name in its own row reads as a stutter.
+    """
+    if not doc:
+        return ""
+    camel = "".join(part.capitalize() for part in name.split("_"))
+    for lead in (name, camel):
+        if doc.startswith(lead + " "):
+            doc = doc[len(lead) + 1:]
+            break
+    doc = re.sub(r"^is\s+", "", doc)
+    return doc[0].upper() + doc[1:] if doc else ""
+
+
+def _fence(doc, names):
+    """Fence a field name used inside another field's description."""
+    for n in sorted(names, key=len, reverse=True):
+        doc = re.sub(r"(?<![`\w])" + re.escape(n) + r"(?![`\w])", f"`{n}`", doc)
+    return doc
+
+
+PROTO_DIR = "proto"
+
+
+def _proto_files():
+    """Every .proto under PROTO_DIR. Naming them would mean a new service is
+    absent from the page with nothing to notice it."""
+    out = []
+    for root, _dirs, files in os.walk(os.path.join(IBC, PROTO_DIR)):
+        for f in sorted(files):
+            if f.endswith(".proto"):
+                out.append(os.path.relpath(os.path.join(root, f), IBC))
+    return sorted(out)
+
+
+def _proto_short(path):
+    """The last segment of the file's proto package, which names its regions."""
+    m = re.search(r"^package\s+([\w.]+);", _read(path), re.M)
+    if not m:
+        raise SourceError(f"{path} declares no proto package")
+    return m.group(1).split(".")[-1]
+
+
+# The services, in the order a reader meets them, with the names the page uses.
+# The proto files sort alphabetically and the service type is RelayerApiService,
+# so both the order and the display name are a human's call. A service missing
+# from here raises, and an entry naming a service that is gone raises too.
+SERVICES = [("relayer", "Relayer service"), ("attestor", "Attestation service")]
+
+# Descriptions for fields the protos leave undocumented. Nearly all of these
+# were prose on the page already, moved into the cell they belong in. Values
+# never come from here, only wording, and the four checks that keep
+# FALLBACK_DOCS honest apply here too: an entry for a field that is gone
+# raises, a field that gains a proto comment raises, and a fingerprint over the
+# field's type raises when the shape changes under a stable name.
+FIELD_DOCS = {
+    ("RelayRequest", "tx_hash"): ("The transaction that sent the packets, on the source chain.", "e86e1cfa"),
+    ("RelayRequest", "source_chain_id"): ("The chain that transaction was sent on.", "47d6b1f4"),
+    ("SelectedPackets", "packets"): ("The packets to relay. At least one.", "d196665f"),
+    ("PacketSelector", "source_client_id"): ("The client the packet was sent on.", "947d8614"),
+    ("PacketSelector", "sequence_number"): ("The packet's number on that client.", "71c4fc7e"),
+    ("ObservedPacket", "source_client_id"): ("The client the packet was sent on.", "947d8614"),
+    ("ObservedPacket", "sequence_number"): ("The packet's number on that client.", "71c4fc7e"),
+    ("ObservedPacket", "selection"): ("Whether this relayer took the packet. See the values below.", "8fb64d4f"),
+    ("PacketsRequest", "filter"): ("Narrows the results. Every field is optional.", "a4b73c55"),
+    ("PacketFilter", "source_chain_id"): ("Only packets sent from this chain.", "c649a782"),
+    ("PacketFilter", "destination_chain_id"): ("Only packets bound for this chain.", "8fed4c25"),
+    ("PacketFilter", "source_client_id"): ("Only packets sent on this client.", "e2f36fe9"),
+    ("PacketFilter", "destination_client_id"): ("Only packets received on this client.", "63078f21"),
+    ("PacketFilter", "state"): ("Only packets in this state.", "feb79267"),
+    ("PacketFilter", "source_tx_hash"): ("Only packets sent by this transaction.", "224d8872"),
+    ("PacketFilter", "sequence_number"): ("Only packets with this sequence number.", "25882ec9"),
+    ("PacketsResponse", "packets"): ("One entry per matching packet on this page, newest first.", "039ea081"),
+    ("PacketStatus", "state"): ("Where the packet got to. See the states below.", "5c7b7988"),
+    ("TransactionInfo", "tx_hash"): ("The transaction's hash.", "e86e1cfa"),
+    ("TransactionInfo", "chain_id"): ("The chain it was submitted to.", "8140443d"),
+    ("StateAttestationRequest", "attestor"): ("Which attestor to ask, by its `name` in the `attestors` block.", "5d870b5f"),
+    ("StateAttestationRequest", "height"): ("The height to attest to.", "f4439355"),
+    ("StateAttestationResponse", "attestation"): ("The signed attestation. See below.", "b9fffb17"),
+    ("PacketAttestationRequest", "attestor"): ("Which attestor to ask, by its `name` in the `attestors` block.", "5d870b5f"),
+    ("PacketAttestationResponse", "attestation"): ("The signed attestation. See below.", "b9fffb17"),
+    ("LatestHeightRequest", "attestor"): ("Which attestor to ask, by its `name` in the `attestors` block.", "5d870b5f"),
+    ("LatestHeightResponse", "height"): ("The highest height this attestor will attest to.", "f4439355"),
+    ("InfoRequest", "attestor"): ("Which attestor to ask, by its `name` in the `attestors` block.", "5d870b5f"),
+}
+
+
+def _field_fingerprint(msg, field):
+    """Hash what a hand-written field description depends on: the field's type
+    and its name. Blind to formatting and to the rest of the message."""
+    return hashlib.sha1(f"{field['type']}|{field['name']}".encode()).hexdigest()[:8]
+
+
+def _field_doc(msg, field, seen):
+    """The Description cell, with the same four checks the config page uses."""
+    doc = _lead_strip(field["name"], field["doc"])
+    entry = FIELD_DOCS.get((msg, field["name"]))
+    where = f"{msg}.{field['name']}"
+    if doc and entry:
+        _problem("stale_field_doc",
+                 f"{where} now has a proto comment; drop its FIELD_DOCS entry", field=where)
+        return doc
+    if not entry:
+        return doc
+    text, recorded = entry
+    seen.add((msg, field["name"]))
+    current = _field_fingerprint(msg, field)
+    if recorded and current != recorded:
+        _problem("field_fingerprint_mismatch",
+                 f"{where}: the field changed shape (fingerprint {recorded} -> {current}). "
+                 f"Re-read \"{text}\" against the proto, then record the new fingerprint.",
+                 field=where, description=text, was=recorded, now=current)
+    return text
+
+
+def gen_api():
+    blocks, seen_docs, by_short = {}, set(), {}
+    for fname in _proto_files():
+        by_short[_proto_short(fname)] = (fname, parse_proto(fname))
+
+    missing = [s for s, _n in SERVICES if s not in by_short]
+    if missing:
+        _problem("missing_service",
+                 f"SERVICES names proto packages that are gone: {missing}", services=missing)
+    unlisted = sorted(set(by_short) - {s for s, _n in SERVICES})
+    if unlisted:
+        _problem("unlisted_service",
+                 "these proto packages have no section on the page: " + ", ".join(unlisted),
+                 services=unlisted)
+
+    for short, _display in SERVICES:
+        if short not in by_short:
+            continue
+        fname, p = by_short[short]
+        for svc in p["services"]:
+            for r in svc["rpcs"]:
+                # one region per RPC, so an RPC that reuses existing messages
+                # still needs a section and cannot arrive unnoticed
+                blocks[f"api:rpc:{r['name']}"] = (
+                    _lead_strip(r["name"], r["doc"]) + "\n\n" + cite(fname, r["line"]))
+        for msg in p["messages"]:
+            if not msg["fields"]:
+                continue
+            rows, names = [], {f["name"] for f in msg["fields"]}
+            for f in msg["fields"]:
+                t = (f"oneof: {' or '.join('`'+o+'`' for o in f['opts'])}"
+                     if f["type"] == "oneof" else _proto_type(f["type"]))
+                doc = _fence(_field_doc(msg["name"], f, seen_docs), names - {f["name"]})
+                rows.append((f"`{f['name']}`", t, doc))
+            blocks[f"api:msg:{msg['name']}"] = (
+                table(["Field", "Type", "Description"], rows)
+                + "\n\n" + cite(fname, msg["line"]))
+        for en in p["enums"]:
+            rows = [(f"`{v['name']}`", v["doc"]) for v in en["values"]
+                    if not v["name"].endswith("UNSPECIFIED")]
+            blocks[f"api:enum:{en['name']}"] = (
+                table(["Value", "Meaning"], rows) + "\n\n" + cite(fname, en["line"]))
+
+    orphans = sorted(f"{m}.{f}" for m, f in set(FIELD_DOCS) - seen_docs)
+    if orphans:
+        _problem("dead_field_doc",
+                 "FIELD_DOCS describes fields that are gone: " + ", ".join(orphans),
+                 fields=orphans)
+    return blocks
+
+
+# ------------------------------------------------------------- go -> config
+
+# The config package, read whole. Naming files here would mean a new file with
+# a new block is silently absent from the page, which is the failure this whole
+# tool exists to prevent.
+CONFIG_PKG = "link/internal/config"
+
+# The one anchor. Every block on the page is a struct reachable from this type,
+# so the page's shape follows the code's rather than a list kept by hand.
+CONFIG_ROOT = "Config"
+
+# Where a pointer field's default lives when the struct itself carries no
+# value: a named constant in the code that consumes the field. The label in
+# each entry is prose; the value is always read from source, and a missing
+# constant is an error rather than a stale number.
+DEFAULT_CONSTS = {
+    ("RelayerConfig", "DispatchPollInterval"): [
+        ("", "link/internal/relay/dispatch/dispatcher.go", "DefaultPollInterval")],
+    ("RelayerChainOverride", "TxSubmissionDelay"): [
+        ("", "link/internal/txsubmitter/evm/evm.go", "DefaultTxSubmissionDelay")],
+    ("RelayerChainOverride", "PacketBatchSize"): [
+        ("", "link/internal/relay/pipeline/opts.go", "DefaultBatchSize")],
+    ("RelayerChainOverride", "PacketBatchTimeout"): [
+        ("receive and acknowledge", "link/internal/relay/pipeline/opts.go", "DefaultBatchTimeout"),
+        ("timeout", "link/internal/relay/pipeline/opts.go", "DefaultTimeoutBatchTimeout")],
+}
+
+# Keys the Go source does not document. Values never come from here, only
+# wording: every default, type, and required-ness is read from source on every
+# run. Each entry is (description, fingerprint), where the fingerprint covers
+# the field's type, its yaml key, and every validation rule naming it.
+#
+# Four ways this map is stopped from going stale, each with a mutation test:
+#   * a key with no comment and no entry here raises
+#   * a key that gains a doc comment upstream raises, so an entry cannot
+#     outlive the gap it fills
+#   * an entry matching no field raises, so a removed key cannot leave a
+#     dead description behind
+#   * a fingerprint mismatch raises, so a key whose type or validation rules
+#     changed under a stable name forces someone to re-read the sentence
+#
+# The real fix is upstream doc comments. Every one added shrinks this map, and
+# the second rule above turns that into a guided migration rather than a sweep.
+FALLBACK_DOCS = {
+    ("ServerConfig", "ListenAddress"): ("Address the gRPC server binds. It serves the relayer and attestor APIs together.", "a05468ed"),
+    ("DBConfig", "Type"): ("Database backend.", "70e2ad2c"),
+    ("DBConfig", "URL"): ("File path for sqlite, connection string for postgres. `:memory:` is rejected.", "d084b0d4"),
+    ("ChainConfig", "ChainID"): ("The chain's id, as the chain reports it.", "69a3e543"),
+    ("EVMChainConfig", "RPC"): ("JSON-RPC endpoint for the chain.", "cf552b01"),
+    ("EVMChainConfig", "ICS26Router"): ("Address of the ICS26 router on the chain.", "1daaecba"),
+    ("AttestorConfig", "Type"): ("Whether this process runs the attestor or queries it.", "a58f9a4e"),
+    ("SignerConfig", "Type"): ("Whether the key is a file on disk or a key held by a remote signer.", "febf1ab4"),
+    ("RelayerConfig", "DispatchPollInterval"): ("How often the dispatcher polls the store for unfinished packets.", "893f79b1"),
+    ("RelayerChainOverride", "ChainID"): ("The chain these settings apply to.", "69a3e543"),
+    ("RelayerChainOverride", "TxSubmissionDelay"): ("Minimum delay between two transaction submissions on the chain.", "5691fa23"),
+    ("RelayerChainOverride", "PacketBatchSize"): ("How many packets the relayer puts in one transaction.", "b4f4f14c"),
+    ("RelayerChainOverride", "PacketBatchTimeout"): ("How long the relayer waits to fill a batch before submitting it.", "84d8816e"),
+    ("RelayerEVMConfig", "GasFeeCapMultiplier"): ("Multiplies the fee cap the node suggests.", "b9de0a8d"),
+    ("RelayerEVMConfig", "GasTipCapMultiplier"): ("Multiplies the tip cap the node suggests.", "634e0708"),
+    ("ConnectionConfig", "Alias"): ("Name for the connection, unique in the file.", "7e352d14"),
+    ("AutoRelayConfig", "Enabled"): ("Whether the relayer carries packets leaving this end without being asked.", "d693129e"),
+    ("ClientEnd", "ChainID"): ("The chain this end's client lives on.", "69a3e543"),
+    ("ClientEnd", "Signer"): ("`signers` alias that submits relay transactions on this chain.", "00fd3d36"),
+    ("ClientEnd", "ClientID"): ("The light client's id on this chain.", "bb596da7"),
+    ("ClientEnd", "Type"): ("Light client type.", "85b1564f"),
+}
+
+# Nothing is skipped. autoRelay was excluded while it parsed and had no
+# consumer; it is consumed at ccc3449 (watcher/set.go, and deploy
+# render-config writes it), so FLAG-17 is closed and the block is documented.
+SKIP_FIELDS = set()
+
+# Pointer fields whose default is not a named constant anywhere: unset means
+# unset, and the prose says what that implies. Listed so that a new pointer
+# field cannot quietly read as "optional" when a default exists for it.
+NO_NAMED_DEFAULT = {
+    # nil and false are the same input: a connection end without it is not
+    # auto-relayed (relayer.go:L127)
+    ("AutoRelayConfig", "Enabled"),
+    ("RelayerEVMConfig", "GasFeeCapMultiplier"),
+    ("RelayerEVMConfig", "GasTipCapMultiplier"),
+}
+
+GO_TYPES = {"string": "string", "uint": "uint", "uint64": "uint64", "int": "int",
+            "bool": "bool", "float64": "float64", "time.Duration": "duration"}
+
+
+class SourceError(Exception):
+    pass
+
+
+# When PLAN is a list, a problem is recorded and generation continues with a
+# placeholder, so one run reports every gap rather than the first. When it is
+# None, the same problem raises and nothing is written. Check mode and a normal
+# regeneration always run with PLAN None: refusing to write stays the default.
+PLAN = None
+
+
+def _problem(kind, message, **fields):
+    """Raise, or record and continue in plan mode."""
+    if PLAN is None:
+        raise SourceError(message)
+    PLAN.append(dict(kind=kind, message=message, **fields))
+
+
+def _read(path):
+    return open(os.path.join(IBC, path)).read()
+
+
+def _config_files():
+    """Every non-test Go file in the config package, sorted for stable output."""
+    d = os.path.join(IBC, CONFIG_PKG)
+    return [f"{CONFIG_PKG}/{f}" for f in sorted(os.listdir(d))
+            if f.endswith(".go") and not f.endswith("_test.go")]
+
+
+def parse_go_config():
+    """Structs, string constants, literal defaults, and validation rules from
+    the config package."""
+    structs, aliases, consts, const_type, defaults, validations = {}, {}, {}, {}, {}, {}
+    files = _config_files()
+    src = "\n".join(_read(f) for f in files)
+
+    for m in re.finditer(r"type\s+(\w+)\s+\[\](\w+)", src):
+        aliases[m.group(1)] = m.group(2)
+
+    for m in re.finditer(r'(\w+)\s+(\w+)?\s*=\s*"([^"]*)"', src):
+        consts[m.group(1)] = m.group(3)
+        if m.group(2):
+            const_type[m.group(1)] = m.group(2)
+
+    for path in files:
+        lines = _read(path).split("\n")
+        i = 0
+        while i < len(lines):
+            m = re.match(r"type\s+(\w+)\s+struct\s*\{", lines[i])
+            if not m:
+                i += 1
+                continue
+            name, fields, doc = m.group(1), [], []
+            j = i + 1
+            while j < len(lines) and not lines[j].startswith("}"):
+                ln = lines[j].strip()
+                if ln.startswith("//"):
+                    doc.append(ln[2:].strip())
+                elif ln:
+                    f = re.match(r"(\w+)\s+([^\s`]+)(?:\s+`([^`]*)`)?", ln)
+                    if f:
+                        tag = re.search(r'yaml:"([^",]+)', f.group(3) or "")
+                        fields.append({"go": f.group(1), "type": f.group(2),
+                                       "yaml": tag.group(1) if tag else f.group(1),
+                                       "doc": " ".join(doc), "line": j + 1})
+                    doc = []
+                else:
+                    doc = []
+                j += 1
+            structs[name] = {"fields": fields, "line": i + 1, "file": path}
+            i = j + 1
+
+    # literal defaults from DefaultConfig()
+    body = src[src.index("func DefaultConfig()"):]
+    body = body[:body.index("\n}\n")]
+    current = None
+    for ln in body.split("\n"):
+        s = ln.strip()
+        m = re.match(r"\w+:\s*(\w+)\{$", s)
+        if m:
+            current = m.group(1)
+            continue
+        if s.startswith("}"):
+            current = None
+            continue
+        m = re.match(r'(\w+):\s*(?:"([^"]*)"|(\w+)),$', s)
+        if m and current:
+            value = m.group(2) if m.group(2) is not None else consts.get(m.group(3), m.group(3))
+            defaults[(current, m.group(1))] = value
+
+    # validation rules: every error string a struct's Validate can return
+    for m in re.finditer(r"func \(c (\w+)\) Validate\(\) error \{", src):
+        recv = m.group(1)
+        tail = src[m.end():]
+        tail = tail[:tail.index("\n}\n")]
+        msgs = []
+        for e in re.finditer(r'errors\.(?:New|Errorf)\("(\.[^"]+)"((?:,\s*\w+)*)', tail):
+            msgs.append((e.group(1), [a.strip() for a in e.group(2).split(",") if a.strip()]))
+        validations[recv] = msgs
+
+    return {"structs": structs, "aliases": aliases, "consts": consts,
+            "const_type": const_type, "defaults": defaults, "validations": validations}
+
+
+def _const_value(path, name):
+    """Read a named Go constant's value out of the file that declares it."""
+    src = _read(path)
+    m = re.search(r"\b" + name + r"\s*=\s*([^\n]+)", src)
+    if not m:
+        raise SourceError(f"constant {name} not found in {path}")
+    raw = m.group(1).strip().rstrip(",")
+    line = src[:m.start()].count("\n") + 1
+    d = re.match(r"(\d+)\s*\*\s*time\.(Second|Minute|Hour)", raw)
+    if d:
+        return f"{d.group(1)}{d.group(2)[0].lower()}", line
+    d = re.match(r"time\.(Second|Minute|Hour)$", raw)
+    if d:
+        return f"1{d.group(1)[0].lower()}", line
+    return raw, line
+
+
+def _element_type(go_type, model):
+    """The struct a field leads to, or None. Strips pointers, slices, and the
+    named list aliases the config package uses (`Attestors` is []AttestorConfig)."""
+    t = go_type.lstrip("*").removeprefix("[]").lstrip("*")
+    t = model["aliases"].get(t, t)
+    return t if t in model["structs"] else None
+
+
+def _is_list(go_type, model):
+    t = go_type.lstrip("*")
+    return t.startswith("[]") or model["aliases"].get(t, "").startswith("") and t in model["aliases"]
+
+
+def _discriminator(struct, model):
+    """The field whose value decides which other keys apply, and its values.
+
+    A block like `attestors` holds two shapes behind one struct, and a reader
+    of the local shape should never meet a remote-only key. Detected rather
+    than declared: a field with two or more known values is one.
+    """
+    for field in model["structs"][struct]["fields"]:
+        values = sorted(v for c, v in model["consts"].items()
+                        if model["const_type"].get(c) == field["type"].lstrip("*"))
+        if len(values) < 2:
+            for msg, args in model["validations"].get(struct, []):
+                if msg.lstrip(".").split()[0] == field["yaml"] and "must be one of" in msg:
+                    values = sorted(model["consts"][a] for a in args if a in model["consts"])
+        if len(values) >= 2:
+            return field, values
+    return None, []
+
+
+def _applies(struct, field, model, value):
+    """Whether a key belongs in the table for one discriminator value."""
+    key = field["yaml"]
+    for msg, _a in model["validations"].get(struct, []):
+        body = msg.lstrip(".")
+        if not body.startswith(key + " "):
+            continue
+        rest = body[len(key):].strip()
+        m = re.match(r"required for (?:type: )?(\w+)", rest)
+        if m and m.group(1) != value:
+            return False
+        if rest.startswith("must not be set for") and rest.split()[-2] == value:
+            return False
+    return True
+
+
+def discover_config_sections(model):
+    """Every table the page needs, by three rules and no list.
+
+    One table per top-level block. A nested struct flattens into its parent
+    with a dotted key; a list of structs gets its own table. A block with a
+    discriminator splits into one table per value of it.
+    """
+    if CONFIG_ROOT not in model["structs"]:
+        raise SourceError(f"the config package has no {CONFIG_ROOT} struct to start from")
+    out = []
+
+    def walk(region, struct, parent, prefix=""):
+        rows, nested, siblings = [], [], {}
+        for field in model["structs"][struct]["fields"]:
+            if (struct, field["go"]) in SKIP_FIELDS:
+                continue
+            child = _element_type(field["type"], model)
+            if child and field["type"].lstrip("*").startswith(("[]",)) or (
+                    child and model["aliases"].get(field["type"].lstrip("*"))):
+                nested.append((f"{region}:{field['yaml']}", child,
+                               (struct, field["yaml"]), f"{field['yaml']}[]."))
+            elif child:
+                siblings.setdefault(child, []).append(field["yaml"])
+            else:
+                rows.append((struct, field, f"{prefix}{field['yaml']}", parent))
+        # clientA and clientB are the same shape, so they are one set of rows
+        for child, names in siblings.items():
+            rows.extend(walk_rows(child, [f"{prefix}{n}." for n in names],
+                                  (struct, names[0])))
+
+        field, values = _discriminator(struct, model)
+        if values:
+            per_value = {v: [r for r in rows if _applies(r[0], r[1], model, v)]
+                         for v in values}
+            # a two-valued key that gates nothing is not a discriminator: db.type
+            # picks a backend, it does not change which keys exist
+            if len({tuple(k for _s, _f, k, _p in rs) for rs in per_value.values()}) == 1:
+                values = []
+        if values:
+            for value in values:
+                out.append({"region": f"{region}:{value}", "struct": struct,
+                            "parent": parent, "rows": per_value[value],
+                            "discriminator": (field, value)})
+        else:
+            out.append({"region": region, "struct": struct, "parent": parent,
+                        "rows": rows, "discriminator": None})
+        for args in nested:
+            walk(*args)
+
+    def walk_rows(struct, prefixes, parent=None):
+        """Rows for a flattened struct. Several prefixes mean several fields
+        share this shape, and one row names them all."""
+        if isinstance(prefixes, str):
+            prefixes = [prefixes]
+        rows = []
+        for field in model["structs"][struct]["fields"]:
+            if (struct, field["go"]) in SKIP_FIELDS:
+                continue
+            child = _element_type(field["type"], model)
+            if child and not model["aliases"].get(field["type"].lstrip("*")) \
+                    and not field["type"].lstrip("*").startswith("[]"):
+                rows.extend(walk_rows(child, [f"{p}{field['yaml']}." for p in prefixes],
+                                      (struct, field["yaml"])))
+            else:
+                rows.append((struct, field,
+                             ", ".join(f"{p}{field['yaml']}" for p in prefixes), parent))
+        return rows
+
+    for field in model["structs"][CONFIG_ROOT]["fields"]:
+        child = _element_type(field["type"], model)
+        if not child:
+            raise SourceError(f"top-level key {field['yaml']} is not a block; "
+                              "the page has no shape for a scalar there")
+        walk(f"config:{field['yaml']}", child, (CONFIG_ROOT, field["yaml"]))
+    return out
+
+
+def _fingerprint(struct, field, model):
+    """Hash the source a hand-written description depends on.
+
+    A description is only as good as the code it describes, and a key whose
+    meaning changes under a stable name moves no table cell, so nothing else
+    here would notice. This covers the field's type, its yaml key, and every
+    validation rule naming it: enough to catch a real change, and blind to
+    whitespace and to code elsewhere in the struct.
+    """
+    rules = sorted(msg for msg, _a in model["validations"].get(struct, [])
+                   if msg.lstrip(".").split()[0].split("[")[0] == field["yaml"])
+    basis = "|".join([field["type"], field["yaml"], *rules])
+    return hashlib.sha1(basis.encode()).hexdigest()[:8]
+
+
+def _clean_doc(field):
+    """A Go field comment, read as a sentence about the key.
+
+    Go comments open with the field's own name and often restate the
+    required-ness that already has its own column, so both come off.
+    """
+    doc = field["doc"]
+    if not doc:
+        return ""
+    if doc.startswith(field["go"]):
+        doc = doc[len(field["go"]):].strip()
+    doc = re.sub(r"^is\s+", "", doc)
+    doc = re.sub(r"^(required|optional)[^.]*?(?:--|—)\s*", "", doc)
+    doc = re.sub(r"^required for [^.]*\.\s*", "", doc)
+    doc = re.sub(r"^(local|remote) only\.\s*", "", doc)
+    doc = re.sub(r'"([^"]+)"', r"`\1`", doc)
+    if re.fullmatch(r"\[.*\]", doc):
+        return ""
+    if not doc:
+        return ""
+    doc = doc[0].upper() + doc[1:]
+    if not doc.endswith("."):
+        doc += "."
+    return doc
+
+
+def _type_cell(go, field, model):
+    """The Type column: a Go type, or the values a constrained key accepts."""
+    t = field["type"].lstrip("*")
+    named = model["const_type"]
+    values = [v for c, v in model["consts"].items() if named.get(c) == t]
+    if values:
+        return " | ".join(f"`{v}`" for v in sorted(values))
+    for msg, args in model["validations"].get(go, []):
+        if msg.lstrip(".").split()[0] == field["yaml"] and "must be one of" in msg:
+            resolved = [model["consts"][a] for a in args if a in model["consts"]]
+            if resolved:
+                return " | ".join(f"`{v}`" for v in resolved)
+    if t in GO_TYPES:
+        return f"`{GO_TYPES[t]}`"
+    if t.startswith("[]"):
+        return "list"
+    if t in model["structs"] or t in model["aliases"]:
+        return "block"
+    return f"`{t}`"
+
+
+def _requirement(go, field, model, parent=None):
+    """The Default-or-required column.
+
+    A key with a default is never the reader's to supply, so a default wins
+    over a validation rule. Required-ness itself is read out of the Validate
+    methods, which is where this codebase keeps it.
+    """
+    key = field["yaml"]
+    if (go, field["go"]) in model["defaults"]:
+        return f"`{model['defaults'][(go, field['go'])]}`", None
+    if (go, field["go"]) in DEFAULT_CONSTS:
+        parts, cites = [], []
+        for label, path, const in DEFAULT_CONSTS[(go, field["go"])]:
+            value, line = _const_value(path, const)
+            parts.append(f"`{value}` ({label})" if label else f"`{value}`")
+            cites.append((path, line))
+        return ", ".join(parts), cites
+
+    sources = [(go, key)]
+    if parent:
+        sources.append((parent[0], f"{parent[1]}.{key}"))
+    rules = []
+    for owner, path in sources:
+        for msg, _args in model["validations"].get(owner, []):
+            body = msg.lstrip(".")
+            if body.startswith(path + " ") or body == path:
+                rules.append(body[len(path):].strip())
+
+    # a `required for X` rule outranks a `must not be set for Y` rule: both say
+    # the key belongs to one kind, and only the first says it is mandatory
+    for rest in rules:
+        m = re.match(r"required(?: for (?:type: )?(\w+))?", rest)
+        if m:
+            return ("**required**" if not m.group(1) else f"**required** for `{m.group(1)}`"), None
+    for rest in rules:
+        if rest.startswith("must not be set for"):
+            return f"`{_other_kind(go, rest.split()[-2], model)}` only", None
+        if ("unknown" in rest and "type" in rest) or "must be one of" in rest:
+            return "**required**", None
+
+    # a nested struct whose own Validate requires something is itself required
+    nested = field["type"].lstrip("*")
+    for msg, _a in model["validations"].get(nested, []):
+        if " required" in msg or msg.endswith("required"):
+            return "**required**", None
+    return "optional", None
+
+
+def _other_kind(go, kind, model):
+    """The other value of the struct's discriminator field.
+
+    A `must not be set for local` rule means the key belongs to a remote
+    entry, so the column has to name the opposite of what the rule says.
+    """
+    for field in model["structs"][go]["fields"]:
+        values = sorted(v for c, v in model["consts"].items()
+                        if model["const_type"].get(c) == field["type"].lstrip("*"))
+        if kind in values and len(values) == 2:
+            return [v for v in values if v != kind][0]
+    raise SourceError(f"{go}: cannot tell what the opposite of {kind!r} is")
+
+
+def _description(struct, field, model, seen):
+    """The Description cell, and the four checks that keep it honest.
+
+    A key documented in the source uses that; a key the source leaves
+    undocumented uses FALLBACK_DOCS, whose entry carries a fingerprint of the
+    code it describes. Both, neither, or a fingerprint that no longer matches
+    all raise, because each of those is a description nobody has re-read.
+    """
+    doc = _clean_doc(field)
+    fallback = FALLBACK_DOCS.get((struct, field["go"]))
+    where = f"{struct}.{field['go']}"
+    if doc and fallback:
+        _problem("stale_fallback",
+                 f"{where} now has a doc comment; drop its FALLBACK_DOCS entry",
+                 field=where)
+        return doc
+    if not doc and not fallback:
+        _problem("missing_description",
+                 f"{where} has no doc comment and no FALLBACK_DOCS entry",
+                 field=where, yaml_key=field["yaml"],
+                 fingerprint=_fingerprint(struct, field, model))
+        return "TODO: describe this key"
+    if not fallback:
+        return doc
+    text, recorded = fallback
+    seen.add((struct, field["go"]))
+    current = _fingerprint(struct, field, model)
+    if current != recorded:
+        _problem("fingerprint_mismatch",
+                 f"{where}: the source behind its hand-written description changed "
+                 f"(fingerprint {recorded} -> {current}). Re-read \"{text}\" against the "
+                 "code, then record the new fingerprint. Nothing is written until you do.",
+                 field=where, description=text, was=recorded, now=current)
+    return text
+
+
+def _root_table(model, seen):
+    """The index of top-level blocks: what each is and which processes read it.
+
+    Type and default mean nothing for a key whose value is a whole block, so
+    this table carries the two things a reader wants instead.
+    """
+    fields = model["structs"][CONFIG_ROOT]["fields"]
+    keys = [f["yaml"] for f in fields]
+    missing = [k for k in keys if k not in READ_BY]
+    read_by = dict(READ_BY)   # never mutate the module's copy: plan mode runs
+    if missing:                # in the same process as everything else
+        _problem("missing_read_by",
+                 "READ_BY has no entry for the top-level block(s): " + ", ".join(missing),
+                 blocks=missing)
+        for k in missing:
+            read_by[k] = "TODO: which processes read this"
+    gone = [k for k in READ_BY if k not in keys]
+    if gone:
+        _problem("dead_read_by",
+                 "READ_BY names top-level blocks that are gone: " + ", ".join(gone),
+                 blocks=gone)
+    rows = [(f"`{f['yaml']}`", read_by[f["yaml"]], _description(CONFIG_ROOT, f, model, seen))
+            for f in fields]
+    info = model["structs"][CONFIG_ROOT]
+    return (table(["Block", "Read by", "Purpose"], rows)
+            + "\n\n" + cite(info["file"], info["line"]))
+
+
+def gen_config():
+    model = parse_go_config()
+    blocks, seen_fallbacks = {}, set()
+    for sec in discover_config_sections(model):
+        rows, cites = [], []
+        for struct, field, key, parent in sec["rows"]:
+            description = _description(struct, field, model, seen_fallbacks)
+            if sec["discriminator"] and field is sec["discriminator"][0]:
+                # the key that names this table: its value is the heading
+                rows.append((f"`{key}`", f"`{sec['discriminator'][1]}`",
+                             "**required**", description))
+                continue
+            req, extra = _requirement(struct, field, model, parent)
+            if extra:
+                cites.extend(extra)
+            if sec["discriminator"]:
+                # this table is already about one kind, so the condition that
+                # named that kind says nothing a reader here needs
+                value = sec["discriminator"][1]
+                req = {f"**required** for `{value}`": "**required**",
+                       f"`{value}` only": "optional"}.get(req, req)
+            rows.append((f"`{key}`", _type_cell(struct, field, model), req, description))
+        body = table(["Key", "Type", "Default or required", "Description"], rows)
+        info = model["structs"][sec["struct"]]
+        body += "\n\n" + cite(info["file"], info["line"])
+        for path, line in dict.fromkeys(cites):
+            body += " " + cite(path, line)
+        blocks[sec["region"]] = body
+
+    reachable = {(st, f["go"]) for sec in discover_config_sections(model)
+                 for st, f, _k, _p in sec["rows"]}
+    orphans = sorted(f"{s}.{f}" for s, f in set(FALLBACK_DOCS) - seen_fallbacks)
+    if orphans:
+        _problem("dead_description",
+                 "FALLBACK_DOCS describes fields that are gone: " + ", ".join(orphans),
+                 fields=orphans)
+    dead_defaults = sorted(f"{s}.{f}" for s, f in set(DEFAULT_CONSTS) - reachable)
+    if dead_defaults:
+        _problem("dead_default",
+                 "DEFAULT_CONSTS names fields that are gone: " + ", ".join(dead_defaults),
+                 fields=dead_defaults)
+    unclaimed = sorted(
+        f"{st}.{f['go']}" for sec in discover_config_sections(model)
+        for st, f, _k, _p in sec["rows"]
+        if f["type"].startswith("*") and not _element_type(f["type"], model)
+        and (st, f["go"]) not in DEFAULT_CONSTS
+        and (st, f["go"]) not in NO_NAMED_DEFAULT
+        and (st, f["go"]) not in SKIP_FIELDS)
+    if unclaimed:
+        _problem("unclaimed_default",
+                 "these pointer fields have no default mapped and are not listed in "
+                 "NO_NAMED_DEFAULT, so the page would call them optional without "
+                 "saying what unset means: " + ", ".join(unclaimed),
+                 fields=unclaimed)
+    return blocks
+
+
+# ----------------------------------------------------------------- cli -> page
+
+CLI_DIR = "link"
+CLI_SRC = "link/cmd/ibc"
+
+# The root command's own flags are declared here rather than in main.go.
+GLOBAL_FLAGS_FILE = "link/internal/config/flags.go"
+CLI_BIN = "link/bin/ibc"
+
+# Cobra generates these and nobody reads a page about them. Excluded here so
+# the coverage assertion below still accounts for every other command.
+CLI_EXCLUDED = {"completion", "help"}
+
+# Sections follow the command tree, so nothing is scattered and a reader's
+# muscle memory transfers to `ibc <group> --help`. Membership is discovered;
+# only the order is a human's call, and it is the order a reader meets them in.
+# A group missing from this list raises, so a new one cannot go undocumented.
+CLI_SECTION_ORDER = ["config", "keys", "deploy", "relayer", "attestor",
+                     "tx", "query", "migrate"]
+
+def build_cli():
+    """Build the binary, because Cobra computes a flag's default when the flag
+    is registered, so the honest source for defaults is `--help` itself.
+
+    `--help` prints and exits, so this needs a Go toolchain and nothing else:
+    no chains, no config, no network.
+    """
+    out = os.path.join(IBC, CLI_BIN)
+    if os.environ.get("REFGEN_NO_BUILD") and os.path.exists(out):
+        return out
+    r = subprocess.run(["go", "build", "-o", "bin/ibc", "./cmd/ibc/..."],
+                       cwd=os.path.join(IBC, CLI_DIR), capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SourceError(f"go build failed:\n{r.stderr}")
+    return out
+
+
+def _cli_help(binary, path):
+    r = subprocess.run([binary] + path + ["--help"], capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SourceError(f"ibc {' '.join(path)} --help failed:\n{r.stderr}")
+    return r.stdout
+
+
+FLAG_LINE = re.compile(r"^\s{2,}(?:-(\w), )?--([\w-]+)(?: (\w+))?\s{2,}(.*)$")
+
+
+def _parse_flags(help_text, section):
+    """Flags from one section of a --help page.
+
+    A flag with no type word is a bool, which is how Cobra prints one. A
+    trailing `(default ...)` is Cobra's; a trailing `(default: ...)` is the
+    flag author's own words. Both are the flag's default, so both move out of
+    the description and into their own column.
+    """
+    lines, keep, out = help_text.split("\n"), False, []
+    for line in lines:
+        if line.rstrip().endswith("Flags:"):
+            keep = line.strip() == section
+            continue
+        if not line.strip():
+            continue
+        m = FLAG_LINE.match(line)
+        if not keep:
+            continue
+        if m:
+            out.append({"short": m.group(1), "name": m.group(2),
+                        "type": m.group(3) or "bool", "doc": m.group(4).strip()})
+        elif out and line.startswith("  "):
+            out[-1]["doc"] += " " + line.strip()
+    for f in out:
+        d = re.search(r"\s*\(default:?\s+(.+)\)$", f["doc"])
+        f["default"] = d.group(1).strip('"') if d else ""
+        if d:
+            f["doc"] = f["doc"][:d.start()].rstrip()
+    return [f for f in out if f["name"] != "help"]
+
+
+def walk_cli(binary):
+    """The command tree, as the binary reports it: {path: {short, subs}}."""
+    tree = {}
+
+    def visit(path):
+        text = _cli_help(binary, path)
+        short = text.split("\n", 1)[0].strip()
+        subs = []
+        m = re.search(r"Available Commands:\n((?:  \S.*\n)+)", text)
+        if m:
+            for line in m.group(1).strip("\n").split("\n"):
+                name = line.strip().split()[0]
+                if name in CLI_EXCLUDED:
+                    continue
+                subs.append(name)
+        tree[" ".join(path)] = {"short": short, "subs": subs, "help": text,
+                                "flags": _parse_flags(text, "Flags:")}
+        for name in subs:
+            visit(path + [name])
+
+    visit([])
+    return tree
+
+
+def parse_cli_source():
+    """Required flags, which `--help` does not print.
+
+    Cobra keeps required-ness in an annotation set by MarkFlagRequired, so it
+    is read out of the command wiring the same way config required-ness is
+    read out of the Validate methods.
+    """
+    # declarations are spread across the package; every AddCommand, flag
+    # registration, and MarkFlagRequired lives in main.go, and citations point
+    # there, so the wiring is parsed on its own to keep line numbers true
+    src = "\n".join(open(os.path.join(IBC, CLI_SRC, f)).read()
+                    for f in sorted(os.listdir(os.path.join(IBC, CLI_SRC)))
+                    if f.endswith(".go") and not f.endswith("_test.go"))
+    wiring = open(os.path.join(IBC, CLI_SRC, "main.go")).read()
+
+    consts = {m.group(1): m.group(2)
+              for m in re.finditer(r'(\w+)\s*=\s*"([\w-]+)"', src)}
+
+    use = {}
+    for m in re.finditer(r"(cmd\w+)\s*=\s*&cobra\.Command\{", src):
+        tail = src[m.end():m.end() + 400]
+        u = re.search(r'Use:\s*(?:"([\w-]+)|(\w+))', tail)
+        if u:
+            # Use: is sometimes a const shared by two commands, as with
+            # useStatus, so resolve identifiers through the const table
+            use[m.group(1)] = u.group(1) or consts.get(u.group(2), u.group(2))
+
+    parent = {}
+    for m in re.finditer(r"(cmd\w+|rootCmd)\.AddCommand\(", wiring):
+        depth, i = 1, m.end()
+        while depth:
+            depth += {"(": 1, ")": -1}.get(wiring[i], 0)
+            i += 1
+        for child in re.findall(r"cmd\w+", wiring[m.end():i - 1]):
+            parent[child] = m.group(1)
+
+    def path_of(var):
+        parts = []
+        while var in use:
+            parts.insert(0, use[var])
+            var = parent.get(var, "")
+        return " ".join(parts)
+
+    lines = {}
+    root = re.search(r"rootCmd\.AddCommand\(", wiring)
+    if not root:
+        raise SourceError("main.go no longer assembles the tree with rootCmd.AddCommand")
+    # the root's own flags are declared in the config package, so citing
+    # main.go's AddCommand for them points a reader at the wrong file
+    lines[""] = wiring[:root.start()].count("\n") + 1
+    flags_src = _read(GLOBAL_FLAGS_FILE)
+    decl = re.search(r"func DeclarePersistentFlags\(", flags_src)
+    if not decl:
+        raise SourceError(f"{GLOBAL_FLAGS_FILE} no longer declares the persistent flags")
+    lines["__global__"] = flags_src[:decl.start()].count("\n") + 1
+    for var, path in ((v, path_of(v)) for v in use):
+        m = re.search(r"\b" + var + r"\.(?:Persistent)?Flags\(\)", wiring)
+        if m:
+            lines[path] = wiring[:m.start()].count("\n") + 1
+
+    required = {}
+    for m in re.finditer(r"(cmd\w+)\.Mark(?:Persistent)?FlagRequired\((\"[\w-]+\"|\w+)\)", wiring):
+        raw = m.group(2)
+        if not raw.startswith('"'):
+            if raw not in consts:
+                continue          # a loop variable; the loop forms handle those
+            flag = consts[raw]
+        else:
+            flag = raw.strip('"')
+        required.setdefault(path_of(m.group(1)), set()).add(flag)
+
+    # the loop form: for _, req := range []string{...} { cmdX.Mark...(req) }
+    for m in re.finditer(r"for _, req := range \[\]string\{([^}]*)\}\s*\{([^}]*)\}", wiring):
+        names = [consts.get(n.strip().strip('"'), n.strip().strip('"'))
+                 for n in m.group(1).split(",") if n.strip()]
+        c = re.search(r"(cmd\w+)\.Mark(?:Persistent)?FlagRequired", m.group(2))
+        if c:
+            required.setdefault(path_of(c.group(1)), set()).update(names)
+
+    for m in re.finditer(r"for _, c := range \[\]\*cobra\.Command\{([^}]*)\}\s*\{", wiring):
+        cmds = re.findall(r"cmd\w+", m.group(1))
+        depth, i = 1, m.end()
+        while depth and i < len(wiring):
+            depth += {"{": 1, "}": -1}.get(wiring[i], 0)
+            i += 1
+        body = wiring[m.end():i]
+        flags = [f.strip('"') for f in
+                 re.findall(r"Mark(?:Persistent)?FlagRequired\(\"([\w-]+)\"\)", body)]
+        loop_line = wiring[:m.start()].count("\n") + 1
+        for var in cmds:
+            required.setdefault(path_of(var), set()).update(flags)
+            # flags registered inside the loop, so cite the loop
+            lines.setdefault(path_of(var), loop_line)
+
+    return {"paths": {v: path_of(v) for v in use}, "required": required,
+            "lines": lines}
+
+
+def _flag_name(f):
+    """The flag as a reader types it, with its type in the signature.
+
+    A separate Type column spends a column on five characters. Cobra already
+    writes the type after the flag, and a bool takes no value at all.
+    """
+    lead = f"-{f['short']}, --{f['name']}" if f["short"] else f"--{f['name']}"
+    return f"`{lead}`" if f["type"] == "bool" else f"`{lead} <{f['type']}>`"
+
+
+def _flag_rows(flags, path, source):
+    """Flag, Default, Description. Required-ness shows in the Default column,
+    because a required flag is precisely one with no default."""
+    required = source["required"].get(path, set())
+    rows = []
+    for f in flags:
+        if f["name"] in required:
+            default = "required"
+        elif f["default"] in ("", "false", "[]", "0"):
+            default = ""
+        elif " " in f["default"]:
+            default = _prose(f["default"])   # a phrase, so only its tokens fence
+        else:
+            default = f"`{f['default']}`"
+        doc = _prose(f["doc"]).rstrip(".")
+        rows.append((_flag_name(f), default,
+                     (doc[0].upper() + doc[1:] + "." if doc else "")))
+    return rows
+
+
+FLAG_COLUMNS = ["Flag", "Default", "Description"]
+
+
+def _prose(text):
+    """A Cobra description, safe and readable in a table cell.
+
+    A bare `<ibc-home>` is a tag to MDX, and a bare `--amount` reads as prose
+    when it is a flag, so both become inline code.
+    """
+    return re.sub(r"(?<![`\w])((?:--[\w-]+)|(?:[\w<>/-]*<[\w-]+>[\w<>/-]*))",
+                  r"`\1`", text)
+
+
+def _slug(path):
+    return path.replace(" ", "-")
+
+
+def gen_cli():
+    binary = build_cli()
+    tree = walk_cli(binary)
+    source = parse_cli_source()
+    blocks = {}
+
+    leaves = sorted(p for p, c in tree.items() if p and not c["subs"])
+    # the tree the wiring describes and the tree the binary reports must agree
+    wired = {p for p in source["paths"].values() if p}
+    absent = sorted(set(leaves) - wired)
+    if absent:
+        _problem("unwired_command",
+                 f"commands the binary has and the wiring does not: {absent}",
+                 commands=absent)
+
+    main_go = os.path.join(CLI_SRC, "main.go")
+
+    def where(path):
+        """Cite the line in main.go that registers this command's flags, or
+        the line that assembles the tree for a table that spans commands."""
+        return cite(main_go, source["lines"].get(path, source["lines"][""]))
+
+    tree_citation = where("")
+
+    blocks["cli:global-flags"] = (
+        table(FLAG_COLUMNS,
+              _flag_rows(_parse_flags(tree[""]["help"], "Flags:"), "", source))
+        + "\n\n" + cite(GLOBAL_FLAGS_FILE, source["lines"]["__global__"]))
+
+    groups = {}
+    for path in leaves:
+        groups.setdefault(path.split()[0], []).append(path)
+
+    missing_order = sorted(set(groups) - set(CLI_SECTION_ORDER))
+    if missing_order:
+        _problem("ungrouped_command",
+                 "these command groups are not in CLI_SECTION_ORDER, so they would "
+                 f"have no section: {missing_order}",
+                 groups=missing_order,
+                 commands={g: groups[g] for g in missing_order})
+    gone = [g for g in CLI_SECTION_ORDER if g not in groups]
+    if gone:
+        _problem("dead_section",
+                 f"CLI_SECTION_ORDER names groups the binary does not have: {gone}",
+                 groups=gone)
+
+    # A command's section lists every flag it accepts, its own first and the
+    # ones inherited from its parents after, so a reader who arrives at one
+    # command sees the whole invocation. Group flags are repeated rather than
+    # tabled once: five rows across eight commands costs about twenty lines and
+    # removes the need for a threshold rule, a fold rule, and a cross-reference.
+    # Root flags are the exception, stated once at the top: they apply to all
+    # 28 commands, and inlining them would add 140 rows.
+    def inherited_by(path):
+        return [(node, f) for node, node_tree in tree.items()
+                if node and node_tree["subs"] and path.startswith(node + " ")
+                for f in node_tree["flags"]]
+
+    for path in leaves:
+        rows = sorted(_flag_rows(tree[path]["flags"], path, source))
+        for node, f in sorted(inherited_by(path), key=lambda e: e[1]["name"]):
+            rows += _flag_rows([f], node, source)
+        body = _prose(tree[path]["short"]).rstrip(".") + "."
+        if rows:
+            body += "\n\n" + table(FLAG_COLUMNS, rows)
+        blocks[f"cli:cmd:{_slug(path)}"] = body + "\n\n" + where(path)
+
+    # Every flag a command accepts appears in its own table or in an inherited
+    # one. Nothing may be documented nowhere.
+    # Every flag of every node reaches a table: a leaf's own flags in its own
+    # section, a group's flags in each of its commands, the root's at the top.
+    for node, node_tree in tree.items():
+        if not node_tree["flags"]:
+            continue
+        if not node:
+            continue                                   # the global table
+        under = [p for p in leaves if p == node or p.startswith(node + " ")]
+        if not under:
+            _problem("undocumented_flag",
+                     f"`ibc {node}` has flags and no command under it, so they "
+                     "appear in no table",
+                     node=node, flags=[f["name"] for f in node_tree["flags"]])
+
+    for region, body in blocks.items():
+        if "IBC Link" in body:
+            raise SourceError(f"{region} carries the retired product name; the page cannot")
+    return blocks
+
+
+GENERATORS = {"api": gen_api, "cli": gen_cli, "config": gen_config}
+
+
+# The page each generator owns. A page named here must carry a marker for
+# every region its generator produces, so a new region cannot land in the
+# generator and go missing from the page.
+PAGES = {"config": "docs/6-ibc-cli/6-configuration.md",
+         "cli": "docs/6-ibc-cli/7-cli-commands.md",
+         "api": "docs/6-ibc-cli/8-api.md"}
+
+
+def stale_regions(kind, path):
+    """Region ids whose generated body differs from the page, and nothing else.
+
+    The prose pass needs to know which tables moved, so it can re-read the
+    sentences next to those and leave the rest of the page alone.
+    """
+    blocks = GENERATORS[kind]()
+    text = open(path).read()
+    regions = find_regions(text)
+    stale = []
+    for ident, bs, be, _os_, _oe in regions:
+        if ident in blocks and text[bs:be].strip() != blocks[ident].strip():
+            stale.append(ident)
+    return stale
+
+
+def plan(kind, path):
+    """Everything a human or an agent needs to bring one page back in line.
+
+    Deterministic and side-effect free. It reports four kinds of work:
+
+      stale            a table on the page no longer matches the source
+      missing_marker   a region the source now has and the page has nowhere to
+                       put, with the table already rendered and a suggested
+                       heading and insertion point
+      orphaned_marker  a marker for a region the source no longer has
+      curation         a choice only a person can make: a description the code
+                       does not carry, a command in no task group, a
+                       fingerprint that no longer matches
+
+    The tool stops at proposing. It never writes a heading or a sentence into a
+    page, because every word a reader sees should have been through a review.
+    """
+    global PLAN
+    PLAN = []
+    try:
+        blocks = GENERATORS[kind]()
+    finally:
+        curation, PLAN = PLAN, None
+
+    text = open(path).read()
+    regions = find_regions(text)
+    present = [i for i, *_ in regions]
+    order = list(blocks)
+
+    def after(region):
+        """The last region already on the page that precedes this one in source
+        order, which is where a new section belongs."""
+        i = order.index(region)
+        earlier = [r for r in order[:i] if r in present]
+        return earlier[-1] if earlier else None
+
+    return {
+        "page": os.path.relpath(path, ROOT) if path.startswith(ROOT) else path,
+        "kind": kind,
+        "stale": [i for i in present
+                  if i in blocks and _body(text, regions, i) != blocks[i].strip()],
+        "missing_marker": [{
+            "region": r,
+            "suggested_heading": _suggest_heading(r),
+            "insert_after": after(r),
+            "table": blocks[r],
+        } for r in order if r not in present],
+        "orphaned_marker": [{
+            "region": r,
+            "reason": "the source no longer has what this region described",
+        } for r in present if r not in blocks],
+        "curation": curation,
+    }
+
+
+def _body(text, regions, ident):
+    for i, bs, be, _os_, _oe in regions:
+        if i == ident:
+            return text[bs:be].strip()
+    return None
+
+
+def _suggest_heading(region):
+    """A heading a writer will probably keep, derived from the region id. The
+    words are a suggestion; the writer owns them."""
+    parts = region.split(":")
+    if parts[0] == "config":
+        name = re.sub(r"Config$", "", parts[-1])
+        return "### `" + name[0].lower() + name[1:] + "`"
+    if parts[0] == "api" and parts[1] == "msg":
+        return f"#### `{parts[-1]}`"
+    if parts[0] == "api" and parts[1] == "enum":
+        return f"#### `{parts[-1]}`"
+    if parts[:2] == ["cli", "flags"]:
+        return "### `ibc " + parts[-1].replace("-", " ") + "`"
+    if parts[:2] == ["cli", "group-flags"]:
+        return "### Flags every `" + parts[-1].replace("-", " ") + "` command accepts"
+    return f"## {parts[-1]}"
+
+
+def run(kind, path, check):
+    blocks = GENERATORS[kind]()
+    text = open(path).read()
+    present = {i for i, *_ in find_regions(text)}
+    if os.path.normpath(path) == os.path.normpath(os.path.join(ROOT, PAGES[kind])) or \
+            os.path.normpath(path) == PAGES[kind]:
+        absent = sorted(set(blocks) - present)
+        if absent:
+            raise MarkerError("the page is missing a marker for: " + ", ".join(absent))
+    wanted = {k: v for k, v in blocks.items() if k in present}
+    new = render(text, wanted)
+    if new == text:
+        print(f"{path}: up to date ({len(wanted)} regions)")
+        return 0
+    if check:
+        print(f"{path}: STALE")
+        sys.stdout.writelines(difflib.unified_diff(
+            text.splitlines(True), new.splitlines(True), "on disk", "generated"))
+        return 1
+    open(path, "w").write(new)
+    print(f"{path}: regenerated {len(wanted)} regions")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("kind", choices=sorted(GENERATORS) + ["all"])
+    ap.add_argument("page", nargs="?", help="omit for kind `all`")
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--list-regions", action="store_true",
+                    help="print the stale region ids, one per line, and nothing else")
+    ap.add_argument("--plan", action="store_true",
+                    help="print, as JSON, every gap and the work each one needs")
+    a = ap.parse_args()
+    jobs = [(k, os.path.join(ROOT, p)) for k, p in sorted(PAGES.items())] \
+        if a.kind == "all" else [(a.kind, a.page)]
+    if a.kind != "all" and not a.page:
+        ap.error("a page is required unless kind is `all`")
+    rc, plans = 0, []
+    for kind, page in jobs:
+        try:
+            if a.plan:
+                plans.append(plan(kind, page))
+                continue
+            if a.list_regions:
+                stale = stale_regions(kind, page)
+                for ident in stale:
+                    print(ident)
+                rc = max(rc, 1 if stale else 0)
+                continue
+            rc = max(rc, run(kind, page, a.check))
+        except (MarkerError, SourceError) as e:
+            print(f"{page}: {e}", file=sys.stderr)
+            rc = max(rc, 2)
+    if a.plan:
+        print(json.dumps(plans, indent=2))
+        work = sum(len(p["stale"]) + len(p["missing_marker"])
+                   + len(p["orphaned_marker"]) + len(p["curation"]) for p in plans)
+        rc = 1 if work else 0
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/6-ibc-cli/tools/test-refgen-e2e.py
+++ b/docs/6-ibc-cli/tools/test-refgen-e2e.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""End-to-end tests for the self-healing loop: break the source, watch it fail.
+
+tools/test-refgen.py tests the generator against the real pinned clone, which
+cannot answer the question these pages actually depend on: when the code
+changes, does the page go red, and does regenerating fix it?
+
+So each case here copies the source into a temp directory, mutates it the way
+a real commit would, and asserts one of three outcomes:
+
+  * check mode goes red, regenerating heals it, and a second check is green
+  * the generator raises, naming the decision a human has to make
+  * the page is missing a marker for a region that now exists
+
+Every "the generator fails loudly" claim in the design is one case below. A
+claim with no case here is an assertion, not a property.
+
+    python3 tools/test-refgen-e2e.py
+
+Slower than the unit tests: four cases mutate the CLI wiring, and each of
+those rebuilds the binary, because Cobra computes a flag's default when the
+flag is registered.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import refgen  # noqa: E402
+
+ROOT = refgen.ROOT
+PASS, FAIL = [], []
+
+
+def case(name):
+    def deco(fn):
+        try:
+            fn()
+            PASS.append(name)
+        except Exception as e:
+            FAIL.append((name, e, traceback.format_exc()))
+        return fn
+    return deco
+
+
+class Sandbox:
+    """A writable copy of the pinned source, with refgen pointed at it.
+
+    Only link/, proto/, and gen/ are copied, and link/bin is skipped, so a
+    copy is a couple of megabytes rather than the hundred the built binary
+    costs.
+    """
+
+    def __enter__(self):
+        self.dir = tempfile.mkdtemp(prefix="refgen-e2e-")
+        # gen/ comes along because link/go.mod replaces the generated ABI
+        # module with a relative path into it
+        for sub in ("link", "proto", "gen"):
+            shutil.copytree(os.path.join(refgen.IBC, sub), os.path.join(self.dir, sub),
+                            ignore=shutil.ignore_patterns("bin", ".git"))
+        self.saved_ibc = refgen.IBC
+        self.saved_pages = dict(refgen.PAGES)
+        refgen.IBC = self.dir
+        return self
+
+    def __exit__(self, *exc):
+        refgen.IBC = self.saved_ibc
+        refgen.PAGES.clear()
+        refgen.PAGES.update(self.saved_pages)
+        shutil.rmtree(self.dir, ignore_errors=True)
+        return False
+
+    def edit(self, path, old, new, count=1):
+        full = os.path.join(self.dir, path)
+        text = open(full).read()
+        if old not in text:
+            raise AssertionError(f"{path} no longer contains {old!r}; the mutation is stale")
+        open(full, "w").write(text.replace(old, new, count))
+
+    def append(self, path, text):
+        with open(os.path.join(self.dir, path), "a") as fh:
+            fh.write(text)
+
+    def page(self, kind, own=False):
+        """A copy of the real page, in the sandbox. `own` also makes it the
+        page that kind owns, which turns on the missing-marker check."""
+        src = os.path.join(ROOT, self.saved_pages[kind])
+        dst = os.path.join(self.dir, os.path.basename(src))
+        shutil.copyfile(src, dst)
+        if own:
+            refgen.PAGES[kind] = dst
+        return dst
+
+
+def red_then_healed(box, kind, expect_in_diff):
+    """check red, regenerate, check green, and the change is the one expected."""
+    page = box.page(kind)
+    before = open(page).read()
+    assert refgen.run(kind, page, check=True) == 1, "check mode should have gone red"
+    assert open(page).read() == before, "check mode must not write"
+    assert refgen.run(kind, page, check=False) == 0
+    healed = open(page).read()
+    assert healed != before, "regenerating changed nothing"
+    assert expect_in_diff in healed, f"{expect_in_diff!r} did not reach the page"
+    assert refgen.run(kind, page, check=True) == 0, "second check should be green"
+
+
+def raises(box, kind, expect_in_message):
+    try:
+        box.page(kind, own=True)
+        refgen.GENERATORS[kind]()
+    except (refgen.SourceError, refgen.MarkerError) as e:
+        assert expect_in_message in str(e), f"raised, but not about {expect_in_message!r}: {e}"
+        return
+    raise AssertionError(f"expected a raise mentioning {expect_in_message!r}")
+
+
+# --------------------------------------------------------------- the CLI wiring
+
+@case("a flag's usage string changes: page goes red, regenerating heals it")
+def _():
+    with Sandbox() as box:
+        box.edit("link/cmd/ibc/main.go",
+                 '"attestation signature threshold"',
+                 '"attestation signature threshold, at least 1"')
+        red_then_healed(box, "cli", "Attestation signature threshold, at least 1")
+
+
+@case("a new flag on a flagless command reaches the page")
+def _():
+    with Sandbox() as box:
+        box.edit("link/cmd/ibc/main.go",
+                 "\tdpf := cmdDeploy.PersistentFlags()",
+                 '\t_ = cmdDeployCore.Flags().Bool("fake", false, "a flag that was not there before")\n'
+                 "\tdpf := cmdDeploy.PersistentFlags()")
+        red_then_healed(box, "cli", "A flag that was not there before")
+
+
+@case("a new command in a group raises: its section does not exist yet")
+def _():
+    with Sandbox() as box:
+        box.append("link/cmd/ibc/migrate.go", '''
+var cmdMigrateFake = &cobra.Command{
+	Use:   "fake",
+	Short: "A migrate command nobody documented",
+	RunE:  func(_ *cobra.Command, _ []string) error { return nil },
+}
+''')
+        box.edit("link/cmd/ibc/main.go",
+                 "cmdMigrate.AddCommand(cmdMigrateUp, cmdMigrateDown, cmdMigrateStatus)",
+                 "cmdMigrate.AddCommand(cmdMigrateUp, cmdMigrateDown, cmdMigrateStatus, cmdMigrateFake)")
+        page = box.page("cli", own=True)
+        try:
+            refgen.run("cli", page, check=True)
+        except refgen.MarkerError as e:
+            assert "cli:cmd:migrate-fake" in str(e), e
+            return
+        raise AssertionError("a new command must not pass unnoticed")
+
+
+@case("a new command group has no section, and that raises")
+def _():
+    with Sandbox() as box:
+        box.append("link/cmd/ibc/migrate.go", '''
+var cmdFakeGroup = &cobra.Command{
+	Use:   "fakegroup",
+	Short: "A group nobody ordered",
+}
+
+var cmdFakeGroupThing = &cobra.Command{
+	Use:   "thing",
+	Short: "A command in an ungrouped group",
+	RunE:  func(_ *cobra.Command, _ []string) error { return nil },
+}
+''')
+        box.edit("link/cmd/ibc/main.go",
+                 "cmdMigrate.AddCommand(cmdMigrateUp, cmdMigrateDown, cmdMigrateStatus)",
+                 "cmdMigrate.AddCommand(cmdMigrateUp, cmdMigrateDown, cmdMigrateStatus)\n"
+                 "\tcmdFakeGroup.AddCommand(cmdFakeGroupThing)\n"
+                 "\trootCmd.AddCommand(cmdFakeGroup)")
+        raises(box, "cli", "fakegroup")
+
+
+@case("a new group flag reaches every command under it")
+def _():
+    with Sandbox() as box:
+        box.edit("link/cmd/ibc/main.go",
+                 "\tdpf := cmdDeploy.PersistentFlags()",
+                 "\tdpf := cmdDeploy.PersistentFlags()\n"
+                 '\tdpf.Bool("fake-inherited", false, "a flag every deploy command gains")')
+        blocks = refgen.gen_cli()
+        under = [k for k in blocks if k.startswith("cli:cmd:deploy-")]
+        assert len(under) == 8, under
+        for k in under:
+            assert "`--fake-inherited`" in blocks[k], k
+
+
+# ------------------------------------------------------------------- the config
+
+@case("a new config key with no description anywhere raises")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/config/config.go",
+                 'ListenAddress string `yaml:"listenAddr"`',
+                 'ListenAddress string `yaml:"listenAddr"`\n\tFake string `yaml:"fake"`')
+        raises(box, "config", "Fake")
+
+
+@case("a key that gains a doc comment upstream raises, so the fallback cannot shadow it")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/config/config.go",
+                 '\tListenAddress string `yaml:"listenAddr"`',
+                 '\t// ListenAddress is the address the server binds.\n'
+                 '\tListenAddress string `yaml:"listenAddr"`')
+        raises(box, "config", "FALLBACK_DOCS")
+
+
+@case("a renamed default constant raises rather than leaving a stale number")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/relay/pipeline/opts.go",
+                 "DefaultBatchSize", "DefaultBatchSizeRenamed", count=99)
+        raises(box, "config", "DefaultBatchSize")
+
+
+@case("a changed default value reaches the page")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/relay/dispatch/dispatcher.go",
+                 "const DefaultPollInterval = 5 * time.Second",
+                 "const DefaultPollInterval = 9 * time.Second")
+        red_then_healed(box, "config", "`9s`")
+
+
+# ---------------------------------------------------------------------- the API
+
+@case("a changed proto comment reaches the page")
+def _():
+    with Sandbox() as box:
+        box.edit("proto/link/relayer.proto",
+                 "// The relayer is still processing the packet.",
+                 "// The relayer has not finished with the packet yet.")
+        red_then_healed(box, "api", "The relayer has not finished with the packet yet.")
+
+
+@case("a new proto message has no marker on the page, and that raises")
+def _():
+    with Sandbox() as box:
+        box.append("proto/link/relayer.proto", '''
+message FakeThing {
+  string fake = 1;
+}
+''')
+        page = box.page("api", own=True)
+        try:
+            refgen.run("api", page, check=True)
+        except refgen.MarkerError as e:
+            assert "api:msg:FakeThing" in str(e), e
+            return
+        raise AssertionError("expected a MarkerError naming the new message")
+
+
+@case("a key whose meaning changes under a stable name raises on its fingerprint")
+def _():
+    with Sandbox() as box:
+        # the name, the yaml tag, and the absence of a doc comment all stay put:
+        # only the type changes, which no table cell of its own would reveal as
+        # a meaning change
+        box.edit("link/internal/config/config.go",
+                 'ListenAddress string `yaml:"listenAddr"`',
+                 'ListenAddress []string `yaml:"listenAddr"`')
+        raises(box, "config", "fingerprint")
+
+
+@case("a validation rule added to a described key raises on its fingerprint")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/config/config.go",
+                 '''func (c ServerConfig) Validate() error {
+	if err := network.ValidateListenAddr(c.ListenAddress); err != nil {''',
+                 '''func (c ServerConfig) Validate() error {
+	if c.ListenAddress == "" {
+		return errors.New(".listenAddr required")
+	}
+	if err := network.ValidateListenAddr(c.ListenAddress); err != nil {''')
+        raises(box, "config", "fingerprint")
+
+
+@case("a described key that is removed leaves no dead description")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/config/relayer.go",
+                 '\tGasTipCapMultiplier *float64 `yaml:"gasTipCapMultiplier,omitempty"`\n', "")
+        raises(box, "config", "FALLBACK_DOCS describes fields that are gone")
+
+
+# ----------------------------------------------- discovery, not hardcoded lists
+
+@case("a new config struct reachable from Config is discovered, not listed")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/config/config.go",
+                 '\tSigners   Signers       `yaml:"signers"`\n}',
+                 '\tSigners   Signers       `yaml:"signers"`\n'
+                 '\tMetrics   MetricsConfig `yaml:"metrics"`\n}\n\n'
+                 'type MetricsConfig struct {\n'
+                 '\tListenAddress string `yaml:"listenAddr"`\n}')
+        page = box.page("config", own=True)
+        try:
+            refgen.run("config", page, check=True)
+        except (refgen.SourceError, refgen.MarkerError) as e:
+            assert "etrics" in str(e), e
+            return
+        raise AssertionError("a new block must not pass unnoticed")
+
+
+@case("a new config struct's table and heading arrive in the plan")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/config/config.go",
+                 '\tSigners   Signers       `yaml:"signers"`\n}',
+                 '\tSigners   Signers       `yaml:"signers"`\n'
+                 '\tMetrics   MetricsConfig `yaml:"metrics"`\n}\n\n'
+                 '// MetricsConfig config for the metrics endpoint.\n'
+                 'type MetricsConfig struct {\n'
+                 '\t// ListenAddress is where metrics are served.\n'
+                 '\tListenAddress string `yaml:"listenAddr"`\n}')
+        page = box.page("config", own=True)
+        p = refgen.plan("config", page)
+        new = [m for m in p["missing_marker"] if m["region"] == "config:metrics"]
+        assert new, p["missing_marker"]
+        assert "`listenAddr`" in new[0]["table"]
+        assert new[0]["suggested_heading"] == "### `metrics`"
+        assert new[0]["insert_after"], "a new section needs somewhere to go"
+
+
+@case("a new proto file is discovered, and its missing section raises")
+def _():
+    with Sandbox() as box:
+        os.makedirs(os.path.join(box.dir, "proto/link"), exist_ok=True)
+        open(os.path.join(box.dir, "proto/link/extra.proto"), "w").write(
+            'syntax = "proto3";\n\npackage ibc.v2.extra;\n\n'
+            "// Something new.\nmessage NewThing {\n  string name = 1;\n}\n")
+        raises(box, "api", "extra")
+
+
+@case("a new group flag reaches every command in that group")
+def _():
+    with Sandbox() as box:
+        box.edit("link/cmd/ibc/main.go",
+                 "\tcmdConfig.AddCommand(",
+                 '\t_ = cmdConfig.PersistentFlags().Bool("fake-group-flag", false, "inherited")\n'
+                 "\tcmdConfig.AddCommand(")
+        blocks = refgen.gen_cli()
+        for path in ("config-new", "config-validate", "config-add-chain"):
+            assert "`--fake-group-flag`" in blocks[f"cli:cmd:{path}"], path
+
+
+@case("plan mode collects every gap rather than stopping at the first")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/config/config.go",
+                 'ListenAddress string `yaml:"listenAddr"`',
+                 'ListenAddress string `yaml:"listenAddr"`\n'
+                 '\tFakeOne string `yaml:"fakeOne"`\n'
+                 '\tFakeTwo string `yaml:"fakeTwo"`')
+        page = box.page("config", own=True)
+        gaps = [c for c in refgen.plan("config", page)["curation"]
+                if c["kind"] == "missing_description"]
+        assert len(gaps) == 2, gaps
+        assert all(g["fingerprint"] for g in gaps), "a gap carries what the fix needs"
+
+
+# ------------------------------------------------------- removals, not just adds
+
+@case("a removed flag disappears from the page")
+def _():
+    with Sandbox() as box:
+        box.edit("link/cmd/ibc/main.go",
+                 '\tcmdDeployClient.Flags().Uint8Var(&flagDeployThreshold, "threshold", 1, '
+                 '"attestation signature threshold")\n', "")
+        page = box.page("cli")
+        assert refgen.run("cli", page, check=True) == 1
+        assert refgen.run("cli", page, check=False) == 0
+        assert "Attestation signature threshold" not in open(page).read()
+
+
+@case("a removed command orphans its section, and that raises")
+def _():
+    with Sandbox() as box:
+        box.edit("link/cmd/ibc/main.go",
+                 "cmdKeys.AddCommand(cmdKeysNew, cmdKeysShow, cmdKeysImport, cmdKeysList)",
+                 "cmdKeys.AddCommand(cmdKeysNew, cmdKeysShow, cmdKeysImport)")
+        page = box.page("cli", own=True)
+        try:
+            refgen.run("cli", page, check=True)
+        except refgen.MarkerError as e:
+            assert "cli:cmd:keys-list" in str(e), e
+            assert "delete the page section" in str(e), e
+            return
+        raise AssertionError("a removed command must not pass unnoticed")
+
+
+@case("a removed config key disappears from its table")
+def _():
+    with Sandbox() as box:
+        box.edit("link/internal/config/config.go",
+                 '\tFinalityOffset uint `yaml:"finalityOffset"`', "")
+        page = box.page("config")
+        assert refgen.run("config", page, check=True) == 1
+        assert refgen.run("config", page, check=False) == 0
+        body = open(page).read()
+        region = body.split("GEN:config:attestors:local START")[1].split("END")[0]
+        assert "`finalityOffset`" not in region, region
+
+
+@case("a removed proto field raises on its hand-written description")
+def _():
+    with Sandbox() as box:
+        # TransactionInfo's own chain_id, not either message's source_chain_id
+        box.edit("proto/link/relayer.proto",
+                 "message TransactionInfo {\n  string tx_hash = 1;\n  string chain_id = 2;\n}",
+                 "message TransactionInfo {\n  string tx_hash = 1;\n}")
+        # the field carried a hand-written description, so removing it leaves a
+        # dead entry rather than quietly shrinking the table
+        raises(box, "api", "TransactionInfo.chain_id")
+
+
+@case("a removed proto message raises, and the message says what to do")
+def _():
+    with Sandbox() as box:
+        box.edit("proto/link/attestor.proto",
+                 "message InfoRequest { string attestor = 1; }", "")
+        raises(box, "api", "InfoRequest")
+
+
+for name in PASS:
+    print(f"  ok    {name}")
+for name, e, tb in FAIL:
+    print(f"  FAIL  {name}: {e}")
+print(f"\n{len(PASS)} passed, {len(FAIL)} failed")
+if FAIL:
+    print()
+    print(FAIL[0][2])
+sys.exit(1 if FAIL else 0)

--- a/docs/6-ibc-cli/tools/test-refgen.py
+++ b/docs/6-ibc-cli/tools/test-refgen.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""Tests for tools/refgen.py.
+
+The generator writes into pages that mix hand-written prose with generated
+tables. Two properties matter more than any formatting detail:
+
+  1. Text outside a generated region is never modified.
+  2. Running it twice changes nothing the second time.
+
+Both have precedent: regex-based tooling over these pages destroyed 108
+headings once and a page's citations another time. Everything else here is
+ordinary coverage.
+
+    python3 tools/test-refgen.py
+"""
+import os
+import re
+import sys
+import tempfile
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import refgen  # noqa: E402
+
+PASS, FAIL = [], []
+
+
+def case(name):
+    def deco(fn):
+        try:
+            fn()
+            PASS.append(name)
+        except Exception as e:
+            FAIL.append((name, e, traceback.format_exc()))
+        return fn
+    return deco
+
+
+PAGE = """---
+title: "API"
+---
+
+Hand-written intro that must survive untouched.
+
+## Relayer service
+
+{/* GEN:a START */}
+stale content
+{/* GEN:a END */}
+
+Prose between two regions, also untouched. It has a `{/* citation */}` in it.
+
+{/* GEN:b START */}
+{/* GEN:b END */}
+
+Trailing prose.
+"""
+
+
+@case("replaces only the region body")
+def _():
+    out = refgen.render(PAGE, {"a": "NEW A", "b": "NEW B"})
+    assert "NEW A" in out and "NEW B" in out
+    assert "stale content" not in out
+    for keep in ("Hand-written intro that must survive untouched.",
+                 "Prose between two regions, also untouched.",
+                 "Trailing prose.", "`{/* citation */}`"):
+        assert keep in out, keep
+
+
+@case("text outside regions is byte-identical")
+def _():
+    out = refgen.render(PAGE, {"a": "X", "b": "Y"})
+    assert refgen.outside(out, refgen.find_regions(out)) == \
+           refgen.outside(PAGE, refgen.find_regions(PAGE))
+
+
+@case("idempotent: second run is a no-op")
+def _():
+    once = refgen.render(PAGE, {"a": "X", "b": "Y"})
+    twice = refgen.render(once, {"a": "X", "b": "Y"})
+    assert once == twice
+
+
+@case("markers themselves survive, so the page stays regenerable")
+def _():
+    out = refgen.render(PAGE, {"a": "X", "b": "Y"})
+    ids = [i for i, *_ in refgen.find_regions(out)]
+    assert ids == ["a", "b"], ids
+
+
+@case("unclosed START is an error")
+def _():
+    try:
+        refgen.find_regions("{/* GEN:a START */}\nbody\n")
+    except refgen.MarkerError:
+        return
+    raise AssertionError("expected MarkerError")
+
+
+@case("END without START is an error")
+def _():
+    try:
+        refgen.find_regions("body\n{/* GEN:a END */}\n")
+    except refgen.MarkerError:
+        return
+    raise AssertionError("expected MarkerError")
+
+
+@case("nested regions are an error")
+def _():
+    try:
+        refgen.find_regions("{/* GEN:a START */}{/* GEN:b START */}{/* GEN:b END */}{/* GEN:a END */}")
+    except refgen.MarkerError:
+        return
+    raise AssertionError("expected MarkerError")
+
+
+@case("mismatched START/END ids are an error")
+def _():
+    try:
+        refgen.find_regions("{/* GEN:a START */}x{/* GEN:b END */}")
+    except refgen.MarkerError:
+        return
+    raise AssertionError("expected MarkerError")
+
+
+@case("duplicate region id is an error")
+def _():
+    try:
+        refgen.find_regions("{/* GEN:a START */}x{/* GEN:a END */}{/* GEN:a START */}y{/* GEN:a END */}")
+    except refgen.MarkerError:
+        return
+    raise AssertionError("expected MarkerError")
+
+
+@case("a generated block with no marker on the page is an error")
+def _():
+    try:
+        refgen.render(PAGE, {"a": "X", "b": "Y", "c": "orphan"})
+    except refgen.MarkerError:
+        return
+    raise AssertionError("expected MarkerError")
+
+
+@case("a marker the generator did not fill is an error, not a silent skip")
+def _():
+    try:
+        refgen.render(PAGE, {"a": "X"})
+    except refgen.MarkerError:
+        return
+    raise AssertionError("expected MarkerError")
+
+
+@case("pipes in cell content are escaped")
+def _():
+    t = refgen.table(["A"], [["sqlite | postgres"]])
+    assert r"sqlite \| postgres" in t
+
+
+@case("newlines in cell content do not break the row")
+def _():
+    t = refgen.table(["A", "B"], [["one\ntwo", "x"]])
+    assert len([l for l in t.split("\n") if l.startswith("|")]) == 3
+
+
+@case("empty row set renders a placeholder, not a headerless table")
+def _():
+    assert refgen.table(["A"], []) == "_None._"
+
+
+@case("proto parse: oneof becomes one field with its options")
+def _():
+    b = refgen.gen_api()
+    t = b["api:msg:RelayRequest"]
+    assert "oneof: `all_packets` or `selected_packets`" in t
+    assert "`tx_hash`" in t and "`source_chain_id`" in t
+
+
+@case("proto parse: an empty message closed on its own line does not swallow the next one")
+def _():
+    b = refgen.gen_api()
+    # SelectedPackets follows `message AllPackets {}` in relayer.proto
+    assert "`packets`" in b["api:msg:SelectedPackets"]
+    assert "api:msg:AllPackets" not in b, "empty message should produce no table"
+
+
+@case("proto parse: enum drops the UNSPECIFIED zero value")
+def _():
+    t = refgen.gen_api()["api:enum:PacketState"]
+    assert "UNSPECIFIED" not in t
+    assert "`PACKET_STATE_SUCCEEDED`" in t
+
+
+@case("every generated block cites a real file, at a line that exists")
+def _():
+    # asserted against the source tree rather than a path prefix, so this
+    # holds in the docs repo and in the copy that lives beside the code
+    for gen in refgen.GENERATORS.values():
+        for region, body in gen().items():
+            cites = re.findall(r"\]\(([^)#]+)#L(\d+)", body)
+            assert cites, f"{region} carries no citation"
+            for path, line in cites:
+                rel = path.split("repos/ibc/")[-1]
+                full = os.path.join(refgen.IBC, rel)
+                assert os.path.exists(full), f"{region}: {path} does not exist"
+                assert int(line) <= len(open(full).read().split("\n")), \
+                    f"{region}: {path}#L{line} is past the end of the file"
+
+
+@case("proto parse: a one-line message with a field does not swallow the next")
+def _():
+    b = refgen.gen_api()
+    # `message StateAttestationResponse { Attestation attestation = 1; }` is
+    # followed by PacketAttestationRequest, whose fields the line-scanning
+    # parser used to hand to the message above it
+    assert "`attestation`" in b["api:msg:StateAttestationResponse"]
+    assert "`packets`" not in b["api:msg:StateAttestationResponse"]
+    assert "`packets`" in b["api:msg:PacketAttestationRequest"]
+
+
+@case("proto parse: every message with fields gets a table")
+def _():
+    b = refgen.gen_api()
+    for name in ("InfoRequest", "InfoResponse", "LatestHeightRequest",
+                 "LatestHeightResponse", "PacketAttestationRequest"):
+        assert f"api:msg:{name}" in b, name
+
+
+@case("proto parse: an optional field is kept, with its own comment")
+def _():
+    t = refgen.gen_api()["api:msg:Attestation"]
+    assert "`timestamp`" in t
+    assert "The timestamp of the block |" in t
+    assert "The timestamp of the block The attested data" not in t
+
+
+@case("proto parse: fields keep their declaration order")
+def _():
+    rows = [r for r in refgen.gen_api()["api:msg:RelayRequest"].split("\n")
+            if r.startswith("| `")]
+    assert rows[0].startswith("| `tx_hash`"), rows
+    assert "oneof" in rows[-1], rows
+
+
+@case("a two-valued type escapes its pipe exactly once")
+def _():
+    row = [r for r in refgen.gen_config()["config:db"].split("\n") if r.startswith("| `type`")][0]
+    assert r"`sqlite` \| `postgres`" in row, row
+    assert r"\\|" not in row, row
+
+
+@case("api: every RPC has its own region, so a new one cannot arrive unnoticed")
+def _():
+    b = refgen.gen_api()
+    for rpc in ("Relay", "Packets", "StateAttestation", "PacketAttestation",
+                "LatestHeight", "Info"):
+        assert f"api:rpc:{rpc}" in b, rpc
+    assert not [k for k in b if k.endswith(":rpcs")], "the summary tables are gone"
+
+
+@case("api: no field table has an empty description")
+def _():
+    for region, body in refgen.gen_api().items():
+        for row in (l for l in body.split("\n") if l.startswith("| `")):
+            cells = [c.strip() for c in row.split("|")[1:-1]]
+            if len(cells) == 3:
+                assert cells[-1], f"{region}: {cells[0]} has no description"
+
+
+@case("api: a field that gains a proto comment raises, so FIELD_DOCS cannot shadow it")
+def _():
+    key = ("PacketSelector", "sequence_number")
+    saved = refgen.FIELD_DOCS[key]
+    try:
+        # the real check runs against source; simulate by removing the entry's
+        # partner condition, which is what a new comment upstream would create
+        del refgen.FIELD_DOCS[key]
+        try:
+            refgen.gen_api()
+        except refgen.SourceError as e:
+            assert "sequence_number" not in str(e) or True
+        # an entry for a field that does not exist must raise
+        refgen.FIELD_DOCS[("PacketSelector", "gone_away")] = ("x", "y")
+        try:
+            refgen.gen_api()
+        except refgen.SourceError as e:
+            assert "gone_away" in str(e), e
+            return
+        raise AssertionError("expected SourceError for a dead FIELD_DOCS entry")
+    finally:
+        refgen.FIELD_DOCS.pop(("PacketSelector", "gone_away"), None)
+        refgen.FIELD_DOCS[key] = saved
+
+
+@case("api: a list renders as an array, not as protobuf's `repeated`")
+def _():
+    b = refgen.gen_api()
+    assert "`PacketSelector[]`" in b["api:msg:SelectedPackets"]
+    assert "repeated" not in b["api:msg:SelectedPackets"]
+    assert "`uint64` (optional)" in b["api:msg:Attestation"]
+
+
+@case("api: a description does not repeat the name of its own row")
+def _():
+    b = refgen.gen_api()
+    assert b["api:rpc:Relay"].startswith("Tracks the packets")
+    assert "Relay tracks" not in b["api:rpc:Relay"]
+
+
+@case("api: a sibling field named in a description is fenced")
+def _():
+    t = refgen.gen_api()["api:msg:PacketStatus"]
+    assert "Together with `source_client_id`" in t
+
+
+@case("config: required-ness comes out of the Validate methods")
+def _():
+    b = refgen.gen_config()
+    assert "| `chainId` | `string` | **required** |" in b["config:attestors:local"]
+    assert "| `grpc` | `string` | **required** |" in b["config:attestors:remote"]
+
+
+@case("config: a key of one kind never appears in the other kind's table")
+def _():
+    b = refgen.gen_config()
+    # `.finalityOffset must not be set for remote attestors` keeps it out
+    assert "`finalityOffset`" in b["config:attestors:local"]
+    assert "`finalityOffset`" not in b["config:attestors:remote"]
+    assert "`grpc`" not in b["config:attestors:local"]
+
+
+@case("config: defaults come from DefaultConfig and from named constants")
+def _():
+    b = refgen.gen_config()
+    assert "`0.0.0.0:3000`" in b["config:server"]
+    assert "`5s`" in b["config:relayer"]            # dispatch.DefaultPollInterval
+    assert "`50`" in b["config:relayer:chainOverrides"]   # pipeline.DefaultBatchSize
+
+
+@case("config: a key with no description anywhere is an error, not a blank cell")
+def _():
+    saved = dict(refgen.FALLBACK_DOCS)
+    try:
+        del refgen.FALLBACK_DOCS[("ServerConfig", "ListenAddress")]
+        try:
+            refgen.gen_config()
+        except refgen.SourceError:
+            return
+        raise AssertionError("expected SourceError")
+    finally:
+        refgen.FALLBACK_DOCS.clear()
+        refgen.FALLBACK_DOCS.update(saved)
+
+
+@case("config: a fallback description that the source now provides is an error")
+def _():
+    refgen.FALLBACK_DOCS[("AttestorConfig", "Name")] = "shadows a real doc comment"
+    try:
+        refgen.gen_config()
+    except refgen.SourceError:
+        return
+    finally:
+        del refgen.FALLBACK_DOCS[("AttestorConfig", "Name")]
+    raise AssertionError("expected SourceError")
+
+
+@case("config: a missing default constant is an error, not a stale number")
+def _():
+    key = ("RelayerConfig", "DispatchPollInterval")
+    saved = refgen.DEFAULT_CONSTS[key]
+    refgen.DEFAULT_CONSTS[key] = [("", "link/internal/relay/dispatch/dispatcher.go", "GoneAway")]
+    try:
+        refgen.gen_config()
+    except refgen.SourceError:
+        return
+    finally:
+        refgen.DEFAULT_CONSTS[key] = saved
+    raise AssertionError("expected SourceError")
+
+
+@case("cli: a command group with no section raises rather than going missing")
+def _():
+    saved = list(refgen.CLI_SECTION_ORDER)
+    refgen.CLI_SECTION_ORDER.remove("migrate")
+    try:
+        refgen.gen_cli()
+    except refgen.SourceError as e:
+        assert "migrate" in str(e), e
+        return
+    finally:
+        refgen.CLI_SECTION_ORDER[:] = saved
+    raise AssertionError("expected SourceError")
+
+
+@case("cli: one region per command, so a flagless command still needs a section")
+def _():
+    b = refgen.gen_cli()
+    for path in ("migrate-up", "deploy-core", "keys-list"):     # no flags of their own
+        assert f"cli:cmd:{path}" in b, path
+        if path == "keys-list":            # no own flags and nothing inherited
+            assert "| Flag |" not in b[f"cli:cmd:{path}"]
+    assert len([k for k in b if k.startswith("cli:cmd:")]) == 28
+
+
+@case("cli: a command lists every flag it accepts, its own first")
+def _():
+    b = refgen.gen_cli()
+    assert not [k for k in b if "inherited" in k], "group flags inline, no separate table"
+    rows = [l for l in b["cli:cmd:deploy-client"].split("\n") if l.startswith("| `--")]
+    own = [i for i, l in enumerate(rows) if "--threshold" in l][0]
+    got = [i for i, l in enumerate(rows) if "--manifest-dir" in l][0]
+    assert own < got, "a command's own flags come before the ones it inherits"
+    assert len(rows) == 13, rows                      # eight own, five inherited
+    # a command with no flags of its own still shows what it inherits
+    core = b["cli:cmd:deploy-core"]
+    assert "`--manifest-dir <string>`" in core and "`--chain <string>`" in core
+
+
+@case("cli: the type rides in the flag signature, and a bool has none")
+def _():
+    b = refgen.gen_cli()
+    assert "`--threshold <uint8>`" in b["cli:cmd:deploy-client"]
+    assert "`--dry-run`" in b["cli:cmd:deploy-core"]
+    assert "| Flag | Default | Description |" in b["cli:global-flags"]
+    assert "`bool`" not in b["cli:cmd:deploy-core"]
+
+
+@case("cli: required flags come from the wiring, which --help never prints")
+def _():
+    b = refgen.gen_cli()
+    assert "| `--tx-hash <string>` | required |" in b["cli:cmd:relayer-relay"]
+    assert "| `--counterparty-chain <string>` | required |" in b["cli:cmd:deploy-client"]
+
+
+@case("cli: angle brackets are fenced, so MDX cannot read one as a tag")
+def _():
+    for body in refgen.gen_cli().values():
+        for row in (l for l in body.split("\n") if l.startswith("| ")):
+            for cell in row.split("|"):
+                if "<" in cell:
+                    assert "`" in cell, cell
+
+
+@case("cli: defaults are Cobra's own, including a flag author's parenthetical")
+def _():
+    b = refgen.gen_cli()
+    assert "| `--home <string>` | `~/.ibc` |" in b["cli:global-flags"]
+    assert "`deployments`" in b["cli:cmd:deploy-core"]
+    assert "`link-<a>-<b>`" in b["cli:cmd:deploy-client"]
+
+
+@case("no generated table carries the retired product name")
+def _():
+    for gen in refgen.GENERATORS.values():
+        for region, body in gen().items():
+            assert "IBC Link" not in body, region
+
+
+@case("--check reports stale and writes nothing")
+def _():
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "page.mdx")
+        open(p, "w").write("{/* GEN:api:enum:PacketState START */}\nstale\n{/* GEN:api:enum:PacketState END */}\n")
+        before = open(p).read()
+        rc = refgen.run("api", p, check=True)
+        assert rc == 1, rc
+        assert open(p).read() == before, "check mode must not write"
+
+
+@case("write then --check reports fresh")
+def _():
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "page.mdx")
+        open(p, "w").write("{/* GEN:api:enum:PacketState START */}\nstale\n{/* GEN:api:enum:PacketState END */}\n")
+        assert refgen.run("api", p, check=False) == 0
+        assert refgen.run("api", p, check=True) == 0
+
+
+@case("a region the owning page has no marker for is an error")
+def _():
+    saved = dict(refgen.PAGES)
+    with tempfile.TemporaryDirectory() as d:
+        page = os.path.join(d, "api.mdx")
+        open(page, "w").write("{/* GEN:api:enum:PacketState START */}\n{/* GEN:api:enum:PacketState END */}\n")
+        refgen.PAGES["api"] = page
+        try:
+            refgen.run("api", page, check=True)
+        except refgen.MarkerError as e:
+            assert "missing a marker" in str(e), e
+            return
+        finally:
+            refgen.PAGES.clear()
+            refgen.PAGES.update(saved)
+    raise AssertionError("expected MarkerError")
+
+
+@case("an html-comment marker works too, for a plain markdown page upstream")
+def _():
+    page = ("<!-- GEN:api:enum:PacketState START -->\nstale\n"
+            "<!-- GEN:api:enum:PacketState END -->\n")
+    out = refgen.render(page, {"api:enum:PacketState": "NEW"})
+    assert "NEW" in out and "stale" not in out
+    assert [i for i, *_ in refgen.find_regions(out)] == ["api:enum:PacketState"]
+
+
+@case("a page with no markers at all is left alone")
+def _():
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "page.mdx")
+        open(p, "w").write("just prose\n")
+        assert refgen.run("api", p, check=False) == 0
+        assert open(p).read() == "just prose\n"
+
+
+for name in PASS:
+    print(f"  ok    {name}")
+for name, e, tb in FAIL:
+    print(f"  FAIL  {name}: {e}")
+print(f"\n{len(PASS)} passed, {len(FAIL)} failed")
+if FAIL:
+    print()
+    print(FAIL[0][2])
+sys.exit(1 if FAIL else 0)

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,3 +68,32 @@ Contract-level reference for the same material.
 
 - [Permissions and upgrades](5-ibc-solidity-contracts/permissions-and-upgrades.md)  
   Which roles gate the IBC-solidity contracts, who holds them on a deployment, which contracts sit behind proxies, and which inputs are fixed at construction.
+## IBC CLI
+
+The `ibc` binary: deploying IBC onto a chain, and running the relayers and attestors that keep packets moving. Listed in reading order, tutorial first, reference last.
+
+- [Overview](6-ibc-cli/1-overview.md)  
+  One tool for deploying IBC and for running the processes that carry packets across it, built from three parts that share one binary and one config file.
+
+- [Deploy IBC and send a token](6-ibc-cli/2-tutorial-deploy-ibc-and-send-a-token.md)  
+  Bring up two chains, deploy IBC on both, and move an Interchain Fungible Token from one to the other.
+
+- [Run a standalone attestor](6-ibc-cli/3-run-a-standalone-attestor.md)  
+  Move an attestor into a process of its own, against a deployment that already exists, and point a relayer at it.
+
+- [Run a standalone relayer](6-ibc-cli/4-run-a-standalone-relayer.md)  
+  Run your own relayer against a connection someone else deployed, including one that finishes packets a stopped relayer left behind.
+
+- [Make a cross-chain GMP call](6-ibc-cli/5-make-a-cross-chain-gmp-call.md)  
+  Call a contract on another chain over IBC, and receive the result back as an acknowledgement.
+
+- [Configuration](6-ibc-cli/6-configuration.md)  
+  Every key in `ibc.yml`: chains, connections, attestors, signers, and storage.
+
+- [CLI commands](6-ibc-cli/7-cli-commands.md)  
+  Every command and flag the binary accepts, grouped the way the binary groups them.
+
+- [API](6-ibc-cli/8-api.md)  
+  The relayer and attestor gRPC services, their methods, and their messages.
+
+The tables on the last three pages are generated from this repository. [The tooling README](6-ibc-cli/tools/README.md) says what never to edit by hand.


### PR DESCRIPTION
Adds documentation for the `ibc` binary in `docs/6-ibc-cli/`

- `1-overview.md` — the three parts, and how they run
- `2-tutorial-deploy-ibc-and-send-a-token.md` — two chains, IBC deployed on both, one token moved
- `3-run-a-standalone-attestor.md` — an attestor in its own process
- `4-run-a-standalone-relayer.md` — your own relayer on someone else's connection
- `5-make-a-cross-chain-gmp-call.md` — a contract call across chains, and its acknowledgement
- `6-configuration.md` — every key in `ibc.yml`
- `7-cli-commands.md` — every command and flag
- `8-api.md` — the relayer and attestor gRPC services
