### PR TITLE
feat(relayer): allow abandoning unrecoverable packets that will never be relayed

### DIFF
--- a/cli/internal/config/relayer.go
+++ b/cli/internal/config/relayer.go
@@ -49,6 +49,10 @@ type RelayerChainOverride struct {
 // DiscoveryConfig per-chain packet discovery settings.
 type DiscoveryConfig struct {
 	ClearInterval *time.Duration `yaml:"clearInterval,omitempty"`
+	// AbandonUnrecoverablePackets stops re-probing packets whose send log the
+	// endpoint will not serve. They are remembered but never looked at again,
+	// so turning it back off recovers them against an archive endpoint.
+	AbandonUnrecoverablePackets *bool `yaml:"abandonUnrecoverablePackets,omitempty"`
 }
 
 // RelayerEVMConfig EVM relaying settings.
@@ -364,4 +368,16 @@ func (c RelayerConfig) ClearIntervalFor(chainID string) time.Duration {
 	}
 
 	return DefaultClearInterval
+}
+
+// AbandonUnrecoverablePacketsFor reports whether a chain stops re-probing
+// packets whose send log no endpoint would serve. It defaults to false, which
+// keeps them in the probe set until an endpoint serves them.
+func (c RelayerConfig) AbandonUnrecoverablePacketsFor(chainID string) bool {
+	override, ok := c.ChainOverride(chainID)
+	if ok && override.Discovery != nil && override.Discovery.AbandonUnrecoverablePackets != nil {
+		return *override.Discovery.AbandonUnrecoverablePackets
+	}
+
+	return false
 }

--- a/cli/internal/config/relayer_test.go
+++ b/cli/internal/config/relayer_test.go
@@ -511,3 +511,22 @@ db:
 		assert.Equal(t, DefaultClearInterval, config.Relayer.ClearIntervalFor("1"))
 	})
 }
+
+func TestRelayerConfigAbandonUnrecoverablePacketsFor(t *testing.T) {
+	config, err := LoadFromFile(filepath.Join("testdata", "sample.yml"), true)
+	require.NoError(t, err)
+
+	// a packet is only abandoned where an operator asked for it
+	for name, tt := range map[string]struct {
+		chainID string
+		want    bool
+	}{
+		"chain that asked for it":    {chainID: "1", want: true},
+		"chain with other overrides": {chainID: "8453"},
+		"chain with no override":     {chainID: "999"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, config.Relayer.AbandonUnrecoverablePacketsFor(tt.chainID))
+		})
+	}
+}

--- a/cli/internal/config/testdata/sample.yml
+++ b/cli/internal/config/testdata/sample.yml
@@ -38,6 +38,7 @@ relayer:
       packetBatchTimeout: 10s
       discovery:
         clearInterval: 15m
+        abandonUnrecoverablePackets: true
     - chainId: "8453"
   connections:
     - alias: "eth-base"

--- a/cli/internal/relay/watcher/clearer.go
+++ b/cli/internal/relay/watcher/clearer.go
@@ -56,6 +56,8 @@ type Result struct {
 	Recovered   int
 	// Unresolved sequences the next pass will probe again.
 	Unresolved int
+	// Abandoned sequences held on record that no pass will probe again.
+	Abandoned int
 }
 
 // Clearer recovers packets the subscription never saw. It asks the chain which
@@ -67,6 +69,7 @@ type Clearer struct {
 	routes  map[string]config.ClientEnd
 	chain   OutstandingQuerier
 	storage ClearStore
+	abandon bool
 	logger  *slog.Logger
 }
 
