### PR TITLE
docs(cli): clarify agent codegen and e2e guidance

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -7,7 +7,7 @@
 - `gen/` at the repository root holds generated code only, and its layout is fixed by an ADR — don't
   move it or put anything handwritten there. Generator scripts belong in the root `scripts/`
   directory, not beside their output. The one exception is `gen/README.md`, which documents the tree.
-- Repository-wide black-box e2e lives in `../e2e`, with its harness in
-  `../e2e/internal/harness` as a separate Go module. The real relayer submits packets through
+- Repository-wide black-box e2e lives in `e2e/` from the repository root. Its harness
+  in `e2e/internal/harness/` is part of the `e2e/` Go module. The real relayer submits packets through
   ICS26Router with attestation proofs signed by harness-managed attestors. Keep
-  `make -C e2e test` green when changing that transport contract.
+  `make -C e2e test` green when changing that transport contract; run it from the repository root.

--- a/cli/internal/server/AGENTS.md
+++ b/cli/internal/server/AGENTS.md
@@ -2,14 +2,16 @@
 
 # ConnectRPC Guide for AI Agents
 
-Development flow:
-1. Update raw protos in `proto/cli/*`.
-2. Run `make codegen` (proto and mocks included).
-3. Implement ConnectRPC handlers in `attestor_handler.go` or `relayer_handler.go`.
-4. Add missing `AttestorService`/`RelayerService` methods if needed.
+Development flow (commands run from the repository root):
+
+1. For RPC schema changes, edit raw protos in `proto/cli/*` and run `make -C cli codegen-proto`.
+2. Implement and test ConnectRPC handlers in `attestor_handler.go` or `relayer_handler.go`.
+   Handler-only changes do not require schema edits or code generation.
+3. Add missing `AttestorService`/`RelayerService` methods if needed and run
+   `make -C cli codegen-mocks` when the service interface changes.
    - Use idiomatic Go: `ctx` first.
    - If a service method needs more than 3 args, use a DTO struct.
-5. Keep `server/` as an adapter only:
+4. Keep `server/` as an adapter only:
    - Convert ConnectRPC/proto types to service DTOs.
    - Call the service interface.
    - Map domain errors to `connect.Code*`.


### PR DESCRIPTION
The CLI guide describes the e2e harness as a separate Go module, and the server guide requires full code generation for every handler change.

Correct the harness module boundary and command working directory. Make protobuf and mock generation conditional on schema and service-interface changes, so handler-only fixes can be implemented and tested directly.

Validation: checked the referenced paths and Makefile targets against the repository and passed `git diff --check`. Builds and application tests were not run for these documentation-only changes.
