### PR TITLE
feat: Log additions to relay

### DIFF
--- a/cli/internal/bootstrap/bootstrap.go
+++ b/cli/internal/bootstrap/bootstrap.go
@@ -84,7 +84,7 @@ func BuildRelayer(cfg config.Config) (*Services, error) {
 	}
 
 	// Provers
-	provers, err := prover.NewSetFromConfig(ctx, cfg, clientSet, append(local, remote...))
+	provers, err := prover.NewSetFromConfig(ctx, cfg, clientSet, append(local, remote...), logger)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/livevalidate/quorum.go
+++ b/cli/internal/livevalidate/quorum.go
@@ -4,6 +4,7 @@ package livevalidate
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/pkg/errors"
 
@@ -33,7 +34,7 @@ func checkAttestorQuorum(ctx context.Context, cfg config.Config, clientSet *chai
 	attestors = append(attestors, local...)
 	attestors = append(attestors, remote...)
 
-	if _, err := prover.NewSetFromConfig(ctx, cfg, clientSet, attestors); err != nil {
+	if _, err := prover.NewSetFromConfig(ctx, cfg, clientSet, attestors, slog.Default()); err != nil {
 		return errors.Wrap(err, "attestor quorum")
 	}
 

--- a/cli/internal/relay/pipeline/pipeline.go
+++ b/cli/internal/relay/pipeline/pipeline.go
@@ -135,7 +135,7 @@ func NewPipeline(
 
 	// deliver timeouts in batches on the source chain
 	batchTimeoutPacket, err := processors.NewBatchTimeoutPacket(
-		deps.Chains, deps.Provers, deps.TxBuilders, deps.Storage, srcTxSubmitter, route,
+		deps.Chains, deps.Provers, deps.TxBuilders, deps.Storage, srcTxSubmitter, route, logger,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing batch timeout packet processor")
@@ -157,7 +157,7 @@ func NewPipeline(
 
 	// deliver recvs in batches on the destination chain
 	batchRecvPacket, err := processors.NewBatchRecvPacket(
-		deps.Chains, deps.Provers, deps.TxBuilders, deps.Storage, dstTxSubmitter, route,
+		deps.Chains, deps.Provers, deps.TxBuilders, deps.Storage, dstTxSubmitter, route, logger,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing batch recv packet processor")
@@ -197,7 +197,7 @@ func NewPipeline(
 
 	// deliver acks in batches on the source chain
 	batchAckPacket, err := processors.NewBatchAckPacket(
-		deps.Chains, deps.Provers, deps.TxBuilders, deps.Storage, srcTxSubmitter, route,
+		deps.Chains, deps.Provers, deps.TxBuilders, deps.Storage, srcTxSubmitter, route, logger,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing batch ack packet processor")

--- a/cli/internal/relay/processors/batch_ack_packet.go
+++ b/cli/internal/relay/processors/batch_ack_packet.go
@@ -6,6 +6,7 @@ package processors
 import (
 	"context"
 	"encoding/hex"
+	"log/slog"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,6 +29,7 @@ type BatchAckPacket struct {
 	txBuilder              txbuilder.TxBuilder
 	txSubmitter            txsubmitter.TxSubmitter
 	storage                TxStorage
+	logger                 *slog.Logger
 }
 
 func NewBatchAckPacket(
@@ -37,6 +39,7 @@ func NewBatchAckPacket(
 	storage TxStorage,
 	txSubmitter txsubmitter.TxSubmitter,
 	route Route,
+	logger *slog.Logger,
 ) (BatchAckPacket, error) {
 	destinationChainClient, ok := chainClients.Get(route.DestinationChainID)
 	if !ok {
@@ -68,6 +71,7 @@ func NewBatchAckPacket(
 		txBuilder:              txBuilder,
 		txSubmitter:            txSubmitter,
 		storage:                storage,
+		logger:                 logger,
 	}, nil
 }
 
@@ -122,7 +126,7 @@ func (p BatchAckPacket) Process(ctx context.Context, transfers []*Transfer) ([]*
 	}
 
 	submission, err := relayPackets(
-		ctx, p.sourceChainClient, p.prover, p.txBuilder, p.txSubmitter,
+		ctx, p.logger, p.sourceChainClient, p.prover, p.txBuilder, p.txSubmitter,
 		p.route.SourceClientID, v2.RelayKindAck,
 		proofHeight, events,
 	)

--- a/cli/internal/relay/processors/batch_recv_packet.go
+++ b/cli/internal/relay/processors/batch_recv_packet.go
@@ -6,6 +6,7 @@ package processors
 import (
 	"context"
 	"encoding/hex"
+	"log/slog"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,6 +29,7 @@ type BatchRecvPacket struct {
 	txBuilder              txbuilder.TxBuilder
 	txSubmitter            txsubmitter.TxSubmitter
 	storage                TxStorage
+	logger                 *slog.Logger
 }
 
 func NewBatchRecvPacket(
@@ -37,6 +39,7 @@ func NewBatchRecvPacket(
 	storage TxStorage,
 	txSubmitter txsubmitter.TxSubmitter,
 	route Route,
+	logger *slog.Logger,
 ) (BatchRecvPacket, error) {
 	sourceChainClient, ok := chainClients.Get(route.SourceChainID)
 	if !ok {
@@ -70,6 +73,7 @@ func NewBatchRecvPacket(
 		txBuilder:              txBuilder,
 		txSubmitter:            txSubmitter,
 		storage:                storage,
+		logger:                 logger,
 	}, nil
 }
 
@@ -116,7 +120,7 @@ func (p BatchRecvPacket) Process(ctx context.Context, transfers []*Transfer) ([]
 	}
 
 	submission, err := relayPackets(
-		ctx, p.destinationChainClient, p.prover, p.txBuilder, p.txSubmitter,
+		ctx, p.logger, p.destinationChainClient, p.prover, p.txBuilder, p.txSubmitter,
 		p.route.DestinationClientID, v2.RelayKindRecv,
 		proofHeight, events,
 	)

--- a/cli/internal/relay/processors/batch_recv_packet_test.go
+++ b/cli/internal/relay/processors/batch_recv_packet_test.go
@@ -125,6 +125,7 @@ func TestBatchRecvPacketSequenceAlignment(t *testing.T) {
 		db,
 		txSubmitter,
 		route,
+		slog.Default(),
 	)
 	require.NoError(t, err)
 
@@ -222,6 +223,7 @@ func TestBatchRecvPacketToleratesPartialEventFetchFailure(t *testing.T) {
 		db,
 		txSubmitter,
 		route,
+		slog.Default(),
 	)
 	require.NoError(t, err)
 
@@ -327,6 +329,7 @@ func TestBatchRecvPacketExcludesNotYetProvablePackets(t *testing.T) {
 		db,
 		txSubmitter,
 		route,
+		slog.Default(),
 	)
 	require.NoError(t, err)
 

--- a/cli/internal/relay/processors/batch_relay.go
+++ b/cli/internal/relay/processors/batch_relay.go
@@ -4,6 +4,7 @@ package processors
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
@@ -70,6 +71,7 @@ func proofKindFor(relayKind v2.RelayKind) v2.ProofKind {
 // via txSubmitter
 func relayPackets(
 	ctx context.Context,
+	logger *slog.Logger,
 	chainClient chains.Client,
 	prover prover.Prover,
 	txBuilder txbuilder.TxBuilder,
@@ -79,6 +81,14 @@ func relayPackets(
 	proofHeight uint64,
 	events []v2.PacketEvent,
 ) (*v2.Submission, error) {
+	sequences := make([]uint64, len(events))
+	for i, event := range events {
+		sequences[i] = event.Packet.Sequence
+	}
+
+	logger = logger.With("kind", relayKind, "clientID", clientID, "proofHeight", proofHeight, "sequences", sequences)
+	logger.Debug("Relaying packets")
+
 	stateProof, err := prover.StateProof(ctx, proofHeight)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating state proof")
@@ -133,6 +143,8 @@ func relayPackets(
 	if err != nil {
 		return nil, errors.Wrap(err, "submitting relay tx")
 	}
+
+	logger.Info("Relayed packets", "txHash", submission.TxHash)
 
 	return submission, nil
 }

--- a/cli/internal/relay/processors/timeout_packet.go
+++ b/cli/internal/relay/processors/timeout_packet.go
@@ -5,6 +5,7 @@ package processors
 import (
 	"context"
 	"encoding/hex"
+	"log/slog"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -26,6 +27,7 @@ type BatchTimeoutPacket struct {
 	txBuilder         txbuilder.TxBuilder
 	txSubmitter       txsubmitter.TxSubmitter
 	storage           TxStorage
+	logger            *slog.Logger
 }
 
 func NewBatchTimeoutPacket(
@@ -35,6 +37,7 @@ func NewBatchTimeoutPacket(
 	storage TxStorage,
 	txSubmitter txsubmitter.TxSubmitter,
 	route Route,
+	logger *slog.Logger,
 ) (BatchTimeoutPacket, error) {
 	sourceChainClient, ok := chainClients.Get(route.SourceChainID)
 	if !ok {
@@ -60,6 +63,7 @@ func NewBatchTimeoutPacket(
 		txBuilder:         txBuilder,
 		txSubmitter:       txSubmitter,
 		storage:           storage,
+		logger:            logger,
 	}, nil
 }
 
@@ -111,7 +115,7 @@ func (p BatchTimeoutPacket) Process(ctx context.Context, transfers []*Transfer) 
 	}
 
 	submission, err := relayPackets(
-		ctx, p.sourceChainClient, p.prover, p.txBuilder, p.txSubmitter,
+		ctx, p.logger, p.sourceChainClient, p.prover, p.txBuilder, p.txSubmitter,
 		p.route.SourceClientID, v2.RelayKindTimeout,
 		proofHeight, events,
 	)

--- a/cli/internal/relay/prover/attestation/generator.go
+++ b/cli/internal/relay/prover/attestation/generator.go
@@ -4,6 +4,7 @@ package attestation
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/pkg/errors"
@@ -23,18 +24,29 @@ type Generator struct {
 	attestors         []attestor.Attestor
 	threshold         int
 	counterpartyChain chains.Client
+	logger            *slog.Logger
 }
 
-func New(attestors []attestor.Attestor, threshold int, counterpartyChain chains.Client) *Generator {
-	return &Generator{attestors: attestors, threshold: threshold, counterpartyChain: counterpartyChain}
+func New(
+	attestors []attestor.Attestor,
+	threshold int,
+	counterpartyChain chains.Client,
+	logger *slog.Logger,
+) *Generator {
+	return &Generator{
+		attestors:         attestors,
+		threshold:         threshold,
+		counterpartyChain: counterpartyChain,
+		logger:            logger,
+	}
 }
 
 func (g *Generator) LatestProvableHeight(ctx context.Context) (uint64, time.Time, error) {
-	return latestProvableHeight(ctx, g.attestors, g.threshold, g.counterpartyChain)
+	return latestProvableHeight(ctx, g.logger, g.attestors, g.threshold, g.counterpartyChain)
 }
 
 func (g *Generator) StateProof(ctx context.Context, height uint64) ([]byte, error) {
-	result, err := queryStateQuorum(ctx, g.attestors, g.threshold, height)
+	result, err := queryStateQuorum(ctx, g.logger, g.attestors, g.threshold, height)
 	if err != nil {
 		return nil, errors.Wrap(err, "querying state attestation quorum")
 	}
@@ -82,7 +94,7 @@ func (g *Generator) PacketProofs(
 		encodedPackets[i] = encoded
 	}
 
-	result, err := queryPacketQuorum(ctx, g.attestors, g.threshold, encodedPackets, height, commitmentType)
+	result, err := queryPacketQuorum(ctx, g.logger, g.attestors, g.threshold, encodedPackets, height, commitmentType)
 	if err != nil {
 		return nil, errors.Wrap(err, "querying packet attestation quorum")
 	}

--- a/cli/internal/relay/prover/attestation/generator_test.go
+++ b/cli/internal/relay/prover/attestation/generator_test.go
@@ -4,6 +4,7 @@ package attestation
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -81,7 +82,7 @@ func TestGeneratorStateProof(t *testing.T) {
 			signedStateAttestor(t, "a2", 10),
 		}
 
-		gen := New(attestors, 2, nil)
+		gen := New(attestors, 2, nil, slog.Default())
 
 		proof, err := gen.StateProof(ctx, 10)
 		require.NoError(t, err)
@@ -94,7 +95,7 @@ func TestGeneratorStateProof(t *testing.T) {
 			signedStateAttestor(t, "a2", 10),
 		}
 
-		gen := New(attestors, 2, nil)
+		gen := New(attestors, 2, nil, slog.Default())
 
 		_, err := gen.StateProof(ctx, 11)
 		require.Error(t, err)
@@ -120,7 +121,7 @@ func TestGeneratorPacketProofs(t *testing.T) {
 			signedPacketAttestor(t, "a2", 20, compact),
 		}
 
-		gen := New(attestors, 2, nil)
+		gen := New(attestors, 2, nil, slog.Default())
 
 		proofs, err := gen.PacketProofs(ctx, 20, v2.ProofKindPacketCommitment, packets)
 		require.NoError(t, err)
@@ -131,7 +132,7 @@ func TestGeneratorPacketProofs(t *testing.T) {
 	t.Run("unsupportedKindErrors", func(t *testing.T) {
 		// an unsupported kind must be rejected before ever querying an
 		// attestor, so the generator here is given no attestors at all.
-		gen := New(nil, 2, nil)
+		gen := New(nil, 2, nil, slog.Default())
 
 		_, err := gen.PacketProofs(ctx, 20, v2.ProofKindUnknown, packets)
 		require.Error(t, err)
@@ -151,7 +152,7 @@ func TestGeneratorLatestProvableHeight(t *testing.T) {
 		GetBlockHeader(mock.Anything, uint64(90)).
 		Return(v2.BlockHeader{Timestamp: someBlockTime}, nil)
 
-	gen := New(attestors, 2, counterpartyChain)
+	gen := New(attestors, 2, counterpartyChain, slog.Default())
 
 	height, timestamp, err := gen.LatestProvableHeight(ctx)
 	require.NoError(t, err)

--- a/cli/internal/relay/prover/attestation/quorum.go
+++ b/cli/internal/relay/prover/attestation/quorum.go
@@ -4,6 +4,7 @@ package attestation
 
 import (
 	"context"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -27,11 +28,12 @@ type quorumResult struct {
 // queryStateQuorum aggregates a StateAttestation claim across attestors.
 func queryStateQuorum(
 	ctx context.Context,
+	logger *slog.Logger,
 	attestors []attestor.Attestor,
 	threshold int,
 	height uint64,
 ) (quorumResult, error) {
-	return queryQuorum(ctx, attestors, threshold, attestorevm.TagStateAttestation, func(
+	return queryQuorum(ctx, logger, attestors, threshold, attestorevm.TagStateAttestation, func(
 		ctx context.Context,
 		a attestor.Attestor,
 	) (attestor.Attestation, error) {
@@ -42,13 +44,14 @@ func queryStateQuorum(
 // queryPacketQuorum aggregates a PacketAttestation claim across attestors.
 func queryPacketQuorum(
 	ctx context.Context,
+	logger *slog.Logger,
 	attestors []attestor.Attestor,
 	threshold int,
 	packets [][]byte,
 	height uint64,
 	kind attestor.CommitmentType,
 ) (quorumResult, error) {
-	return queryQuorum(ctx, attestors, threshold, attestorevm.TagPacketAttestation, func(
+	return queryQuorum(ctx, logger, attestors, threshold, attestorevm.TagPacketAttestation, func(
 		ctx context.Context,
 		a attestor.Attestor,
 	) (attestor.Attestation, error) {
@@ -77,6 +80,7 @@ type quorumResponse struct {
 // the number of distinct signers to reach threshold.
 func queryQuorum(
 	ctx context.Context,
+	logger *slog.Logger,
 	attestors []attestor.Attestor,
 	threshold int,
 	typeTag byte,
@@ -96,18 +100,25 @@ func queryQuorum(
 		go func(i int, a attestor.Attestor) {
 			defer wg.Done()
 
-			responses[i] = queryOne(ctx, a, typeTag, query)
+			responses[i] = queryOne(ctx, logger, a, typeTag, query)
 		}(i, a)
 	}
 
 	wg.Wait()
 
-	return reduceQuorum(responses, threshold)
+	return reduceQuorum(logger, responses, threshold)
 }
 
-func queryOne(ctx context.Context, a attestor.Attestor, typeTag byte, query attestationQuery) quorumResponse {
+func queryOne(
+	ctx context.Context,
+	logger *slog.Logger,
+	a attestor.Attestor,
+	typeTag byte,
+	query attestationQuery,
+) quorumResponse {
 	attestation, err := query(ctx, a)
 	if err != nil {
+		logger.Warn("Attestor query failed", "attestor", a.Name(), "err", err)
 		return quorumResponse{name: a.Name(), err: errors.Wrapf(err, "attestor %q", a.Name())}
 	}
 
@@ -116,6 +127,7 @@ func queryOne(ctx context.Context, a attestor.Attestor, typeTag byte, query atte
 
 	signer, err := attestorevm.RecoverSigner(attestorevm.Digest(typeTag, data), sig)
 	if err != nil {
+		logger.Warn("Attestor returned an unrecoverable signature", "attestor", a.Name(), "err", err)
 		return quorumResponse{name: a.Name(), err: errors.Wrapf(err, "attestor %q", a.Name())}
 	}
 
@@ -124,7 +136,7 @@ func queryOne(ctx context.Context, a attestor.Attestor, typeTag byte, query atte
 
 // reduceQuorum groups responses by their exact attestationData value
 // and returns the first value whose distinct signers reach threshold.
-func reduceQuorum(responses []quorumResponse, threshold int) (quorumResult, error) {
+func reduceQuorum(logger *slog.Logger, responses []quorumResponse, threshold int) (quorumResult, error) {
 	buckets := make(map[string][]quorumResponse)
 
 	for _, resp := range responses {
@@ -150,6 +162,20 @@ func reduceQuorum(responses []quorumResponse, threshold int) (quorumResult, erro
 		}
 
 		if len(signatures) >= threshold {
+			// quorum is met, but flag any attestors that did not contribute so a
+			// degrading set is visible before it drops below threshold
+			if len(signatures) < len(responses) {
+				logger.Warn(
+					"Attestation quorum met with some attestors excluded",
+					"signatures", len(signatures),
+					"attestors", len(responses),
+					"threshold", threshold,
+					"reasons", joinResponseErrors(responses),
+				)
+			} else {
+				logger.Debug("Attestation quorum met", "signatures", len(signatures), "threshold", threshold)
+			}
+
 			return quorumResult{AttestationData: bucket[0].data, Signatures: signatures}, nil
 		}
 	}
@@ -184,6 +210,7 @@ func joinResponseErrors(responses []quorumResponse) string {
 // that answered, requiring at least threshold of them to respond.
 func latestProvableHeight(
 	ctx context.Context,
+	logger *slog.Logger,
 	attestors []attestor.Attestor,
 	threshold int,
 	counterpartyChain chains.Client,
@@ -235,6 +262,16 @@ func latestProvableHeight(
 		return 0, time.Time{}, errors.Errorf(
 			"latest height quorum not met: got %d of %d required responses (%s)",
 			len(heights), threshold, strings.Join(errMsgs, "; "),
+		)
+	}
+
+	if len(errMsgs) > 0 {
+		logger.Warn(
+			"Some attestors did not report a latest height",
+			"responded", len(heights),
+			"attestors", len(attestors),
+			"threshold", threshold,
+			"reasons", strings.Join(errMsgs, "; "),
 		)
 	}
 

--- a/cli/internal/relay/prover/attestation/quorum_test.go
+++ b/cli/internal/relay/prover/attestation/quorum_test.go
@@ -4,6 +4,7 @@ package attestation
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func TestQueryQuorum(t *testing.T) {
 			signedAttestor(t, "a2", data),
 		}
 
-		result, err := queryStateQuorum(ctx, attestors, 2, 10)
+		result, err := queryStateQuorum(ctx, slog.Default(), attestors, 2, 10)
 		require.NoError(t, err)
 		require.Equal(t, data, result.AttestationData)
 		require.Len(t, result.Signatures, 2)
@@ -61,7 +62,7 @@ func TestQueryQuorum(t *testing.T) {
 			signedAttestor(t, "a1", data),
 		}
 
-		_, err := queryStateQuorum(ctx, attestors, 2, 10)
+		_, err := queryStateQuorum(ctx, slog.Default(), attestors, 2, 10)
 		require.ErrorContains(t, err, "quorum not met")
 	})
 
@@ -71,7 +72,7 @@ func TestQueryQuorum(t *testing.T) {
 			signedAttestor(t, "a2", []byte("a different claim entirely")),
 		}
 
-		_, err := queryStateQuorum(ctx, attestors, 2, 10)
+		_, err := queryStateQuorum(ctx, slog.Default(), attestors, 2, 10)
 		require.ErrorContains(
 			t,
 			err,
@@ -91,7 +92,7 @@ func TestQueryQuorum(t *testing.T) {
 			signedAttestor(t, "a3", data),
 		}
 
-		result, err := queryStateQuorum(ctx, attestors, 2, 10)
+		result, err := queryStateQuorum(ctx, slog.Default(), attestors, 2, 10)
 		require.NoError(t, err)
 		require.Equal(t, data, result.AttestationData)
 		require.Len(t, result.Signatures, 2)
@@ -108,7 +109,7 @@ func TestQueryQuorum(t *testing.T) {
 			erroring,
 		}
 
-		result, err := queryStateQuorum(ctx, attestors, 2, 10)
+		result, err := queryStateQuorum(ctx, slog.Default(), attestors, 2, 10)
 		require.NoError(t, err)
 		require.Len(t, result.Signatures, 2)
 	})
@@ -127,7 +128,7 @@ func TestQueryQuorum(t *testing.T) {
 		}
 
 		// threshold 2 still met by the two valid attestors despite the bad one
-		result, err := queryStateQuorum(ctx, attestors, 2, 10)
+		result, err := queryStateQuorum(ctx, slog.Default(), attestors, 2, 10)
 		require.NoError(t, err)
 		require.Len(t, result.Signatures, 2)
 	})
@@ -155,7 +156,7 @@ func TestQueryQuorum(t *testing.T) {
 			makeAttestor("a2-same-key"),
 		}
 
-		_, err = queryStateQuorum(ctx, attestors, 2, 10)
+		_, err = queryStateQuorum(ctx, slog.Default(), attestors, 2, 10)
 		require.ErrorContains(
 			t,
 			err,
@@ -205,7 +206,7 @@ func TestLatestProvableHeight(t *testing.T) {
 			GetBlockHeader(mock.Anything, uint64(100)).
 			Return(v2.BlockHeader{Timestamp: someBlockTime}, nil)
 
-		height, timestamp, err := latestProvableHeight(ctx, attestors, 2, counterpartyChain)
+		height, timestamp, err := latestProvableHeight(ctx, slog.Default(), attestors, 2, counterpartyChain)
 		require.NoError(t, err)
 		require.Equal(
 			t,
@@ -228,7 +229,7 @@ func TestLatestProvableHeight(t *testing.T) {
 			GetBlockHeader(mock.Anything, uint64(95)).
 			Return(v2.BlockHeader{Timestamp: someBlockTime}, nil)
 
-		height, _, err := latestProvableHeight(ctx, attestors, 2, counterpartyChain)
+		height, _, err := latestProvableHeight(ctx, slog.Default(), attestors, 2, counterpartyChain)
 		require.NoError(t, err)
 		require.Equal(t, uint64(95), height)
 	})
@@ -244,7 +245,7 @@ func TestLatestProvableHeight(t *testing.T) {
 		// before ever consulting the chain
 		counterpartyChain := mocks.NewMockClient(t)
 
-		_, _, err := latestProvableHeight(ctx, attestors, 2, counterpartyChain)
+		_, _, err := latestProvableHeight(ctx, slog.Default(), attestors, 2, counterpartyChain)
 		require.ErrorContains(t, err, "quorum not met")
 	})
 
@@ -257,7 +258,7 @@ func TestLatestProvableHeight(t *testing.T) {
 		counterpartyChain := mocks.NewMockClient(t)
 		counterpartyChain.EXPECT().GetBlockHeader(mock.Anything, uint64(100)).Return(v2.BlockHeader{}, assert.AnError)
 
-		_, _, err := latestProvableHeight(ctx, attestors, 2, counterpartyChain)
+		_, _, err := latestProvableHeight(ctx, slog.Default(), attestors, 2, counterpartyChain)
 		require.ErrorContains(t, err, "getting header")
 	})
 }

--- a/cli/internal/relay/prover/attestation/resolve.go
+++ b/cli/internal/relay/prover/attestation/resolve.go
@@ -5,6 +5,7 @@ package attestation
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -22,6 +23,7 @@ func ResolveGenerator(
 	self, counterparty config.ClientEnd,
 	clientSet *chains.ClientSet,
 	attestors []attestor.Attestor,
+	logger *slog.Logger,
 ) (*Generator, error) {
 	matched, minRequiredSigs, err := MatchAttestors(ctx, self, counterparty, clientSet, attestors)
 	if err != nil {
@@ -33,7 +35,7 @@ func ResolveGenerator(
 		return nil, errors.Errorf("no configured chain client for counterparty chain %q", counterparty.ChainID)
 	}
 
-	return New(matched, int(minRequiredSigs), counterpartyChain), nil
+	return New(matched, int(minRequiredSigs), counterpartyChain, logger), nil
 }
 
 // MatchAttestors resolves self's on-chain attestation set and returns the

--- a/cli/internal/relay/prover/attestation/resolve_test.go
+++ b/cli/internal/relay/prover/attestation/resolve_test.go
@@ -4,6 +4,7 @@ package attestation
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -61,7 +62,14 @@ func TestResolveGenerator(t *testing.T) {
 
 		candidate := localCandidate(t, "watches-b", conn.ClientB.ChainID, "0xAAA")
 
-		gen, err := ResolveGenerator(ctx, conn.ClientA, conn.ClientB, clientSet, []attestor.Attestor{candidate})
+		gen, err := ResolveGenerator(
+			ctx,
+			conn.ClientA,
+			conn.ClientB,
+			clientSet,
+			[]attestor.Attestor{candidate},
+			slog.Default(),
+		)
 
 		require.NoError(t, err, "address match is case-insensitive")
 		require.NotNil(t, gen)
@@ -79,7 +87,14 @@ func TestResolveGenerator(t *testing.T) {
 
 		candidate := localCandidate(t, "watcher", conn.ClientB.ChainID, "0xaaa")
 
-		_, err := ResolveGenerator(ctx, conn.ClientA, conn.ClientB, clientSet, []attestor.Attestor{candidate})
+		_, err := ResolveGenerator(
+			ctx,
+			conn.ClientA,
+			conn.ClientB,
+			clientSet,
+			[]attestor.Attestor{candidate},
+			slog.Default(),
+		)
 
 		require.ErrorContains(t, err, `only 1 reachable/matching attestors for chain "8453"`)
 		require.ErrorContains(t, err, "on-chain quorum requires 2")
@@ -99,7 +114,14 @@ func TestResolveGenerator(t *testing.T) {
 		first := localCandidate(t, "watcher-1", conn.ClientB.ChainID, "0xaaa")
 		second := localCandidate(t, "watcher-2", conn.ClientB.ChainID, "0xAAA")
 
-		_, err := ResolveGenerator(ctx, conn.ClientA, conn.ClientB, clientSet, []attestor.Attestor{first, second})
+		_, err := ResolveGenerator(
+			ctx,
+			conn.ClientA,
+			conn.ClientB,
+			clientSet,
+			[]attestor.Attestor{first, second},
+			slog.Default(),
+		)
 
 		require.ErrorContains(t, err, `attestors "watcher-1" and "watcher-2" share address "0xAAA"`)
 	})
@@ -115,7 +137,14 @@ func TestResolveGenerator(t *testing.T) {
 		// address not registered on-chain
 		candidate := localCandidate(t, "watcher", conn.ClientB.ChainID, "0xdeadbeef")
 
-		_, err := ResolveGenerator(ctx, conn.ClientA, conn.ClientB, clientSet, []attestor.Attestor{candidate})
+		_, err := ResolveGenerator(
+			ctx,
+			conn.ClientA,
+			conn.ClientB,
+			clientSet,
+			[]attestor.Attestor{candidate},
+			slog.Default(),
+		)
 
 		require.ErrorContains(t, err, "only 0 reachable/matching attestors")
 	})
@@ -131,7 +160,14 @@ func TestResolveGenerator(t *testing.T) {
 		// wrong chain, despite matching address
 		candidate := localCandidate(t, "watcher", "some-other-chain", "0xaaa")
 
-		_, err := ResolveGenerator(ctx, conn.ClientA, conn.ClientB, clientSet, []attestor.Attestor{candidate})
+		_, err := ResolveGenerator(
+			ctx,
+			conn.ClientA,
+			conn.ClientB,
+			clientSet,
+			[]attestor.Attestor{candidate},
+			slog.Default(),
+		)
 
 		require.ErrorContains(t, err, "only 0 reachable/matching attestors")
 	})
@@ -140,7 +176,7 @@ func TestResolveGenerator(t *testing.T) {
 		conn := testConnection()
 		clientSet := chains.NewClientSet(nil)
 
-		_, err := ResolveGenerator(ctx, conn.ClientA, conn.ClientB, clientSet, nil)
+		_, err := ResolveGenerator(ctx, conn.ClientA, conn.ClientB, clientSet, nil, slog.Default())
 
 		require.ErrorContains(t, err, `no configured chain client for "1"`)
 	})
@@ -153,7 +189,7 @@ func TestResolveGenerator(t *testing.T) {
 
 		clientSet := chains.NewClientSet(map[string]chains.Client{conn.ClientA.ChainID: selfChain})
 
-		_, err := ResolveGenerator(ctx, conn.ClientA, conn.ClientB, clientSet, nil)
+		_, err := ResolveGenerator(ctx, conn.ClientA, conn.ClientB, clientSet, nil, slog.Default())
 
 		require.ErrorContains(t, err, `no configured chain client for counterparty chain "8453"`)
 	})

--- a/cli/internal/relay/prover/prover.go
+++ b/cli/internal/relay/prover/prover.go
@@ -7,6 +7,7 @@ package prover
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/pkg/errors"
@@ -76,11 +77,12 @@ func NewSetFromConfig(
 	cfg config.Config,
 	clientSet *chains.ClientSet,
 	attestors []attestor.Attestor,
+	logger *slog.Logger,
 ) (*Set, error) {
 	generators := make(map[string]Prover, len(cfg.Relayer.Connections)*2)
 
 	err := forEachClientEnd(cfg, func(connAlias string, self, counterparty config.ClientEnd) error {
-		return addGenerator(ctx, generators, connAlias, self, counterparty, clientSet, attestors)
+		return addGenerator(ctx, generators, connAlias, self, counterparty, clientSet, attestors, logger)
 	})
 	if err != nil {
 		return nil, err
@@ -115,10 +117,13 @@ func addGenerator(
 	client, clientCounterparty config.ClientEnd,
 	clientSet *chains.ClientSet,
 	attestors []attestor.Attestor,
+	logger *slog.Logger,
 ) error {
+	logger = logger.With("module", "prover", "chainID", client.ChainID, "clientID", client.ClientID)
+
 	switch client.Type {
 	case config.ClientTypeAttestation:
-		gen, err := attestation.ResolveGenerator(ctx, client, clientCounterparty, clientSet, attestors)
+		gen, err := attestation.ResolveGenerator(ctx, client, clientCounterparty, clientSet, attestors, logger)
 		if err != nil {
 			return err
 		}
@@ -138,7 +143,7 @@ func addGenerator(
 		}
 
 		generators[Key(client.ChainID, client.ClientID)] = remote.NewFromURL(
-			remoteParams.URL, client.ChainID, client.ClientID,
+			remoteParams.URL, client.ChainID, client.ClientID, logger,
 		)
 
 		return nil

--- a/cli/internal/relay/prover/prover_test.go
+++ b/cli/internal/relay/prover/prover_test.go
@@ -4,6 +4,7 @@ package prover
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -85,7 +86,7 @@ func TestNewSetFromConfig(t *testing.T) {
 		cfg, clientSet, attestors := testConfig(t)
 		conn := cfg.Relayer.Connections[0]
 
-		set, err := NewSetFromConfig(ctx, cfg, clientSet, attestors)
+		set, err := NewSetFromConfig(ctx, cfg, clientSet, attestors, slog.Default())
 		require.NoError(t, err)
 
 		_, ok := set.Get(conn.ClientA.ChainID, conn.ClientA.ClientID)
@@ -109,7 +110,7 @@ func TestNewSetFromConfig(t *testing.T) {
 		cfg := config.Config{Relayer: config.RelayerConfig{Connections: []config.ConnectionConfig{conn}}}
 
 		// ACT
-		_, err := NewSetFromConfig(ctx, cfg, clientSet, nil)
+		_, err := NewSetFromConfig(ctx, cfg, clientSet, nil, slog.Default())
 
 		// ASSERT
 		require.ErrorContains(t, err, `unsupported client type "tendermint"`)

--- a/cli/internal/relay/prover/remote/remote.go
+++ b/cli/internal/relay/prover/remote/remote.go
@@ -6,6 +6,7 @@ package remote
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -25,20 +26,22 @@ type Prover struct {
 	client   proverv2.ProverServiceClient
 	chainID  string
 	clientID string
+	logger   *slog.Logger
 }
 
-func New(httpClient connect.HTTPClient, url, chainID, clientID string) *Prover {
+func New(httpClient connect.HTTPClient, url, chainID, clientID string, logger *slog.Logger) *Prover {
 	return &Prover{
 		client:   proverv2.NewProverServiceClient(httpClient, url, connect.WithGRPC()),
 		chainID:  chainID,
 		clientID: clientID,
+		logger:   logger.With("module", "remoteProver", "chainID", chainID, "clientID", clientID, "url", url),
 	}
 }
 
 // NewFromURL dials url with a client that can negotiate h2c, which gRPC
 // requires over plaintext.
-func NewFromURL(url, chainID, clientID string) *Prover {
-	return New(newHTTPClient(), url, chainID, clientID)
+func NewFromURL(url, chainID, clientID string, logger *slog.Logger) *Prover {
+	return New(newHTTPClient(), url, chainID, clientID, logger)
 }
 
 func newHTTPClient() *http.Client {
@@ -67,6 +70,8 @@ func (p *Prover) LatestProvableHeight(ctx context.Context) (uint64, time.Time, e
 	//nolint:gosec // seconds since the epoch, matching the ibc packet timestamp
 	seconds := int64(res.Msg.GetTimestamp())
 
+	p.logger.Debug("Resolved latest provable height", "height", res.Msg.GetHeight())
+
 	return res.Msg.GetHeight(), time.Unix(seconds, 0).UTC(), nil
 }
 
@@ -81,6 +86,8 @@ func (p *Prover) StateProof(ctx context.Context, height uint64) ([]byte, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "remote prover: state proof")
 	}
+
+	p.logger.Debug("Fetched state proof", "height", height)
 
 	return res.Msg.GetProof(), nil
 }
@@ -115,6 +122,8 @@ func (p *Prover) PacketProofs(
 			"remote prover returned %d proofs for %d packets", len(proofs), len(packets),
 		)
 	}
+
+	p.logger.Debug("Fetched packet proofs", "height", height, "kind", kind, "packets", len(packets))
 
 	return proofs, nil
 }

--- a/cli/internal/relay/prover/remote/remote_test.go
+++ b/cli/internal/relay/prover/remote/remote_test.go
@@ -4,6 +4,7 @@ package remote
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 
 func TestProverRequestTimeout(t *testing.T) {
 	client := timeoutProverClient{t: t}
-	prover := &Prover{client: client, chainID: "chain-a", clientID: "client-0"}
+	prover := &Prover{client: client, chainID: "chain-a", clientID: "client-0", logger: slog.Default()}
 	ctx := context.Background()
 
 	_, _, err := prover.LatestProvableHeight(ctx)

--- a/cli/internal/testutil/proverservice/server.go
+++ b/cli/internal/testutil/proverservice/server.go
@@ -95,7 +95,14 @@ func NewAttestationServer(ctx context.Context, configPath string) (*http.Server,
 			{conn.ClientA, conn.ClientB},
 			{conn.ClientB, conn.ClientA},
 		} {
-			gen, resolveErr := attestation.ResolveGenerator(ctx, end.self, end.counterparty, clients, attestors)
+			gen, resolveErr := attestation.ResolveGenerator(
+				ctx,
+				end.self,
+				end.counterparty,
+				clients,
+				attestors,
+				slog.Default(),
+			)
 			if resolveErr != nil {
 				return nil, errors.Wrapf(resolveErr, "connection %q", conn.Alias)
 			}

--- a/cli/internal/testutil/proverservice/server_test.go
+++ b/cli/internal/testutil/proverservice/server_test.go
@@ -4,6 +4,7 @@ package proverservice
 
 import (
 	"context"
+	"log/slog"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -57,7 +58,7 @@ func newClient(t *testing.T, set *prover.Set, chainID, clientID string) *remote.
 	server.StartTLS()
 	t.Cleanup(server.Close)
 
-	return remote.New(server.Client(), server.URL, chainID, clientID)
+	return remote.New(server.Client(), server.URL, chainID, clientID, slog.Default())
 }
 
 // A custom light client is reached only through this contract, so the round trip

--- a/cli/internal/types/v2/types.go
+++ b/cli/internal/types/v2/types.go
@@ -51,6 +51,19 @@ const (
 	RelayKindTimeout
 )
 
+func (k RelayKind) String() string {
+	switch k {
+	case RelayKindRecv:
+		return "recv"
+	case RelayKindAck:
+		return "ack"
+	case RelayKindTimeout:
+		return "timeout"
+	default:
+		return "unknown"
+	}
+}
+
 // PacketRelayItem one packet operation to include in a relay tx, along with
 // the membership/non-membership proof authorizing it.
 type PacketRelayItem struct {


### PR DESCRIPTION
Adds some logging to the attestor/relayer.


Most of this PR is just threading the logger through, with a couple of additions of info/warn and a few debug logs.