@@ -75,6 +78,7 @@ func NewClearer(
 	connections []config.ConnectionConfig,
 	chain OutstandingQuerier,
 	storage ClearStore,
+	clearing ClearConfig,
 	logger *slog.Logger,
 ) *Clearer {
 	return &Clearer{
@@ -82,6 +86,7 @@ func NewClearer(
 		routes:  routesOf(chainID, connections),
 		chain:   chain,
 		storage: storage,
+		abandon: clearing.AbandonUnrecoverablePackets,
 		logger:  logger.With("module", "clearer", "chainID", chainID),
 	}
 }
@@ -137,7 +142,16 @@ func (c *Clearer) Clear(ctx context.Context, clientID string) (Result, error) {
 
 	from := state.LastProbed + 1
 
+	// abandoned sequences are carried rather than probed: dropping them from the
+	// probe is what bounds the pass, and keeping them on record is what lets an
+	// operator who later has an archive endpoint recover them by turning the
+	// setting back off.
+	// ponytail: the abandoned set is read every pass and thrown away; make the
+	// query aware of the setting if anyone parks enough of them to notice.
 	reprobe := state.Unresolved
+	if c.abandon {
+		reprobe = nil
+	}
 
 	outstanding, probed, probeHeight, err := c.outstanding(ctx, clientID, reprobe, from, latest, head.Height)
 	if err != nil {
@@ -168,7 +182,11 @@ func (c *Clearer) Clear(ctx context.Context, clientID string) (Result, error) {
 	// rather than probed had nothing learned about it, so it stays untouched
 	delta := unresolvedDelta(reprobe, unresolved, probeHeight)
 
-	result.Unresolved = len(unresolved)
+	if c.abandon {
+		result.Abandoned = len(state.Unresolved) + len(delta.Add)
+	} else {
+		result.Unresolved = len(unresolved)
+	}
 
 	return result, c.persist(ctx, clientID, rows, latest, delta)
 }
@@ -204,9 +222,20 @@ func unresolvedDelta(probed, unresolved []uint64, height uint64) store.Unresolve
 }
 
 func (c *Clearer) warnUnservable(clientID string, sequences []uint64) {
+	if c.abandon {
+		c.logger.Warn(
+			"Abandoning packets whose send log no endpoint would serve: their escrow stays locked "+
+				"and no pass will look at them again until abandonUnrecoverablePackets is turned off",
+			"clientID", clientID,
+			"sequences", sequences,
+		)
+
+		return
+	}
+
 	// nothing drains this set on an endpoint that has permanently pruned the
 	// logs, so these are re-probed forever. Point the relayer at an archive
-	// endpoint.
+	// endpoint, or abandon them.
 	c.logger.Warn(
 		"Outstanding packets whose send log no endpoint would serve: their escrow stays locked "+
 			"and every pass will retry them",

--- a/cli/internal/relay/watcher/clearer_test.go
+++ b/cli/internal/relay/watcher/clearer_test.go
@@ -22,7 +22,11 @@ import (
 const waitFor = 5 * time.Second
 
 func newTestClearer(chain OutstandingQuerier, storage ClearStore) *Clearer {
-	return NewClearer(sourceChainID, testConnections(), chain, storage, slog.Default())
+	return newClearer(chain, storage, ClearConfig{})
+}
+
+func newClearer(chain OutstandingQuerier, storage ClearStore, clearing ClearConfig) *Clearer {
+	return NewClearer(sourceChainID, testConnections(), chain, storage, clearing, slog.Default())
 }
 
 // fakeChain models what one chain has sent and what is still committed at a
@@ -117,6 +121,16 @@ func (c *fakeChain) prune(sequences ...uint64) {
 
 	for _, sequence := range sequences {
 		c.pruned[sequence] = struct{}{}
+	}
+}
+
+// unprune serves the sends again, as pointing the relayer at an archive endpoint does.
+func (c *fakeChain) unprune(sequences ...uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, sequence := range sequences {
+		delete(c.pruned, sequence)
 	}
 }
 
@@ -612,6 +626,44 @@ func TestClearerClear(t *testing.T) {
 		assert.Equal(t, store.ClearingState{LastProbed: 2}, clearingState(t, db))
 	})
 
+	t.Run("anAbandonedSendIsRememberedButNotProbed", func(t *testing.T) {
+		chain := newFakeChain()
+		chain.send(1, 2)
+		chain.prune(1)
+
+		db := watcherStore(t)
+		abandoning := newClearer(chain, db, ClearConfig{AbandonUnrecoverablePackets: true})
+
+		result, err := abandoning.Clear(ctx, sourceClientID)
+		require.NoError(t, err)
+
+		assert.Equal(t, Result{Probed: 2, Outstanding: 2, Recovered: 1, Abandoned: 1}, result)
+		assert.Equal(t, []uint64{2}, recorded(t, db))
+		assert.Equal(t, store.ClearingState{LastProbed: 2, Unresolved: []uint64{1}}, clearingState(t, db))
+
+		before := len(chain.probeCalls())
+
+		result, err = abandoning.Clear(ctx, sourceClientID)
+		require.NoError(t, err)
+
+		// on record but out of the probe, so it costs the pass nothing
+		assert.Empty(t, chain.probeCalls()[before:])
+		assert.Equal(t, 1, result.Abandoned)
+		assert.Equal(t, store.ClearingState{LastProbed: 2, Unresolved: []uint64{1}}, clearingState(t, db))
+
+		// an archive endpoint turns up later: turning the setting off is the
+		// whole recovery, since the sequence was never forgotten
+		chain.unprune(1)
+
+		result, err = newTestClearer(chain, db).Clear(ctx, sourceClientID)
+		require.NoError(t, err)
+
+		assert.Equal(t, [][]uint64{{1}}, chain.probeCalls()[before:])
+		assert.Equal(t, Result{Probed: 1, Outstanding: 1, Recovered: 1}, result)
+		assert.Equal(t, []uint64{1, 2}, recorded(t, db))
+		assert.Equal(t, store.ClearingState{LastProbed: 2}, clearingState(t, db))
+	})
+
 	t.Run("aFailedRowWriteLeavesNoWatermark", func(t *testing.T) {
 		chain := newFakeChain()
 		chain.send(1, 2)
@@ -705,8 +757,10 @@ func TestUnresolvedDelta(t *testing.T) {
 		"resolve":     {probed: []uint64{5, 9}, unresolved: []uint64{9}, resolve: []uint64{5}},
 		"replaced":    {probed: []uint64{5}, unresolved: []uint64{9}, add: []uint64{9}, resolve: []uint64{5}},
 		"allResolved": {probed: []uint64{5, 9}, resolve: []uint64{5, 9}},
-		"firstSeen":   {unresolved: []uint64{9}, add: []uint64{9}},
-		"bothEmpty":   {},
+		// a pass that probed nothing held, which is what abandoning does, must
+		// resolve nothing: it learned nothing about the set it carried
+		"nothingProbed": {unresolved: []uint64{9}, add: []uint64{9}},
+		"bothEmpty":     {},
 	} {
 		t.Run(name, func(t *testing.T) {
 			delta := unresolvedDelta(tt.probed, tt.unresolved, 42)

--- a/cli/internal/relay/watcher/set.go
+++ b/cli/internal/relay/watcher/set.go
@@ -42,8 +42,9 @@ func NewSetFromConfig(
 			client,
 			storage,
 			ClearConfig{
-				OnStart:  cfg.Relayer.ClearOnStartEnabled(),
-				Interval: cfg.Relayer.ClearIntervalFor(chain.ChainID),
+				OnStart:                     cfg.Relayer.ClearOnStartEnabled(),
+				Interval:                    cfg.Relayer.ClearIntervalFor(chain.ChainID),
+				AbandonUnrecoverablePackets: cfg.Relayer.AbandonUnrecoverablePacketsFor(chain.ChainID),
 			},
 			DefaultMinBackoff,
 			DefaultMaxBackoff,

--- a/cli/internal/relay/watcher/watcher.go
+++ b/cli/internal/relay/watcher/watcher.go
@@ -39,6 +39,9 @@ type ClearConfig struct {
 	OnStart bool
 	// Interval how often a pass runs after that.
 	Interval time.Duration
+	// AbandonUnrecoverablePackets drops packets whose send log the endpoint will
+	// not serve out of the probe set, keeping the record of them.
+	AbandonUnrecoverablePackets bool
 }
 
 // Watcher records a packet row for every SendPacket event one chain emits on
@@ -92,7 +95,7 @@ func New(
 		routes:     routesOf(chainID, connections),
 		subscriber: subscriber,
 		storage:    storage,
-		clearer:    NewClearer(chainID, connections, querier, storage, logger),
+		clearer:    NewClearer(chainID, connections, querier, storage, clearing, logger),
 		clearing:   clearing,
 		minBackoff: minBackoff,
 		maxBackoff: maxBackoff,
@@ -322,6 +325,7 @@ func (w *Watcher) clear(ctx context.Context) {
 			"alreadyHeld", result.AlreadyHeld,
 			"recovered", result.Recovered,
 			"unresolved", result.Unresolved,
+			"abandoned", result.Abandoned,
 			"took", time.Since(started),
 		)
 	}

--- a/docs/6-ibc-cli/5-configuration.md
+++ b/docs/6-ibc-cli/5-configuration.md
@@ -197,7 +197,7 @@ With `autoRelay.enabled` on an end, the relayer carries that end's outgoing pack
 
 Auto-relaying discovers packets two ways: a websocket subscription to `SendPacket` on the source chain, and a periodic clearing pass that reads live packet commitments from the router and picks up anything the subscription missed. A pass also runs immediately after a subscription reconnect, regardless of `clearOnStart`, because a dropped connection is a known gap.
 
-A pass probes the sequences sent since the last pass, plus anything an earlier pass could not resolve, and records how far it got. Its cost tracks how much a client has sent between passes rather than over its lifetime; only the first pass on a client walks its whole sequence range. The watermark is shared, so several relayer processes can run against one database without either of them probing what the other already did. Turning `autoRelay` on for a client that has already sent packets is therefore not a fresh start: that first pass covers the client's entire sequence range, so every packet still outstanding on it gets relayed, including ones sent before the route existed. Clearing skips any sequence the relayer already holds a row for, whatever state that row is in, so it does not retry packets that have already failed.
+A pass probes the sequences sent since the last pass, plus anything an earlier pass could not resolve, and records how far it got. Its cost tracks how much a client has sent between passes rather than over its lifetime; only the first pass on a client walks its whole sequence range. Both the watermark and the commitment probes are read at `latest`. The watermark is shared, so several relayer processes can run against one database without either of them probing what the other already did. Turning `autoRelay` on for a client that has already sent packets is therefore not a fresh start: that first pass covers the client's entire sequence range, so every packet still outstanding on it gets relayed, including ones sent before the route existed. Clearing skips any sequence the relayer already holds a row for, whatever state that row is in, so it does not retry packets that have already failed.
 
 ### Relay settings
 
@@ -226,6 +226,7 @@ The relayer uses these defaults unless you override them.
 | `chainOverrides[].evm.gasFeeCapMultiplier` | `float64` | optional | Multiplies the fee cap the node suggests. |
 | `chainOverrides[].evm.gasTipCapMultiplier` | `float64` | optional | Multiplies the tip cap the node suggests. |
 | `chainOverrides[].discovery.clearInterval` | `duration` | optional | Overrides `clearInterval` for packets sourced from this chain. |
+| `chainOverrides[].discovery.abandonUnrecoverablePackets` | `bool` | `false` | Stops re-probing packets whose send log the endpoint will not serve. |
 
 <!-- [relayer.go:L35](cli/internal/config/relayer.go#L35) --> <!-- [evm.go:L26](cli/internal/txsubmitter/evm/evm.go#L26) --> <!-- [opts.go:L14](cli/internal/relay/pipeline/opts.go#L14) --> <!-- [opts.go:L15](cli/internal/relay/pipeline/opts.go#L15) --> <!-- [opts.go:L16](cli/internal/relay/pipeline/opts.go#L16) -->
 
@@ -245,6 +246,14 @@ relayer:
         gasFeeCapMultiplier: 1.2
         gasTipCapMultiplier: 1.1
 ```
+
+#### `discovery.abandonUnrecoverablePackets`
+
+A packet whose commitment is still live but whose `SendPacket` log the endpoint will not serve cannot be relayed: the relayer has the sequence but not the packet data. By default those sequences stay in the probe set and every pass retries them, on the assumption that the log will eventually be served. On an endpoint that has permanently pruned its logs it never will, and the retries cost a `multicall` and an `eth_getLogs` per pass forever.
+
+Setting this to `true` takes them out of the probe. The relayer still records which sequences they are, it just stops looking at them, so the per-pass cost falls back to the newly-assigned sequences. Their escrow stays locked and they are not relayed — abandoning is giving up on a packet, not resolving it. The sequences are logged at `WARN` as they are abandoned, and the `abandoned` field in each pass's log line reports how many are parked.
+
+This is reversible. Point the relayer at an archive endpoint, set it back to `false`, and the next pass probes exactly the abandoned sequences — no rescan of the client's history — writes rows for the ones it can now read, and drops them from the set as they resolve. Nothing is deleted while a packet is abandoned, which is what makes the recovery cheap.
 
 Receive batches use the destination chain's settings. Acknowledgement and timeout batches use the source chain's settings. <!-- [opts.go:L34-L71](cli/internal/relay/pipeline/opts.go#L34-L71) -->
 


### PR DESCRIPTION
A packet whose commitment is live but whose SendPacket log the endpoint will not serve cannot be relayed, the relayer has the sequence but not the packet data. Those sequences stay in the probe set and cost a multicall and an eth_getLogs every pass, forever, on an endpoint that has pruned its logs. Adds `discovery.abandonUnrecoverablePackets`, off by default, which parks them: they are recorded and logged at `WARN` but no longer probed. This process is also reversible, point at an archive endpoint, set it back to false, and the next pass probes exactly those sequences and resolves what it can read.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>